### PR TITLE
feat(codex): add notify hook auto-injection templates

### DIFF
--- a/scripts/copy-templates.js
+++ b/scripts/copy-templates.js
@@ -11,7 +11,7 @@
  * - src/templates/cursor/ - Cursor commands
  * - src/templates/iflow/ - iFlow CLI commands, agents, hooks
  * - src/templates/opencode/ - OpenCode commands, agents, hooks
- * - src/templates/codex/ - Codex skills
+ * - src/templates/codex/ - Codex skills and hooks config
  * - src/templates/kiro/ - Kiro Code skills
  * - src/templates/markdown/ - Markdown templates (spec, guides)
  *

--- a/src/configurators/codex.ts
+++ b/src/configurators/codex.ts
@@ -1,12 +1,19 @@
 import path from "node:path";
-import { getAllSkills } from "../templates/codex/index.js";
+import {
+  getAllHooks,
+  getAllSkills,
+  getConfigTemplate,
+} from "../templates/codex/index.js";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
+import { resolvePlaceholders } from "./shared.js";
 
 /**
  * Configure Codex by writing skill templates.
  *
  * Output:
  * - .agents/skills/<skill-name>/SKILL.md
+ * - .codex/hooks/*
+ * - .codex/config.toml
  */
 export async function configureCodex(cwd: string): Promise<void> {
   const skillsRoot = path.join(cwd, ".agents", "skills");
@@ -18,4 +25,19 @@ export async function configureCodex(cwd: string): Promise<void> {
     const targetPath = path.join(skillDir, "SKILL.md");
     await writeFile(targetPath, skill.content);
   }
+
+  const codexRoot = path.join(cwd, ".codex");
+  ensureDir(codexRoot);
+
+  for (const hook of getAllHooks()) {
+    const targetPath = path.join(codexRoot, hook.targetPath);
+    ensureDir(path.dirname(targetPath));
+    await writeFile(targetPath, hook.content);
+  }
+
+  const config = getConfigTemplate();
+  await writeFile(
+    path.join(codexRoot, config.targetPath),
+    resolvePlaceholders(config.content),
+  );
 }

--- a/src/configurators/index.ts
+++ b/src/configurators/index.ts
@@ -38,7 +38,11 @@ import {
   getAllHooks as getIflowHooks,
   getSettingsTemplate as getIflowSettings,
 } from "../templates/iflow/index.js";
-import { getAllSkills as getCodexSkills } from "../templates/codex/index.js";
+import {
+  getAllHooks as getCodexHooks,
+  getAllSkills as getCodexSkills,
+  getConfigTemplate as getCodexConfig,
+} from "../templates/codex/index.js";
 import { getAllCommands as getKiloCommands } from "../templates/kilo/index.js";
 import { getAllSkills as getKiroSkills } from "../templates/kiro/index.js";
 
@@ -130,6 +134,14 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       for (const skill of getCodexSkills()) {
         files.set(`.agents/skills/${skill.name}/SKILL.md`, skill.content);
       }
+      for (const hook of getCodexHooks()) {
+        files.set(`.codex/${hook.targetPath}`, hook.content);
+      }
+      const config = getCodexConfig();
+      files.set(
+        `.codex/${config.targetPath}`,
+        resolvePlaceholders(config.content),
+      );
       return files;
     },
   },
@@ -165,8 +177,16 @@ export const PLATFORM_IDS = Object.keys(AI_TOOLS) as AITool[];
 /** All platform config directory names (e.g., [".claude", ".cursor", ".iflow", ".opencode"]) */
 export const CONFIG_DIRS = PLATFORM_IDS.map((id) => AI_TOOLS[id].configDir);
 
