### PR TITLE
fix: parse_simple_yaml greedy quote strip destroys nested quotes

### DIFF
--- a/.trellis/scripts/common/worktree.py
+++ b/.trellis/scripts/common/worktree.py
@@ -25,6 +25,25 @@ from .paths import (
 # YAML Simple Parser (no dependencies)
 # =============================================================================
 
+
+def _unquote(s: str) -> str:
+    """Remove exactly one layer of matching surrounding quotes.
+
+    Unlike str.strip('"'), this only removes the outermost pair,
+    preserving any nested quotes inside the value.
+
+    Examples:
+        _unquote('"hello"')        -> 'hello'
+        _unquote("'hello'")        -> 'hello'
+        _unquote('"echo \\'hi\\'"')  -> "echo 'hi'"
+        _unquote('hello')          -> 'hello'
+        _unquote('"hello\\'')       -> '"hello\\''  (mismatched, unchanged)
+    """
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
 def parse_simple_yaml(content: str) -> dict:
     """Parse simple YAML with nested dict support (no dependencies).
 
@@ -77,12 +96,12 @@ def _parse_yaml_block(
 
         if stripped.startswith("- "):
             if current_list is not None:
-                current_list.append(stripped[2:].strip().strip('"').strip("'"))
+                current_list.append(_unquote(stripped[2:].strip()))
             i += 1
         elif ":" in stripped:
             key, _, value = stripped.partition(":")
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = _unquote(value.strip())
             current_list = None
 
             if value:

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -152,7 +152,7 @@ export function loadUpdateSkipPaths(cwd: string): string[] {
       if (inSkip) {
         const match = trimmed.match(/^\s+-\s+(.+)$/);
         if (match) {
-          paths.push(match[1].trim());
+          paths.push(match[1].trim().replace(/^['"]|['"]$/g, ""));
           continue;
         }
         // If line is non-empty and not a list item, we've left the skip section

--- a/packages/cli/src/templates/trellis/scripts/common/worktree.py
+++ b/packages/cli/src/templates/trellis/scripts/common/worktree.py
@@ -25,6 +25,25 @@ from .paths import (
 # YAML Simple Parser (no dependencies)
 # =============================================================================
 
+
+def _unquote(s: str) -> str:
+    """Remove exactly one layer of matching surrounding quotes.
+
+    Unlike str.strip('"'), this only removes the outermost pair,
+    preserving any nested quotes inside the value.
+
+    Examples:
+        _unquote('"hello"')        -> 'hello'
+        _unquote("'hello'")        -> 'hello'
+        _unquote('"echo \\'hi\\'"')  -> "echo 'hi'"
+        _unquote('hello')          -> 'hello'
+        _unquote('"hello\\'')       -> '"hello\\''  (mismatched, unchanged)
+    """
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
 def parse_simple_yaml(content: str) -> dict:
     """Parse simple YAML with nested dict support (no dependencies).
 
@@ -77,12 +96,12 @@ def _parse_yaml_block(
 
         if stripped.startswith("- "):
             if current_list is not None:
-                current_list.append(stripped[2:].strip().strip('"').strip("'"))
+                current_list.append(_unquote(stripped[2:].strip()))
             i += 1
         elif ":" in stripped:
             key, _, value = stripped.partition(":")
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = _unquote(value.strip())
             current_list = None
 
             if value:

--- a/packages/cli/test/commands/update-internals.test.ts
+++ b/packages/cli/test/commands/update-internals.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 
 import {
   cleanupEmptyDirs,
+  loadUpdateSkipPaths,
   sortMigrationsForExecution,
 } from "../../src/commands/update.js";
 
@@ -96,6 +97,55 @@ describe("cleanupEmptyDirs", () => {
   it("handles non-existent directory gracefully", () => {
     // Should not throw
     expect(() => cleanupEmptyDirs(tmpDir, ".claude/nonexistent")).not.toThrow();
+  });
+});
+
+// =============================================================================
+// loadUpdateSkipPaths — YAML quote handling
+// =============================================================================
+
+describe("loadUpdateSkipPaths", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-skip-"));
+    fs.mkdirSync(path.join(tmpDir, ".trellis"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("strips double quotes from skip paths", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      'update:\n  skip:\n    - ".claude/commands/"\n',
+    );
+    const paths = loadUpdateSkipPaths(tmpDir);
+    expect(paths).toEqual([".claude/commands/"]);
+  });
+
+  it("strips single quotes from skip paths", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "update:\n  skip:\n    - '.claude/commands/'\n",
+    );
+    const paths = loadUpdateSkipPaths(tmpDir);
+    expect(paths).toEqual([".claude/commands/"]);
+  });
+
+  it("handles unquoted skip paths", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "update:\n  skip:\n    - .claude/commands/\n",
+    );
+    const paths = loadUpdateSkipPaths(tmpDir);
+    expect(paths).toEqual([".claude/commands/"]);
+  });
+
+  it("returns empty array when no config exists", () => {
+    const paths = loadUpdateSkipPaths(tmpDir);
+    expect(paths).toEqual([]);
   });
 });
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -12,10 +12,12 @@
  * 5. Platform Registry (beta.9, beta.13, beta.16)
  */
 
