### PR TITLE
fix: resolve exit code 1 in get-context.sh

### DIFF
--- a/.trellis/scripts/common/git-context.sh
+++ b/.trellis/scripts/common/git-context.sh
@@ -182,7 +182,7 @@ output_text() {
           assignee=$(jq -r '.assignee // "-"' "$t_json")
         fi
         echo "- $dir_name/ ($status) @$assignee"
-        ((task_count++))
+        ((task_count++)) || true
       fi
     done
   fi
@@ -205,7 +205,7 @@ output_text() {
             local title=$(jq -r '.title // .name // "unknown"' "$t_json")
             local priority=$(jq -r '.priority // "P2"' "$t_json")
             echo "- [$priority] $title ($status)"
-            ((my_task_count++))
+            ((my_task_count++)) || true
           fi
         fi
       fi


### PR DESCRIPTION
## Problem

Running `.trellis/scripts/get-context.sh` returned exit code 1 even when executed successfully.

**Actual error output:**
```
● Bash(./trellis/scripts/get-context.sh)
  ⎿  Error: Exit code 1
     ========================================
     SESSION CONTEXT
     ========================================

     ## DEVELOPER
     Name: Rking
```

## Root Cause

In bash, `(( 0 ))` returns exit code 1. The script uses `set -e` (exit on error), causing:
- `((task_count++))` - returns exit code 1 when counter is 0
- `((my_task_count++))` - same issue

## Solution

Append `|| true` to arithmetic expressions to ensure they always return exit code 0:

```bash
((task_count++)) || true
((my_task_count++)) || true
```

## Files Changed

- `.trellis/scripts/common/git-context.sh` (lines 185, 208)

## Testing

- Script now returns exit code 0 on successful execution

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)