-/** All directories managed by Trellis (including .trellis itself) */
-export const ALL_MANAGED_DIRS = [".trellis", ...CONFIG_DIRS];
+function getManagedDirsForTool(id: AITool): string[] {
+  const config = AI_TOOLS[id];
+  return [config.configDir, ...(config.extraManagedDirs ?? [])];
+}
+
+/** All directories managed by Trellis (including .trellis and platform extra dirs) */
+export const ALL_MANAGED_DIRS = [
+  ".trellis",
+  ...new Set(PLATFORM_IDS.flatMap((id) => getManagedDirsForTool(id))),
+];
 
 /**
  * Detect which platforms are configured by checking for directory existence

--- a/src/templates/codex/config.toml
+++ b/src/templates/codex/config.toml
@@ -1,0 +1,6 @@
+# Trellis Codex Hook configuration
+#
+# Codex loads project config from .codex/config.toml when the project is trusted.
+# This hook keeps a lightweight Trellis context snapshot up to date.
+
+notify = ["{{PYTHON_CMD}}", "hooks/notify.py"]

--- a/src/templates/codex/hooks/notify.py
+++ b/src/templates/codex/hooks/notify.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Codex notify hook for Trellis.
+
+Codex invokes this command after each completed turn and appends a JSON payload
+as the last argv item. We convert that payload + Trellis metadata into a
+lightweight snapshot file that Codex skills can reference.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MAX_SECTION_CHARS = 6000
+
+
+def parse_payload(argv: list[str]) -> dict[str, Any]:
+    if len(argv) < 2:
+        return {}
+
+    raw = argv[-1]
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(parsed, dict):
+        return {}
+
+    return parsed
+
+
+def read_text(path: Path, fallback: str = "") -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError, OSError):
+        return fallback
+
+
+def clip(value: str, max_chars: int = MAX_SECTION_CHARS) -> str:
+    value = value.strip()
+    if len(value) <= max_chars:
+        return value
+    return value[: max_chars - 20] + "\n... [truncated]"
+
+
+def run_context_script(script_path: Path, cwd: Path) -> str:
+    if not script_path.is_file():
+        return ""
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-W", "ignore", str(script_path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=8,
+            cwd=cwd,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+
+    return result.stdout.strip()
+
+
+def build_snapshot(project_dir: Path, payload: dict[str, Any]) -> str:
+    trellis_dir = project_dir / ".trellis"
+
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    turn_id = payload.get("turn-id", "unknown")
+    thread_id = payload.get("thread-id", "unknown")
+
+    parts: list[str] = []
+    parts.append("# Trellis Codex Context Snapshot")
+    parts.append("")
+    parts.append(f"- GeneratedAt: {generated_at}")
+    parts.append(f"- ThreadID: {thread_id}")
+    parts.append(f"- TurnID: {turn_id}")
+
+    input_messages = payload.get("input-messages")
+    if isinstance(input_messages, list) and input_messages:
+        last_user_message = str(input_messages[-1]).strip()
+        if last_user_message:
+            parts.append("- LastUserMessage:")
+            parts.append(f"  {last_user_message}")
+
+    last_assistant_message = payload.get("last-assistant-message")
+    if isinstance(last_assistant_message, str) and last_assistant_message.strip():
+        parts.append("- LastAssistantMessage:")
+        parts.append(f"  {last_assistant_message.strip()}")
+
+    parts.append("")
+    parts.append("## Current State")
+
+    current_state = run_context_script(trellis_dir / "scripts" / "get_context.py", project_dir)
+    if current_state:
+        parts.append("```")
+        parts.append(clip(current_state))
+        parts.append("```")
+    else:
+        parts.append("No get_context.py output available.")
+
+    parts.append("")
+    parts.append("## Workflow")
+    workflow = read_text(trellis_dir / "workflow.md", "workflow.md not found")
+    parts.append("```")
+    parts.append(clip(workflow))
+    parts.append("```")
+
+    parts.append("")
+    parts.append("## Spec Index")
+    for label, rel in (
+        ("Frontend", "spec/frontend/index.md"),
+        ("Backend", "spec/backend/index.md"),
+        ("Guides", "spec/guides/index.md"),
+    ):
+        parts.append(f"### {label}")
+        content = read_text(trellis_dir / rel, f"{rel} not found")
+        parts.append("```")
+        parts.append(clip(content, 3000))
+        parts.append("```")
+        parts.append("")
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def write_snapshot(project_dir: Path, payload: dict[str, Any]) -> None:
+    context_dir = project_dir / ".codex" / "context"
+    context_dir.mkdir(parents=True, exist_ok=True)
+
+    snapshot_path = context_dir / "trellis-context.md"
+    event_path = context_dir / "last-notify-event.json"
+
+    snapshot_path.write_text(build_snapshot(project_dir, payload), encoding="utf-8")
+    event_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    payload = parse_payload(sys.argv)
+
+    cwd_value = payload.get("cwd")
+    if isinstance(cwd_value, str) and cwd_value.strip():
+        project_dir = Path(cwd_value).resolve()
+    else:
+        project_dir = Path.cwd().resolve()
+
+    # Hook should never block Codex usage.
+    try:
+        if (project_dir / ".trellis").is_dir():
+            write_snapshot(project_dir, payload)
+    except OSError:
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/templates/codex/index.ts
+++ b/src/templates/codex/index.ts
@@ -1,11 +1,14 @@
 /**
- * Codex skill templates
+ * Codex templates
  *
  * These are GENERIC templates for user projects.
- * Do NOT use Trellis project's own .agents/skills directory (which may be customized).
+ * Do NOT use Trellis project's own .agents/skills or .codex directory (which may be customized).
  *
  * Directory structure:
  *   codex/
+ *   ├── config.toml
+ *   ├── hooks/
+ *   │   └── notify.py
  *   └── skills/
  *       └── <skill-name>/
  *           └── SKILL.md
@@ -20,6 +23,14 @@ const __dirname = dirname(__filename);
 
 function readTemplate(relativePath: string): string {
   return readFileSync(join(__dirname, relativePath), "utf-8");
+}
+
+function listFiles(dir: string): string[] {
+  try {
+    return readdirSync(join(__dirname, dir));
+  } catch {
+    return [];
+  }
 }
 
 function listSkillNames(): string[] {
@@ -38,6 +49,11 @@ export interface SkillTemplate {
   content: string;
 }
 
+export interface HookTemplate {
+  targetPath: string;
+  content: string;
+}
+
 export function getAllSkills(): SkillTemplate[] {
   const skills: SkillTemplate[] = [];
 
@@ -47,4 +63,22 @@ export function getAllSkills(): SkillTemplate[] {
   }
 
   return skills;
+}
+
+export function getAllHooks(): HookTemplate[] {
+  const hooks: HookTemplate[] = [];
+
+  for (const file of listFiles("hooks")) {
+    const content = readTemplate(`hooks/${file}`);
+    hooks.push({ targetPath: `hooks/${file}`, content });
+  }
+
+  return hooks;
+}
+
+export function getConfigTemplate(): HookTemplate {
+  return {
+    targetPath: "config.toml",
+    content: readTemplate("config.toml"),
+  };
 }

--- a/src/templates/markdown/agents.md
+++ b/src/templates/markdown/agents.md
@@ -13,6 +13,8 @@ Use `@/.trellis/` to learn:
 - Project structure guidelines (`spec/`)
 - Developer workspace (`workspace/`)
 
+If `.codex/context/trellis-context.md` exists, read it before planning or coding.
+
 Keep this managed block so 'trellis update' can refresh the instructions.
 
 <!-- TRELLIS:END -->

--- a/src/types/ai-tools.ts
+++ b/src/types/ai-tools.ts
@@ -52,6 +52,8 @@ export interface AIToolConfig {
   templateDirs: TemplateDir[];
   /** Config directory name in the project root (e.g., ".claude") */
   configDir: string;
