### PR TITLE
docs(readme): update EN/ZH slogans

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-<strong>Trellis is an open-source AI coding workflow framework that injects your project standards and task context into every session so AI tools work like they actually know your codebase.</strong><br/>
+<strong>A multi-platform AI coding framework that rules</strong><br/>
 <sub>Supports Claude Code, Cursor, OpenCode, iFlow, Codex, Kilo, Kiro, Gemini CLI, and Antigravity.</sub>
 </p>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-<strong>Trellis 是一个开源 AI 编程工作流框架，它会把项目规范和任务上下文注入到每次会话里，让 AI 工具真正按你的代码库方式工作。</strong><br/>
+<strong>给 AI 立规矩的开源框架</strong><br/>
 <sub>支持 Claude Code、Cursor、OpenCode、iFlow、Codex、Kilo、Kiro、Gemini CLI 和 Antigravity。</sub>
 </p>
 


### PR DESCRIPTION
## Summary
- EN slogan → "A multi-platform AI coding framework that rules"
- ZH slogan → "给 AI 立规矩的开源框架"
- Replaces verbose machine-translated descriptions with concise, memorable taglines

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify README_CN.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)