### PR TITLE
feat(commands): add /create-task, /activate-task, /archive-task

### DIFF
--- a/.claude/commands/activate-task.md
+++ b/.claude/commands/activate-task.md
@@ -1,0 +1,39 @@
+# Activate Task
+
+Set a task as the current active task so hooks can inject its context into subagents.
+
+---
+
+## Usage
+
+```
+/activate-task [task-name]
+```
+
+If no task name is provided, list active tasks and ask the user to pick one.
+
+---
+
+## Steps `[AI]`
+
+### Step 1: Identify Task
+
+If `$ARGUMENTS` is provided, use it as the task name/directory.
+
+If not provided, list tasks and ask user to choose:
+
+```bash
+python3 ./.trellis/scripts/task.py list
+```
+
+### Step 2: Activate
+
+```bash
+python3 ./.trellis/scripts/task.py start <task-dir>
+```
+
+Where `<task-dir>` is the task directory name (e.g. `03-16-create-task-commands`).
+
+### Step 3: Report
+
+Confirm which task is now active. Mention that subagent context injection is now enabled for this task.

--- a/.claude/commands/archive-task.md
+++ b/.claude/commands/archive-task.md
@@ -1,0 +1,37 @@
+# Archive Task
+
+Archive a completed task to `.trellis/tasks/archive/{year-month}/`.
+
+---
+
+## Usage
+
+```
+/archive-task [task-name]
+```
+
+If no task name is provided, list active tasks and ask the user to pick one.
+
+---
+
+## Steps `[AI]`
+
+### Step 1: Identify Task
+
+If `$ARGUMENTS` is provided, use it as the task name.
+
+If not provided, list tasks and ask user to choose:
+
+```bash
+python3 ./.trellis/scripts/task.py list
+```
+
+### Step 2: Archive
+
+```bash
+python3 ./.trellis/scripts/task.py archive <task-name>
+```
+
+### Step 3: Report
+
+Confirm the task has been archived and show the archive path.

--- a/.claude/commands/create-task.md
+++ b/.claude/commands/create-task.md
@@ -1,0 +1,35 @@
+# Create Task
+
+Create a new task directory with task.json.
+
+---
+
+## Usage
+
+```
+/create-task <title>
+```
+
+User provides a task title (and optionally a slug). If no slug is given, generate one from the title.
+
+---
+
+## Steps `[AI]`
+
+### Step 1: Parse Arguments
+
+From `$ARGUMENTS`, extract:
+- **title** (required): The task title
+- **slug** (optional): If user provides `--slug <name>`, use it; otherwise auto-generate a short kebab-case slug from the title
+
+### Step 2: Create Task
+
+```bash
+python3 ./.trellis/scripts/task.py create "<title>" --slug <slug>
+```
+
+### Step 3: Report
+
+Show the user:
+- Task directory path created
+- Suggest next steps: write a PRD, or run `/activate-task` to set it as current task


### PR DESCRIPTION
## Summary
- Add three slash commands wrapping `task.py` for task lifecycle management:
  - `/create-task <title>` — creates task directory + task.json
  - `/activate-task [name]` — sets current active task for hook context injection
  - `/archive-task [name]` — archives completed task to `archive/{year-month}/`
- Dry-tested full lifecycle (create → activate → archive) successfully in trellis-mkt

## Test plan
- [ ] Run `/create-task test-task` and verify directory created
- [ ] Run `/activate-task test-task` and verify `.current-task` set
- [ ] Run `/archive-task test-task` and verify moved to archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)