+  /** Additional managed directories for this tool (e.g., ".codex") */
+  extraManagedDirs?: string[];
   /** CLI flag name for --flag options (e.g., "claude" for --claude) */
   cliFlag: CliFlag;
   /** Whether this tool is checked by default in interactive init prompt */
@@ -108,9 +110,10 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Codex",
     templateDirs: ["common", "codex"],
     configDir: ".agents/skills",
+    extraManagedDirs: [".codex"],
     cliFlag: "codex",
     defaultChecked: false,
-    hasPythonHooks: false,
+    hasPythonHooks: true,
   },
   kilo: {
     name: "Kilo CLI",

--- a/test/commands/init.integration.test.ts
+++ b/test/commands/init.integration.test.ts
@@ -98,6 +98,8 @@ describe("init() integration", () => {
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills", "start", "SKILL.md"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills", "parallel"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".codex", "config.toml"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".codex", "hooks", "notify.py"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".cursor"))).toBe(false);
   });

--- a/test/configurators/index.test.ts
+++ b/test/configurators/index.test.ts
@@ -42,7 +42,10 @@ describe("ALL_MANAGED_DIRS", () => {
   });
 
   it("contains .trellis plus all config dirs", () => {
-    expect(ALL_MANAGED_DIRS).toEqual([".trellis", ...CONFIG_DIRS]);
+    expect(ALL_MANAGED_DIRS).toEqual(
+      expect.arrayContaining([".trellis", ...CONFIG_DIRS]),
+    );
+    expect(ALL_MANAGED_DIRS).toContain(".codex");
   });
 
   it("has no duplicates", () => {
@@ -63,6 +66,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".iflow/hooks/test.py")).toBe(true);
     expect(isManagedPath(".opencode/config.json")).toBe(true);
     expect(isManagedPath(".agents/skills/start/SKILL.md")).toBe(true);
+    expect(isManagedPath(".codex/hooks/notify.py")).toBe(true);
     expect(isManagedPath(".kiro/skills/start/SKILL.md")).toBe(true);
   });
 
@@ -73,6 +77,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".iflow")).toBe(true);
     expect(isManagedPath(".opencode")).toBe(true);
     expect(isManagedPath(".agents/skills")).toBe(true);
+    expect(isManagedPath(".codex")).toBe(true);
     expect(isManagedPath(".kiro/skills")).toBe(true);
     expect(isManagedPath(".trellis")).toBe(true);
   });
@@ -90,6 +95,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".cursorignore")).toBe(false);
     expect(isManagedPath(".opencode-v2")).toBe(false);
     expect(isManagedPath(".agents/skills-backup")).toBe(false);