+import { execSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearManifestCache,
   getAllMigrations,
@@ -43,6 +45,7 @@ import {
   multiAgentPlan,
   multiAgentStart,
   commonCliAdapter,
+  commonWorktree,
   getAllScripts,
 } from "../src/templates/trellis/index.js";
 import {
@@ -781,6 +784,100 @@ describe("regression: collectTemplates paths match init directory structure (0.3
         "/commands/",
       );
     }
+  });
+});
+
+// =============================================================================
+// YAML Quote Stripping (0.3.8)
+// =============================================================================
+
+describe("regression: parse_simple_yaml uses _unquote not greedy strip (0.3.8)", () => {
+  it("worktree.py defines _unquote helper", () => {
+    expect(commonWorktree).toContain("def _unquote(s: str) -> str:");
+  });
+
+  it("worktree.py uses _unquote for list items, not .strip('\"')", () => {
+    // The bug: .strip('"').strip("'") greedily eats nested quotes
+    // e.g. "echo 'hello'" -> strip("'") -> echo 'hello (broken!)
+    expect(commonWorktree).not.toContain(".strip('\"').strip(\"'\")");
+    expect(commonWorktree).toContain("_unquote(stripped[2:].strip())");
+  });
+
+  it("worktree.py uses _unquote for key-value, not .strip('\"')", () => {
+    expect(commonWorktree).toContain("_unquote(value.strip())");
+  });
+});
+
+describe("regression: parse_simple_yaml Python execution (0.3.8)", () => {
+  // Extract _unquote + _parse_yaml_block + _next_content_line + parse_simple_yaml
+  // from commonWorktree and run them in an isolated Python process.
+  // We can't import worktree.py directly because it has `from .paths import ...`
+  let tmpDir: string;
+  let extractedPy: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-yaml-py-"));
+    // Extract _unquote + parse_simple_yaml + _parse_yaml_block + _next_content_line
+    // These 4 functions have no external imports — safe to run standalone.
+    const fnStart = commonWorktree.indexOf("def _unquote(");
+    const fnEnd = commonWorktree.indexOf("\ndef _yaml_get_value(");
+    extractedPy = commonWorktree.substring(fnStart, fnEnd);
+    fs.writeFileSync(path.join(tmpDir, "yaml_parser.py"), extractedPy);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Run parse_simple_yaml via Python subprocess and return parsed result */
+  function runPythonYaml(yamlContent: string): unknown {
+    const scriptFile = path.join(tmpDir, "_test.py");
+    const script = [
+      "import sys, json",
+      `sys.path.insert(0, ${JSON.stringify(tmpDir)})`,
+      "from yaml_parser import parse_simple_yaml",
+      `result = parse_simple_yaml(${JSON.stringify(yamlContent)})`,
+      "print(json.dumps(result))",
+    ].join("\n");
+    fs.writeFileSync(scriptFile, script);
+    const out = execSync(`python3 ${JSON.stringify(scriptFile)}`, {
+      encoding: "utf-8",
+    });
+    return JSON.parse(out.trim());
+  }
+
+  it("nested single quotes inside double quotes are preserved", () => {
+    const result = runPythonYaml('key: "echo \'hello\'"');
+    expect(result).toEqual({ key: "echo 'hello'" });
+  });
+
+  it("nested double quotes inside single quotes are preserved", () => {
+    const result = runPythonYaml("key: 'say \"hi\"'");
+    expect(result).toEqual({ key: 'say "hi"' });
+  });
+
+  it("list items with nested quotes are preserved", () => {
+    const result = runPythonYaml(
+      'hooks:\n  after_create:\n    - "echo \'Task created\'"',
+    );
+    expect(result).toEqual({
+      hooks: { after_create: ["echo 'Task created'"] },
+    });
+  });
+
+  it("simple quoted values work", () => {
+    const result = runPythonYaml('a: "hello"\nb: \'world\'');
+    expect(result).toEqual({ a: "hello", b: "world" });
+  });
+
+  it("unquoted values are unchanged", () => {
+    const result = runPythonYaml("key: plain value");
+    expect(result).toEqual({ key: "plain value" });
+  });
+
+  it("mismatched quotes are left as-is", () => {
+    const result = runPythonYaml("key: \"hello'");
+    expect(result).toEqual({ key: "\"hello'" });
   });
 });
 


### PR DESCRIPTION
str.strip('"').strip("'") greedily removes ALL matching chars from both ends, corrupting values like "echo 'hello'" into "echo 'hello".

- Add _unquote() helper that removes exactly one matching outer pair
- Fix worktree.py list item (line 80) and key-value (line 85) parsing
- Fix update.ts loadUpdateSkipPaths to strip quotes from skip paths
- Add 6 Python execution tests (parse_simple_yaml via subprocess)
- Add 3 template content regression tests
- Add 4 loadUpdateSkipPaths quote handling tests