### PR TITLE
feat: add Antigravity workflow integration (official path + slash trigger)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-<strong>All-in-one AI framework & toolkit for Claude Code, Cursor, Gemini CLI, iFlow, Codex & Kiro Code</strong><br/>
+<strong>All-in-one AI framework & toolkit for Claude Code, Cursor, Gemini CLI, iFlow, Codex, Kilo, Kiro & Antigravity</strong><br/>
 <sub>Wild AI ships nothing.</sub>
 </p>
 
@@ -63,6 +63,9 @@ trellis init --kiro -u your-name
 
 # Or include Gemini CLI support
 trellis init --gemini -u your-name
+
+# Or include Antigravity workflow support
+trellis init --antigravity -u your-name
 
 # 3. Start Claude Code and begin working
 ```
@@ -146,7 +149,7 @@ Create commands like `/trellis:before-frontend-dev` that load component guidelin
 
 - [ ] **Better Code Review** — More thorough automated review workflow
 - [ ] **Skill Packs** — Pre-built workflow packs, plug and play
-- [ ] **Broader Tool Support** — Cursor, OpenCode, Codex, Kiro, Gemini integration
+- [ ] **Broader Tool Support** — Cursor, OpenCode, Codex, Kilo, Kiro, Gemini, Antigravity integration
 - [ ] **Stronger Session Continuity** — Autosave session-wide history
 - [ ] **Visual Parallel Sessions** — Real-time progress for each agent
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -64,6 +64,9 @@ trellis init --kiro -u your-name
 # 或包含 Gemini CLI 支持
 trellis init --gemini -u your-name
 
+# 或包含 Antigravity Workflow 支持
+trellis init --antigravity -u your-name
+
 # 3. 启动 Claude Code，开始干活
 ```
 
@@ -146,7 +149,7 @@ trellis init --gemini -u your-name
 
 - [ ] **更好的代码审查** — 更完善的自动化审查流程
 - [ ] **Skill 包** — 预置工作流包，即插即用
-- [ ] **更广泛的工具支持** — Cursor、OpenCode、Codex、Kiro、Gemini 集成
+- [ ] **更广泛的工具支持** — Cursor、OpenCode、Codex、Kilo、Kiro、Gemini、Antigravity 集成
 - [ ] **更强的会话连续性** — 自动保存全会话历史
 - [ ] **可视化并行会话** — 实时查看每个 Agent 的进度
 

--- a/scripts/copy-templates.js
+++ b/scripts/copy-templates.js
@@ -13,6 +13,7 @@
  * - src/templates/opencode/ - OpenCode commands, agents, hooks
  * - src/templates/codex/ - Codex skills
  * - src/templates/kilo/ - Kilo CLI commands
+ * - src/templates/antigravity/ - Antigravity workflows
  * - src/templates/kiro/ - Kiro Code skills
  * - src/templates/gemini/ - Gemini CLI commands (TOML)
  * - src/templates/markdown/ - Markdown templates (spec, guides)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,6 +68,7 @@ program
   .option("--kilo", "Include Kilo CLI commands")
   .option("--kiro", "Include Kiro Code skills")
   .option("--gemini", "Include Gemini CLI commands")
