### PR TITLE
fix(cli): correct hook matcher names in iflow settings

### DIFF
--- a/packages/cli/src/templates/iflow/settings.json
+++ b/packages/cli/src/templates/iflow/settings.json
@@ -22,7 +22,7 @@
                 ]
             },
             {
-                "matcher": "compact",
+                "matcher": "compress",
                 "hooks": [
                     {
                         "type": "command",
@@ -34,7 +34,7 @@
         ],
         "PreToolUse": [
             {
-                "matcher": "Task",
+                "matcher": "task",
                 "hooks": [
                     {
                         "type": "command",


### PR DESCRIPTION
- Change 'compact' to 'compress' for PostToolUse hook
- Change 'Task' to 'task' (lowercase) for PreToolUse hook