### PR TITLE
fix(update): add missing cli_adapter.py to template files

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -41,6 +41,7 @@ import {
   commonTaskUtils,
   commonPhase,
   commonRegistry,
+  commonCliAdapter,
   // Python scripts - multi_agent
   multiAgentInit,
   multiAgentStart,
@@ -147,6 +148,7 @@ function collectTemplateFiles(_cwd: string): Map<string, string> {
   files.set(`${PATHS.SCRIPTS}/common/task_utils.py`, commonTaskUtils);
   files.set(`${PATHS.SCRIPTS}/common/phase.py`, commonPhase);
   files.set(`${PATHS.SCRIPTS}/common/registry.py`, commonRegistry);
+  files.set(`${PATHS.SCRIPTS}/common/cli_adapter.py`, commonCliAdapter);
 
   // Python scripts - multi_agent
   files.set(`${PATHS.SCRIPTS}/multi_agent/__init__.py`, multiAgentInit);

--- a/src/templates/trellis/index.ts
+++ b/src/templates/trellis/index.ts
@@ -41,6 +41,7 @@ export const commonTaskQueue = readTemplate("scripts/common/task_queue.py");
 export const commonTaskUtils = readTemplate("scripts/common/task_utils.py");
 export const commonPhase = readTemplate("scripts/common/phase.py");
 export const commonRegistry = readTemplate("scripts/common/registry.py");
+export const commonCliAdapter = readTemplate("scripts/common/cli_adapter.py");
 
 // Python scripts - multi_agent
 export const multiAgentInit = readTemplate("scripts/multi_agent/__init__.py");
@@ -82,6 +83,7 @@ export function getAllScripts(): Map<string, string> {
   scripts.set("common/task_utils.py", commonTaskUtils);
   scripts.set("common/phase.py", commonPhase);
   scripts.set("common/registry.py", commonRegistry);
+  scripts.set("common/cli_adapter.py", commonCliAdapter);
 
   // Multi-agent
   scripts.set("multi_agent/__init__.py", multiAgentInit);


### PR DESCRIPTION
cli_adapter.py is a critical dependency library used by:
- task.py
- multi_agent/status.py
- multi_agent/start.py
- multi_agent/plan.py

The file was missing from the update.ts collectTemplateFiles() function, preventing bug fixes and new features from being propagated to user projects via `trellis update`.

This fix adds cli_adapter.py to both:
1. src/templates/trellis/index.ts (export + getAllScripts)
2. src/commands/update.ts (collectTemplateFiles)

Now `trellis update` will properly update this file.