+  .option("--antigravity", "Include Antigravity workflows")
   .option("-y, --yes", "Skip prompts and use defaults")
   .option(
     "-u, --user <name>",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -312,6 +312,7 @@ interface InitOptions {
   kilo?: boolean;
   kiro?: boolean;
   gemini?: boolean;
+  antigravity?: boolean;
   yes?: boolean;
   user?: string;
   force?: boolean;

--- a/src/configurators/antigravity.ts
+++ b/src/configurators/antigravity.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { getAllWorkflows } from "../templates/antigravity/index.js";
+import { ensureDir, writeFile } from "../utils/file-writer.js";
+
+/**
+ * Configure Antigravity by writing workflow templates.
+ *
+ * Output:
+ * - .agent/workflows/<workflow-name>.md
+ */
+export async function configureAntigravity(cwd: string): Promise<void> {
+  const workflowRoot = path.join(cwd, ".agent", "workflows");
+  ensureDir(workflowRoot);
+
+  for (const workflow of getAllWorkflows()) {
+    const targetPath = path.join(workflowRoot, `${workflow.name}.md`);
+    await writeFile(targetPath, workflow.content);
+  }
+}

--- a/src/configurators/index.ts
+++ b/src/configurators/index.ts
@@ -21,6 +21,7 @@ import { configureCodex } from "./codex.js";
 import { configureKilo } from "./kilo.js";
 import { configureKiro } from "./kiro.js";
 import { configureGemini } from "./gemini.js";
+import { configureAntigravity } from "./antigravity.js";
 
 // Shared utilities
 import { resolvePlaceholders } from "./shared.js";
@@ -43,6 +44,7 @@ import { getAllSkills as getCodexSkills } from "../templates/codex/index.js";
 import { getAllCommands as getKiloCommands } from "../templates/kilo/index.js";
 import { getAllSkills as getKiroSkills } from "../templates/kiro/index.js";
 import { getAllCommands as getGeminiCommands } from "../templates/gemini/index.js";
+import { getAllWorkflows as getAntigravityWorkflows } from "../templates/antigravity/index.js";
 
 // =============================================================================
 // Platform Functions Registry
@@ -161,6 +163,16 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       const files = new Map<string, string>();
       for (const cmd of getGeminiCommands()) {
         files.set(`.gemini/commands/trellis/${cmd.name}.toml`, cmd.content);
+      }
+      return files;
+    },
+  },
+  antigravity: {
+    configure: configureAntigravity,
+    collectTemplates: () => {
+      const files = new Map<string, string>();
+      for (const workflow of getAntigravityWorkflows()) {
+        files.set(`.agent/workflows/${workflow.name}.md`, workflow.content);
       }
       return files;
     },

--- a/src/templates/antigravity/index.ts
+++ b/src/templates/antigravity/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Antigravity workflow templates
+ *
+ * Antigravity uses workspace workflows under .agent/workflows/.
+ * We reuse Codex skill content as workflow content.
+ */
+
+import {
+  getAllSkills as getAllCodexSkills,
+  type SkillTemplate as CodexSkillTemplate,
+} from "../codex/index.js";
+
+export interface WorkflowTemplate {
+  name: string;
+  content: string;
+}
+
+function adaptSkillContentToWorkflow(
+  content: string,
+  workflowNames: string[],
+): string {
+  const base = content
+    .replaceAll("Codex skills", "Antigravity workflows")
+    .replaceAll("Codex skill", "Antigravity workflow")
+    .replaceAll("Create New Skill", "Create New Workflow")
+    .replaceAll(
+      ".agents/skills/<skill-name>/SKILL.md",
+      ".agent/workflows/<workflow-name>.md",
+    )
+    .replace(
+      /\.agents\/skills\/([^/\s`]+)\/SKILL\.md/g,
+      ".agent/workflows/$1.md",
+    )
+    .replaceAll(".agents/skills/", ".agent/workflows/")
+    .replaceAll("$<skill-name>", "/<workflow-name>")
+    .replaceAll("Or open /skills and select it", "Or type / and select it");
+
+  // Antigravity workflows are triggered with slash commands (/start), not "$skill".
+  return workflowNames.reduce(
+    (adapted, name) => adapted.replaceAll(`$${name}`, `/${name}`),
+    base,
+  );
+}
+
+export function getAllWorkflows(): WorkflowTemplate[] {
+  const skills: CodexSkillTemplate[] = getAllCodexSkills();
+  const workflowNames = skills.map((skill) => skill.name);
+  return skills.map((skill) => ({
+    name: skill.name,
+    content: adaptSkillContentToWorkflow(skill.content, workflowNames),
+  }));
+}

--- a/src/templates/extract.ts
+++ b/src/templates/extract.ts
@@ -165,6 +165,30 @@ export function getKiroSourcePath(): string {
 }
 
 /**
+ * Get the path to the antigravity templates directory.
+ *
+ * This reads from src/templates/antigravity/ (development) or dist/templates/antigravity/ (production).
+ * These are GENERIC templates, not the Trellis project's own .agent/workflows configuration.
+ */
+export function getAntigravityTemplatePath(): string {
+  const templatePath = path.join(__dirname, "antigravity");
+  if (fs.existsSync(templatePath)) {
+    return templatePath;
+  }
+
+  throw new Error(
+    "Could not find antigravity templates directory. Expected at templates/antigravity/",
+  );
+}
+
+/**
+ * @deprecated Use getAntigravityTemplatePath() instead.
+ */
+export function getAntigravitySourcePath(): string {
+  return getAntigravityTemplatePath();
+}
+
+/**
  * Read a file from the .trellis directory
  * @param relativePath - Path relative to .trellis/ (e.g., 'scripts/task.py')
  * @returns File content as string

--- a/src/templates/trellis/scripts/common/cli_adapter.py
+++ b/src/templates/trellis/scripts/common/cli_adapter.py
@@ -1,7 +1,7 @@
 """
 CLI Adapter for Multi-Platform Support.
 
-Abstracts differences between Claude Code, OpenCode, Cursor, iFlow, Codex, Kilo, Kiro Code, and Gemini CLI interfaces.
+Abstracts differences between Claude Code, OpenCode, Cursor, iFlow, Codex, Kilo, Kiro Code, Gemini CLI, and Antigravity interfaces.
 
 Supported platforms:
 - claude: Claude Code (default)
@@ -12,6 +12,7 @@ Supported platforms:
 - kilo: Kilo CLI
 - kiro: Kiro Code (skills-based)
 - gemini: Gemini CLI
+- antigravity: Antigravity (workflow-based)
 
 Usage:
     from common.cli_adapter import CLIAdapter
@@ -30,7 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Literal
 
-Platform = Literal["claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini"]
+Platform = Literal["claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini", "antigravity"]
 
 
 @dataclass
@@ -74,7 +75,7 @@ class CLIAdapter:
         """Get platform-specific config directory name.
 
         Returns:
-            Directory name ('.claude', '.opencode', '.cursor', '.iflow', '.agents', '.kiro', or '.gemini')
+            Directory name ('.claude', '.opencode', '.cursor', '.iflow', '.agents', '.kilocode', '.kiro', '.gemini', or '.agent')
         """
         if self.platform == "opencode":
             return ".opencode"
@@ -90,6 +91,8 @@ class CLIAdapter:
             return ".kiro"
         elif self.platform == "gemini":
             return ".gemini"
+        elif self.platform == "antigravity":
+            return ".agent"
         else:
             return ".claude"
 
@@ -100,7 +103,7 @@ class CLIAdapter:
             project_root: Project root directory
 
         Returns:
-            Path to config directory (.claude, .opencode, .cursor, .iflow, .agents, or .kiro)
+            Path to config directory (.claude, .opencode, .cursor, .iflow, .agents, .kilocode, .kiro, or .agent)
         """
         return project_root / self.config_dir_name
 
@@ -129,8 +132,18 @@ class CLIAdapter:
 
         Note:
             Cursor uses prefix naming: .cursor/commands/trellis-<name>.md
+            Antigravity uses workflow directory: .agent/workflows/<name>.md
             Claude/OpenCode use subdirectory: .claude/commands/trellis/<name>.md
         """
+        if self.platform == "antigravity":
+            workflow_dir = self.get_config_dir(project_root) / "workflows"
+            if not parts:
+                return workflow_dir
+            if len(parts) >= 2 and parts[0] == "trellis":
+                filename = parts[-1]
+                return workflow_dir / filename
+            return workflow_dir / Path(*parts)
+
         if not parts:
             return self.get_config_dir(project_root) / "commands"
 
@@ -156,6 +169,7 @@ class CLIAdapter:
             Codex: .agents/skills/<name>/SKILL.md
             Kiro: .kiro/skills/<name>/SKILL.md
             Gemini: .gemini/commands/trellis/<name>.toml
+            Antigravity: .agent/workflows/<name>.md
             Others: .{platform}/commands/trellis/<name>.md
         """
         if self.platform == "cursor":
@@ -166,6 +180,8 @@ class CLIAdapter:
             return f".kiro/skills/{name}/SKILL.md"
         elif self.platform == "gemini":
             return f".gemini/commands/trellis/{name}.toml"
+        elif self.platform == "antigravity":
+            return f".agent/workflows/{name}.md"
         else:
             return f"{self.config_dir_name}/commands/trellis/{name}.md"
 
@@ -187,6 +203,8 @@ class CLIAdapter:
             return {"KIRO_NON_INTERACTIVE": "1"}
         elif self.platform == "gemini":
             return {}  # Gemini CLI doesn't have a non-interactive env var
+        elif self.platform == "antigravity":
+            return {}
         else:
             return {"CLAUDE_NON_INTERACTIVE": "1"}
 
@@ -245,6 +263,10 @@ class CLIAdapter:
         elif self.platform == "gemini":
             cmd = ["gemini"]
             cmd.append(prompt)
+        elif self.platform == "antigravity":
+            raise ValueError(
+                "Antigravity workflows are UI slash commands; CLI agent run is not supported."
+            )
 
         else:  # claude
             cmd = ["claude", "-p"]
@@ -283,6 +305,10 @@ class CLIAdapter:
             return ["kiro", "resume", session_id]
         elif self.platform == "gemini":
             return ["gemini", "--resume", session_id]
+        elif self.platform == "antigravity":
+            raise ValueError(
+                "Antigravity workflows are UI slash commands; CLI resume is not supported."
+            )
         else:
             return ["claude", "--resume", session_id]
 
@@ -336,6 +362,8 @@ class CLIAdapter:
             return "kiro"
         elif self.platform == "gemini":
             return "gemini"
+        elif self.platform == "antigravity":
+            return "agy"
         else:
             return "claude"
 
@@ -390,7 +418,7 @@ def get_cli_adapter(platform: str = "claude") -> CLIAdapter:
     """Get CLI adapter for the specified platform.
 
     Args:
-        platform: Platform name ('claude', 'opencode', 'cursor', 'iflow', 'codex', or 'kiro')
+        platform: Platform name ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', or 'antigravity')
 
     Returns:
         CLIAdapter instance
@@ -398,8 +426,8 @@ def get_cli_adapter(platform: str = "claude") -> CLIAdapter:
     Raises:
         ValueError: If platform is not supported
     """
-    if platform not in ("claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini"):
-        raise ValueError(f"Unsupported platform: {platform} (must be 'claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', or 'gemini')")
+    if platform not in ("claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini", "antigravity"):
+        raise ValueError(f"Unsupported platform: {platform} (must be 'claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', or 'antigravity')")
 
     return CLIAdapter(platform=platform)  # type: ignore
 
@@ -416,19 +444,20 @@ def detect_platform(project_root: Path) -> Platform:
     6. .kilocode directory exists → kilo
     7. .kiro/skills exists and no other platform dirs → kiro
     8. .gemini directory exists → gemini
-    9. Default → claude
+    9. .agent/workflows exists and no other platform dirs → antigravity
+    10. Default → claude
 
     Args:
         project_root: Project root directory
 
     Returns:
-        Detected platform ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', or 'gemini')
+        Detected platform ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', or 'antigravity')
     """
     import os
 
     # Check environment variable first
     env_platform = os.environ.get("TRELLIS_PLATFORM", "").lower()
-    if env_platform in ("claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini"):
+    if env_platform in ("claude", "opencode", "cursor", "iflow", "codex", "kilo", "kiro", "gemini", "antigravity"):
         return env_platform  # type: ignore
 
     # Check for .opencode directory (OpenCode-specific)
@@ -451,7 +480,7 @@ def detect_platform(project_root: Path) -> Platform:
         return "gemini"
 
     # Check for Codex skills directory only when no other platform config exists
-    other_platform_dirs_codex = (".claude", ".cursor", ".iflow", ".opencode", ".kilocode", ".kiro", ".gemini")
+    other_platform_dirs_codex = (".claude", ".cursor", ".iflow", ".opencode", ".kilocode", ".kiro", ".gemini", ".agent")
     has_other_platform_config = any(
         (project_root / directory).is_dir() for directory in other_platform_dirs_codex
     )
@@ -463,12 +492,20 @@ def detect_platform(project_root: Path) -> Platform:
         return "kilo"
 
     # Check for Kiro skills directory only when no other platform config exists
-    other_platform_dirs_kiro = (".claude", ".cursor", ".iflow", ".opencode", ".agents", ".kilocode", ".gemini")
+    other_platform_dirs_kiro = (".claude", ".cursor", ".iflow", ".opencode", ".agents", ".kilocode", ".gemini", ".agent")
     has_other_platform_config = any(
         (project_root / directory).is_dir() for directory in other_platform_dirs_kiro
     )
     if (project_root / ".kiro" / "skills").is_dir() and not has_other_platform_config:
         return "kiro"
+
+    # Check for Antigravity workflow directory only when no other platform config exists
+    other_platform_dirs_antigravity = (".claude", ".cursor", ".iflow", ".opencode", ".agents", ".kilocode", ".kiro")
+    has_other_platform_config = any(
+        (project_root / directory).is_dir() for directory in other_platform_dirs_antigravity
+    )
+    if (project_root / ".agent" / "workflows").is_dir() and not has_other_platform_config:
+        return "antigravity"
 
     return "claude"
 

--- a/src/templates/trellis/scripts/common/registry.py
+++ b/src/templates/trellis/scripts/common/registry.py
@@ -290,7 +290,7 @@ def registry_add_agent(
         pid: Process ID.
         task_dir: Task directory path.
         repo_root: Repository root path. Defaults to auto-detected.
-        platform: Platform used (e.g., 'claude', 'opencode', 'codex', 'kiro'). Defaults to 'claude'.
+        platform: Platform used (e.g., 'claude', 'opencode', 'codex', 'kiro', 'antigravity'). Defaults to 'claude'.
 
     Returns:
         True on success.

--- a/src/types/ai-tools.ts
+++ b/src/types/ai-tools.ts
@@ -15,7 +15,8 @@ export type AITool =
   | "codex"
   | "kilo"
   | "kiro"
-  | "gemini";
+  | "gemini"
+  | "antigravity";
 
 /**
  * Template directory categories
@@ -29,10 +30,11 @@ export type TemplateDir =
   | "codex"
   | "kilo"
   | "kiro"
-  | "gemini";
+  | "gemini"
+  | "antigravity";
 
 /**
- * CLI flag names for platform selection (e.g., --claude, --cursor, --kilo, --kiro)
+ * CLI flag names for platform selection (e.g., --claude, --cursor, --kilo, --kiro, --gemini, --antigravity)
  * Must match keys in InitOptions (src/commands/init.ts)
  */
 export type CliFlag =
@@ -43,7 +45,8 @@ export type CliFlag =
   | "codex"
   | "kilo"
   | "kiro"
-  | "gemini";
+  | "gemini"
+  | "antigravity";
 
 /**
  * Configuration for an AI tool
@@ -136,6 +139,14 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     templateDirs: ["common", "gemini"],
     configDir: ".gemini",
     cliFlag: "gemini",
+    defaultChecked: false,
+    hasPythonHooks: false,
+  },
+  antigravity: {
+    name: "Antigravity",
+    templateDirs: ["common", "antigravity"],
+    configDir: ".agent/workflows",
+    cliFlag: "antigravity",
     defaultChecked: false,
     hasPythonHooks: false,
   },

--- a/test/commands/init.integration.test.ts
+++ b/test/commands/init.integration.test.ts
@@ -64,6 +64,9 @@ describe("init() integration", () => {
     expect(fs.existsSync(path.join(tmpDir, ".cursor"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".agent", "workflows"))).toBe(
+      false,
+    );
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".gemini"))).toBe(false);
 
@@ -79,6 +82,9 @@ describe("init() integration", () => {
     expect(fs.existsSync(path.join(tmpDir, ".iflow"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".opencode"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".agent", "workflows"))).toBe(
+      false,
+    );
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".gemini"))).toBe(false);
   });
@@ -91,6 +97,9 @@ describe("init() integration", () => {
     expect(fs.existsSync(path.join(tmpDir, ".opencode"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".iflow"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".agent", "workflows"))).toBe(
+      false,
+    );
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".gemini"))).toBe(false);
   });
@@ -99,8 +108,14 @@ describe("init() integration", () => {
     await init({ yes: true, codex: true });
 
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, ".agents", "skills", "start", "SKILL.md"))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, ".agents", "skills", "parallel"))).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, ".agents", "skills", "start", "SKILL.md"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpDir, ".agents", "skills", "parallel")),
+    ).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".cursor"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".gemini"))).toBe(false);
@@ -110,8 +125,30 @@ describe("init() integration", () => {
     await init({ yes: true, kiro: true });
 
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills", "start", "SKILL.md"))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills", "parallel"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(tmpDir, ".kiro", "skills", "start", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpDir, ".kiro", "skills", "parallel")),
+    ).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".cursor"))).toBe(false);
+  });
+
+  it("#3d antigravity platform creates .agent/workflows", async () => {
+    await init({ yes: true, antigravity: true });
+
+    expect(fs.existsSync(path.join(tmpDir, ".agent", "workflows"))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(path.join(tmpDir, ".agent", "workflows", "start.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, ".agent", "workflows", "parallel.md"),
+      ),
+    ).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".cursor"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".gemini"))).toBe(false);
@@ -209,9 +246,7 @@ describe("init() integration", () => {
     await init({ yes: true });
 
     const specDir = path.join(tmpDir, PATHS.SPEC);
-    expect(fs.existsSync(path.join(specDir, "backend", "index.md"))).toBe(
-      true,
-    );
+    expect(fs.existsSync(path.join(specDir, "backend", "index.md"))).toBe(true);
     expect(fs.existsSync(path.join(specDir, "frontend", "index.md"))).toBe(
       true,
     );

--- a/test/configurators/index.test.ts
+++ b/test/configurators/index.test.ts
@@ -63,6 +63,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".iflow/hooks/test.py")).toBe(true);
     expect(isManagedPath(".opencode/config.json")).toBe(true);
     expect(isManagedPath(".agents/skills/start/SKILL.md")).toBe(true);
+    expect(isManagedPath(".agent/workflows/start.md")).toBe(true);
     expect(isManagedPath(".kiro/skills/start/SKILL.md")).toBe(true);
   });
 
@@ -73,6 +74,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".iflow")).toBe(true);
     expect(isManagedPath(".opencode")).toBe(true);
     expect(isManagedPath(".agents/skills")).toBe(true);
+    expect(isManagedPath(".agent/workflows")).toBe(true);
     expect(isManagedPath(".kiro/skills")).toBe(true);
     expect(isManagedPath(".trellis")).toBe(true);
   });
@@ -90,6 +92,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".cursorignore")).toBe(false);
     expect(isManagedPath(".opencode-v2")).toBe(false);
     expect(isManagedPath(".agents/skills-backup")).toBe(false);
+    expect(isManagedPath(".agent/workflows-backup")).toBe(false);
     expect(isManagedPath(".kiro/skills-backup")).toBe(false);
   });
 
@@ -118,6 +121,7 @@ describe("isManagedPath", () => {
     expect(isManagedPath(".trellis\\spec\\backend")).toBe(true);
     expect(isManagedPath(".iflow\\hooks\\test.py")).toBe(true);
     expect(isManagedPath(".agents\\skills\\start\\SKILL.md")).toBe(true);
+    expect(isManagedPath(".agent\\workflows\\start.md")).toBe(true);
     expect(isManagedPath(".kiro\\skills\\start\\SKILL.md")).toBe(true);
   });
 
@@ -242,9 +246,7 @@ describe("getPlatformsWithPythonHooks", () => {
   });
 
   it("includes all platforms with hasPythonHooks: true", () => {
-    const expected = PLATFORM_IDS.filter(
-      (id) => AI_TOOLS[id].hasPythonHooks,
-    );
+    const expected = PLATFORM_IDS.filter((id) => AI_TOOLS[id].hasPythonHooks);
     expect(result).toEqual(expected);
   });
 
@@ -269,9 +271,7 @@ describe("collectPlatformTemplates", () => {
   it("returns Map or undefined for each platform", () => {
     for (const id of PLATFORM_IDS) {
       const result = collectPlatformTemplates(id);
-      expect(
-        result === undefined || result instanceof Map,
-      ).toBe(true);
+      expect(result === undefined || result instanceof Map).toBe(true);
     }
   });
 

--- a/test/configurators/platforms.test.ts
+++ b/test/configurators/platforms.test.ts
@@ -10,6 +10,7 @@ import {
 import { AI_TOOLS } from "../../src/types/ai-tools.js";
 import { setWriteMode } from "../../src/utils/file-writer.js";
 import { getAllSkills } from "../../src/templates/codex/index.js";
+import { getAllWorkflows as getAllAntigravityWorkflows } from "../../src/templates/antigravity/index.js";
 import { getAllSkills as getAllKiroSkills } from "../../src/templates/kiro/index.js";
 import { getAllCommands as getAllGeminiCommands } from "../../src/templates/gemini/index.js";
 
@@ -61,6 +62,14 @@ describe("getConfiguredPlatforms", () => {
     fs.mkdirSync(path.join(tmpDir, ".agents", "skills"), { recursive: true });
     const result = getConfiguredPlatforms(tmpDir);
     expect(result.has("codex")).toBe(true);
+  });
+
+  it("detects .agent/workflows directory as antigravity", () => {
+    fs.mkdirSync(path.join(tmpDir, ".agent", "workflows"), {
+      recursive: true,
+    });
+    const result = getConfiguredPlatforms(tmpDir);
+    expect(result.has("antigravity")).toBe(true);
   });
 
   it("detects .kiro/skills directory as kiro", () => {
@@ -235,6 +244,38 @@ describe("configurePlatform", () => {
       expect(file).not.toMatch(/\.d\.ts$/);
       expect(file).not.toMatch(/\.js\.map$/);
       expect(file).not.toMatch(/\.d\.ts\.map$/);
+    }
+  });
+
+  it("configurePlatform('antigravity') creates .agent/workflows directory", async () => {
+    await configurePlatform("antigravity", tmpDir);
+    expect(fs.existsSync(path.join(tmpDir, ".agent", "workflows"))).toBe(
+      true,
+    );
+  });
+
+  it("configurePlatform('antigravity') writes all workflow templates", async () => {
+    await configurePlatform("antigravity", tmpDir);
+
+    const expectedWorkflows = getAllAntigravityWorkflows();
+    const expectedNames = expectedWorkflows
+      .map((workflow) => workflow.name)
+      .sort();
+
+    const workflowsRoot = path.join(tmpDir, ".agent", "workflows");
+    const actualNames = fs
+      .readdirSync(workflowsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name.replace(/\.md$/, ""))
+      .sort();
+
+    expect(actualNames).toEqual(expectedNames);
+    expect(actualNames).not.toContain("parallel");
+
+    for (const workflow of expectedWorkflows) {
+      const workflowPath = path.join(workflowsRoot, `${workflow.name}.md`);
+      expect(fs.existsSync(workflowPath)).toBe(true);
+      expect(fs.readFileSync(workflowPath, "utf-8")).toBe(workflow.content);
     }
   });
 

--- a/test/regression.test.ts
+++ b/test/regression.test.ts
@@ -46,7 +46,10 @@ import {
   commonCliAdapter,
   getAllScripts,
 } from "../src/templates/trellis/index.js";
-import { collectPlatformTemplates, PLATFORM_IDS } from "../src/configurators/index.js";
+import {
+  collectPlatformTemplates,
+  PLATFORM_IDS,
+} from "../src/configurators/index.js";
 
 afterEach(() => {
   clearManifestCache();
@@ -61,7 +64,7 @@ describe("regression: Windows encoding (beta.10, beta.11, beta.16)", () => {
     expect(commonInit).toContain("def _configure_stream");
   });
 
-  it("[beta.10] common/__init__.py has reconfigure(encoding=\"utf-8\") pattern", () => {
+  it('[beta.10] common/__init__.py has reconfigure(encoding="utf-8") pattern', () => {
     expect(commonInit).toContain('reconfigure(encoding="utf-8"');
   });
 
@@ -69,7 +72,7 @@ describe("regression: Windows encoding (beta.10, beta.11, beta.16)", () => {
     expect(commonInit).toContain("TextIOWrapper");
   });
 
-  it("[beta.10] common/__init__.py has sys.platform == \"win32\" guard", () => {
+  it('[beta.10] common/__init__.py has sys.platform == "win32" guard', () => {
     expect(commonInit).toContain('sys.platform == "win32"');
   });
 
@@ -88,7 +91,9 @@ describe("regression: Windows encoding (beta.10, beta.11, beta.16)", () => {
     // The reconfigure pattern is safe to call multiple times
     // The function should NOT use detach() unconditionally (beta.16 bug root cause)
     // It should check hasattr(stream, "reconfigure") FIRST
-    const reconfigureIndex = commonInit.indexOf('hasattr(stream, "reconfigure")');
+    const reconfigureIndex = commonInit.indexOf(
+      'hasattr(stream, "reconfigure")',
+    );
     const detachIndex = commonInit.indexOf('hasattr(stream, "detach")');
     expect(reconfigureIndex).toBeLessThan(detachIndex);
   });
@@ -181,9 +186,10 @@ describe("regression: task directory paths (0.2.14, 0.2.15, beta.13)", () => {
     for (const [name, content] of scripts) {
       // Check for hardcoded username in path patterns (workspace/taosu, /Users/taosu)
       // but allow usage examples like "python3 status.py -a taosu"
-      expect(content, `${name} should not contain hardcoded username in paths`).not.toMatch(
-        /workspace\/taosu|\/Users\/taosu/,
-      );
+      expect(
+        content,
+        `${name} should not contain hardcoded username in paths`,
+      ).not.toMatch(/workspace\/taosu|\/Users\/taosu/);
     }
   });
 });
@@ -247,7 +253,9 @@ describe("regression: semver prerelease handling (beta.5)", () => {
     // Should not include beta.0 itself (only > fromVersion)
     const versions = getAllMigrationVersions();
     if (versions.includes("0.3.0-beta.1")) {
-      expect(hasPendingMigrations("0.3.0-beta.0", "0.3.0-beta.2")).toBeDefined();
+      expect(
+        hasPendingMigrations("0.3.0-beta.0", "0.3.0-beta.2"),
+      ).toBeDefined();
     }
   });
 });
@@ -256,7 +264,10 @@ describe("regression: migration data integrity (beta.14)", () => {
   it("[beta.14] all migrations have non-undefined 'from' field", () => {
     const allMigrations = getAllMigrations();
     for (const m of allMigrations) {
-      expect(m.from, `migration should have 'from' field defined`).toBeDefined();
+      expect(
+        m.from,
+        `migration should have 'from' field defined`,
+      ).toBeDefined();
       expect(typeof m.from).toBe("string");
       expect(m.from.length).toBeGreaterThan(0);
     }
@@ -276,7 +287,10 @@ describe("regression: migration data integrity (beta.14)", () => {
       (m) => m.type === "rename" || m.type === "rename-dir",
     );
     for (const m of renames) {
-      expect(m.to, `rename migration from '${m.from}' should have 'to'`).toBeDefined();
+      expect(
+        m.to,
+        `rename migration from '${m.from}' should have 'to'`,
+      ).toBeDefined();
       expect(typeof m.to).toBe("string");
       expect((m.to as string).length).toBeGreaterThan(0);
     }
@@ -298,7 +312,16 @@ describe("regression: update only configured platforms (beta.16)", () => {
   });
 
   it("[beta.16] collectPlatformTemplates returns Map for platforms with tracking", () => {
-    const withTracking = ["claude-code", "cursor", "iflow", "codex", "kilo", "kiro", "gemini"] as const;
+    const withTracking = [
+      "claude-code",
+      "cursor",
+      "iflow",
+      "codex",
+      "kilo",
+      "kiro",
+      "gemini",
+      "antigravity",
+    ] as const;
     for (const id of withTracking) {
       const result = collectPlatformTemplates(id);
       expect(result, `${id} should have template tracking`).toBeInstanceOf(Map);
@@ -314,7 +337,9 @@ describe("regression: shell to Python migration (beta.0)", () => {
   it("[beta.0] no .sh scripts remain in trellis templates", () => {
     const scripts = getAllScripts();
     for (const [name] of scripts) {
-      expect(name.endsWith(".sh"), `${name} should not end with .sh`).toBe(false);
+      expect(name.endsWith(".sh"), `${name} should not end with .sh`).toBe(
+        false,
+      );
     }
   });
 
@@ -383,7 +408,9 @@ describe("regression: hook JSON format (beta.7)", () => {
 
   it("[beta.7] iFlow hook commands use {{PYTHON_CMD}} placeholder", () => {
     const settings = JSON.parse(iflowSettingsTemplate);
-    const hookTypes = Object.values(settings.hooks) as { hooks: { command: string }[] }[][];
+    const hookTypes = Object.values(settings.hooks) as {
+      hooks: { command: string }[];
+    }[][];
     for (const entries of hookTypes) {
       for (const entry of entries) {
         for (const hook of entry.hooks) {
@@ -463,6 +490,11 @@ describe("regression: platform additions (beta.9, beta.13, beta.16)", () => {
     expect(AI_TOOLS.gemini.configDir).toBe(".gemini");
   });
 
+  it("[antigravity] Antigravity platform is registered", () => {
+    expect(AI_TOOLS).toHaveProperty("antigravity");
+    expect(AI_TOOLS.antigravity.configDir).toBe(".agent/workflows");
+  });
+
   it("[beta.9] all platforms have consistent required fields", () => {
     for (const id of PLATFORM_IDS) {
       const tool = AI_TOOLS[id];
@@ -508,6 +540,11 @@ describe("regression: cli_adapter platform support (beta.9, beta.13, beta.16)", 
     expect(commonCliAdapter).toContain(".gemini");
   });
 
+  it("[antigravity] cli_adapter.py supports antigravity platform", () => {
+    expect(commonCliAdapter).toContain('"antigravity"');
+    expect(commonCliAdapter).toContain(".agent");
+  });
+
   it("[beta.9] cli_adapter.py has detect_platform function", () => {
     expect(commonCliAdapter).toContain("def detect_platform");
   });
@@ -527,6 +564,7 @@ describe("regression: cli_adapter platform support (beta.9, beta.13, beta.16)", 
     expect(commonCliAdapter).toContain(".agents");
     expect(commonCliAdapter).toContain(".kiro");
     expect(commonCliAdapter).toContain(".gemini");
+    expect(commonCliAdapter).toContain(".agent");
   });
 });
 
@@ -570,7 +608,10 @@ describe("regression: migration manifest consistency", () => {
       expect(idx, `${knownOrder[i]} should be in versions`).not.toBe(-1);
       if (i > 0) {
         const prevIdx = versions.indexOf(knownOrder[i - 1]);
-        expect(idx, `${knownOrder[i]} should come after ${knownOrder[i - 1]}`).toBeGreaterThan(prevIdx);
+        expect(
+          idx,
+          `${knownOrder[i]} should come after ${knownOrder[i - 1]}`,
+        ).toBeGreaterThan(prevIdx);
       }
     }
   });

--- a/test/templates/antigravity.test.ts
+++ b/test/templates/antigravity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getAllWorkflows } from "../../src/templates/antigravity/index.js";
+
+const EXPECTED_SKILL_NAMES = [
+  "before-backend-dev",
+  "before-frontend-dev",
+  "brainstorm",
+  "break-loop",
+  "check-backend",
+  "check-cross-layer",
+  "check-frontend",
+  "create-command",
+  "finish-work",
+  "integrate-skill",
+  "onboard",
+  "record-session",
+  "start",
+  "update-spec",
+];
+
+describe("antigravity getAllWorkflows", () => {
+  it("returns the expected workflow set (without parallel)", () => {
+    const workflows = getAllWorkflows();
+    const names = workflows.map((workflow) => workflow.name);
+    expect(names).toEqual(EXPECTED_SKILL_NAMES);
+  });
+
+  it("each workflow has non-empty content", () => {
+    const workflows = getAllWorkflows();
+    for (const workflow of workflows) {
+      expect(workflow.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("adapts codex skill paths to antigravity workflow paths", () => {
+    const workflows = getAllWorkflows();
+
+    for (const workflow of workflows) {
+      expect(workflow.content).not.toContain(".agents/skills/");
+    }
+
+    const createCommand = workflows.find((w) => w.name === "create-command");
+    expect(createCommand?.content).toContain("Antigravity workflow");
+    expect(createCommand?.content).toContain(
+      ".agent/workflows/<workflow-name>.md",
+    );
+    expect(createCommand?.content).toContain("/create-command");
+    expect(createCommand?.content).not.toContain("$create-command");
+    expect(createCommand?.content).not.toContain("open /skills and select it");
+
+    const integrateSkill = workflows.find((w) => w.name === "integrate-skill");
+    expect(integrateSkill?.content).toContain(
+      ".agent/workflows/<workflow-name>.md",
+    );
+  });
+});

--- a/test/templates/extract.test.ts
+++ b/test/templates/extract.test.ts
@@ -9,6 +9,7 @@ import {
   getKiloTemplatePath,
   getKiroTemplatePath,
   getGeminiTemplatePath,
+  getAntigravityTemplatePath,
   getTrellisSourcePath,
   getCursorSourcePath,
   getClaudeSourcePath,
@@ -16,6 +17,7 @@ import {
   getOpenCodeSourcePath,
   getKiroSourcePath,
   getGeminiSourcePath,
+  getAntigravitySourcePath,
   readTrellisFile,
   readTemplate,
   readScript,
@@ -79,6 +81,12 @@ describe("template path functions", () => {
     expect(fs.existsSync(p)).toBe(true);
     expect(fs.statSync(p).isDirectory()).toBe(true);
   });
+
+  it("getAntigravityTemplatePath returns existing directory", () => {
+    const p = getAntigravityTemplatePath();
+    expect(fs.existsSync(p)).toBe(true);
+    expect(fs.statSync(p).isDirectory()).toBe(true);
+  });
 });
 
 // =============================================================================
@@ -112,6 +120,10 @@ describe("deprecated source path aliases", () => {
 
   it("getGeminiSourcePath equals getGeminiTemplatePath", () => {
     expect(getGeminiSourcePath()).toBe(getGeminiTemplatePath());
+  });
+
+  it("getAntigravitySourcePath equals getAntigravityTemplatePath", () => {
+    expect(getAntigravitySourcePath()).toBe(getAntigravityTemplatePath());
   });
 });
 


### PR DESCRIPTION
## Summary
- add `antigravity` as a first-class platform in registry and CLI init flags
- configure Antigravity templates into official workspace path: `.agent/workflows/*.md`
- update Trellis Python `cli_adapter` to detect `.agent/workflows` and map command paths accordingly
- adapt Antigravity workflow template content from Codex skills:
  - `.agents/skills/.../SKILL.md` -> `.agent/workflows/... .md`
  - `$workflow` style triggers -> `/workflow` style triggers
  - remove `/skills` UX wording for Antigravity
- add/refresh tests for init, configurator detection, managed path checks, regression coverage, and Antigravity template adaptation

## Verification
- `pnpm -s typecheck`
- `pnpm -s test` (23 files, 348 tests)
- `pnpm -s lint`
- `pnpm -s lint:py` (warnings only, no errors)

## Notes
- aligned with official Antigravity guidance: workflows live in `.agent/workflows` and are invoked via `/workflow-name` in chat.
