### PR TITLE
Add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,15 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
         "matcher": "Task",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as the first `PreToolUse` Bash hook in `.claude/settings.json`, before the existing `Task`/`Agent` context injection hooks.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag, and exits 2 to block. All existing session-start, context-injection, and ralph-loop hooks are preserved unchanged.

Closes #101

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