+    expect(isManagedPath(".codex-backup")).toBe(false);
     expect(isManagedPath(".kiro/skills-backup")).toBe(false);
   });
 
@@ -118,6 +124,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".trellis\\spec\\backend")).toBe(true);
     expect(isManagedPath(".iflow\\hooks\\test.py")).toBe(true);
     expect(isManagedPath(".agents\\skills\\start\\SKILL.md")).toBe(true);
+    expect(isManagedPath(".codex\\hooks\\notify.py")).toBe(true);
     expect(isManagedPath(".kiro\\skills\\start\\SKILL.md")).toBe(true);
   });
 
@@ -275,13 +282,19 @@ describe("collectPlatformTemplates", () => {
     }
   });
 
-  it("all returned paths start with platform configDir", () => {
+  it("all returned paths start with managed roots for that platform", () => {
     for (const id of PLATFORM_IDS) {
       const result = collectPlatformTemplates(id);
       if (result) {
-        const configDir = AI_TOOLS[id].configDir;
+        const managedRoots = [
+          AI_TOOLS[id].configDir,
+          ...(AI_TOOLS[id].extraManagedDirs ?? []),
+        ];
         for (const [filePath] of result) {
-          expect(filePath.startsWith(configDir + "/")).toBe(true);
+          const startsWithManagedRoot = managedRoots.some((root) =>
+            filePath.startsWith(root + "/"),
+          );
+          expect(startsWithManagedRoot).toBe(true);
         }
       }
     }

--- a/test/configurators/platforms.test.ts
+++ b/test/configurators/platforms.test.ts
@@ -155,6 +155,21 @@ describe("configurePlatform", () => {
     }
   });
 
+  it("configurePlatform('codex') writes .codex hook files and config.toml", async () => {
+    await configurePlatform("codex", tmpDir);
+
+    const hookPath = path.join(tmpDir, ".codex", "hooks", "notify.py");
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+
+    expect(fs.existsSync(hookPath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const config = fs.readFileSync(configPath, "utf-8");
+    expect(config).toContain('notify = ["');
+    expect(config).toContain("python");
+    expect(config).toContain("hooks/notify.py");
+  });
+
   it("configurePlatform('kiro') creates .kiro/skills directory", async () => {
     await configurePlatform("kiro", tmpDir);
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(true);

--- a/test/templates/codex.test.ts
+++ b/test/templates/codex.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getAllSkills } from "../../src/templates/codex/index.js";
+import {
+  getAllHooks,
+  getAllSkills,
+  getConfigTemplate,
+} from "../../src/templates/codex/index.js";
 
 const EXPECTED_SKILL_NAMES = [
   "before-backend-dev",
@@ -47,5 +51,24 @@ describe("codex getAllSkills", () => {
       expect(skill.content).not.toContain("subagent_type");
       expect(skill.content).not.toContain('model: "opus"');
     }
+  });
+});
+
+describe("codex hooks and config templates", () => {
+  it("each hook has targetPath under hooks/ and non-empty content", () => {
+    const hooks = getAllHooks();
+    expect(hooks.length).toBeGreaterThan(0);
+    for (const hook of hooks) {
+      expect(hook.targetPath.startsWith("hooks/")).toBe(true);
+      expect(hook.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("config template uses notify hook with {{PYTHON_CMD}} placeholder", () => {
+    const config = getConfigTemplate();
+    expect(config.targetPath).toBe("config.toml");
+    expect(config.content).toContain("notify =");
+    expect(config.content).toContain("{{PYTHON_CMD}}");
+    expect(config.content).not.toContain("python3");
   });
 });


### PR DESCRIPTION
## Summary
- add Codex managed config templates under `.codex/`:
  - `.codex/config.toml`
  - `.codex/hooks/notify.py`
- make Codex configurator write both skill templates (`.agents/skills/*`) and hook/config templates (`.codex/*`)
- include `.codex` in Trellis managed directories for update tracking and path protection
- update AGENTS template to read `.codex/context/trellis-context.md` when present
- add test coverage for Codex hook/config generation and managed directory behavior

## Docs Cross-check
- Verified Codex supports `notify` command config and passes JSON payload to the command:
  - https://developers.openai.com/codex/config-reference/
- Verified trusted-project loading and project config lookup locations (`.codex/config.toml` and repo root fallback):
  - https://developers.openai.com/codex/config-basic/
- Verified project-config relative path behavior note and sample config patterns:
  - https://developers.openai.com/codex/config-advanced/
  - https://developers.openai.com/codex/sample-config/

## Validation
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Hook payload runtime test (real script execution with JSON payload):
  - `python3 .codex/hooks/notify.py '<payload-json>'`
  - confirmed outputs:
    - `.codex/context/trellis-context.md`
    - `.codex/context/last-notify-event.json`
