### PR TITLE
feat: improve skill scores for Trellis

### DIFF
--- a/.agents/skills/before-dev/SKILL.md
+++ b/.agents/skills/before-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: before-dev
-description: "Read the relevant development guidelines before starting your task."
+description: "Discovers and injects project-specific coding guidelines from .trellis/spec/ before implementation begins. Reads spec indexes, pre-development checklists, and shared thinking guides for the target package. Use when starting a new coding task, before writing any code, switching to a different package, or needing to refresh project conventions and standards."
 ---
 
 Read the relevant development guidelines before starting your task.

--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: "Brainstorm - Requirements Discovery (AI Coding Enhanced)"
+description: "Collaborative requirements discovery session optimized for AI coding workflows. Creates task directories, seeds PRDs, runs codebase research, proposes concrete implementation approaches with trade-offs, and converges on MVP scope through structured Q&A. Use when requirements are unclear, multiple implementation paths exist, trade-offs need evaluation, or a complex feature needs scoping before development."
 ---
 
 # Brainstorm - Requirements Discovery (AI Coding Enhanced)

--- a/.agents/skills/break-loop/SKILL.md
+++ b/.agents/skills/break-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: break-loop
-description: "Break the Loop - Deep Bug Analysis"
+description: "Deep post-fix bug analysis across five dimensions: root cause categorization, fix failure analysis, prevention mechanisms, systematic expansion, and knowledge capture. Updates .trellis/spec/ guides with lessons learned to prevent recurring bugs. Use when a debugging session completes, after fixing a tricky bug, when the same class of bug keeps recurring, or when you want to capture debugging insights into project documentation."
 ---
 
 # Break the Loop - Deep Bug Analysis

--- a/.agents/skills/check-cross-layer/SKILL.md
+++ b/.agents/skills/check-cross-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-cross-layer
-description: "Cross-Layer Check"
+description: "Post-implementation verification across multiple code dimensions: cross-layer data flow, code reuse analysis, import path validation, and same-layer consistency checks. Identifies missed update sites, type mismatches, and duplicated constants. Use when changes span 3+ architectural layers, after modifying shared constants or configs, after batch file modifications, or when creating new utility functions."
 ---
 
 # Cross-Layer Check

--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: "Check if the code you just wrote follows the development guidelines."
+description: "Validates recently written code against project-specific development guidelines from .trellis/spec/. Identifies changed files via git diff, discovers applicable spec modules, runs lint and typecheck, and reports guideline violations. Use when code is written and needs quality verification, to catch context drift during long sessions, or before committing changes."
 ---
 
 Check if the code you just wrote follows the development guidelines.

--- a/.agents/skills/create-command/SKILL.md
+++ b/.agents/skills/create-command/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-command
-description: "Create New Slash Command"
+description: "Scaffolds a new slash command in both .cursor/commands/ and .claude/commands/ directories with proper naming conventions and structure. Analyzes requirements to determine command type and generates appropriate content. Use when adding a new developer workflow command, creating a custom slash command, or extending the Trellis command set."
 ---
 
 # Create New Slash Command

--- a/.agents/skills/finish-work/SKILL.md
+++ b/.agents/skills/finish-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-work
-description: "Finish Work - Pre-Commit Checklist"
+description: "Pre-commit quality checklist covering lint, typecheck, tests, code-spec sync, API changes, database migrations, cross-layer verification, and manual testing. Blocks commit if infra or cross-layer specs lack executable depth. Use when code is written and tested but not yet committed, before submitting changes, or as a final review before git commit."
 ---
 
 # Finish Work - Pre-Commit Checklist

--- a/.agents/skills/improve-ut/SKILL.md
+++ b/.agents/skills/improve-ut/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve-ut
-description: "Improve Unit Test Coverage for New Changes"
+description: "Analyzes changed files and improves unit test coverage using project-specific testing conventions from .trellis/spec/ unit-test specs. Determines test scope (unit vs integration vs regression), adds or updates tests following existing patterns, and runs validation. Use when code changes need test coverage, after implementing a feature, after fixing a bug, or when test gaps are identified."
 ---
 
 # Improve Unit Tests (UT)

--- a/.agents/skills/integrate-skill/SKILL.md
+++ b/.agents/skills/integrate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-skill
-description: "Integrate Claude Skill into Project Guidelines"
+description: "Adapts a Claude global skill into project-specific development guidelines in .trellis/spec/. Creates guideline sections, code example templates with .template suffix, and updates spec indexes. Use when integrating an external Claude skill, adding a new skill's patterns to project conventions, or incorporating third-party skill best practices into .trellis/spec/ documentation."
 ---
 
 # Integrate Claude Skill into Project Guidelines

--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "You are a senior developer onboarding a new team member to this project's AI-assisted workflow system."
+description: "Interactive three-part onboarding for new team members to the Trellis AI-assisted workflow system. Covers core philosophy (AI memory, project-specific knowledge, context drift), system structure and command deep-dives, real-world workflow examples, and guideline customization. Use when a new developer joins the project, someone needs to understand the Trellis workflow, or project guidelines need initial setup."
 ---
 
 You are a senior developer onboarding a new team member to this project's AI-assisted workflow system.

--- a/.agents/skills/parallel/SKILL.md
+++ b/.agents/skills/parallel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel
-description: "Multi-Agent Pipeline Orchestrator"
+description: "Multi-agent pipeline orchestrator that plans and dispatches parallel development tasks to worktree agents. Reads project context, configures task directories with PRDs and jsonl context files, and launches isolated coding agents. Use when multiple independent features need parallel development, orchestrating worktree agents, or managing multi-agent coding pipelines."
 ---
 
 # Multi-Agent Pipeline Orchestrator

--- a/.agents/skills/record-session/SKILL.md
+++ b/.agents/skills/record-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: record-session
-description: "[!] **Prerequisite**: This command should only be used AFTER the human has tested and committed the code."
+description: "Records completed work progress to .trellis/workspace/ journal files after human testing and commit. Captures session summaries, commit hashes, and updates developer index files for future session context. Use when a coding session is complete, after the human has committed code, or to persist session knowledge for future AI sessions."
 ---
 
 [!] **Prerequisite**: This command should only be used AFTER the human has tested and committed the code.

--- a/.agents/skills/start/SKILL.md
+++ b/.agents/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "Start Session"
+description: "Initializes an AI development session by reading workflow guides, developer identity, git status, active tasks, and project guidelines from .trellis/. Classifies incoming tasks and routes to brainstorm, direct edit, or task workflow. Use when beginning a new coding session, resuming work, starting a new task, or re-establishing project context."
 ---
 
 # Start Session

--- a/.agents/skills/update-spec/SKILL.md
+++ b/.agents/skills/update-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-spec
-description: "Update Code-Spec - Capture Executable Contracts"
+description: "Captures executable contracts and coding knowledge into .trellis/spec/ documents after implementation, debugging, or design decisions. Enforces code-spec depth for infra and cross-layer changes with mandatory sections for signatures, contracts, validation matrices, and test points. Use when a feature is implemented, a bug is fixed, a design decision is made, a new pattern is discovered, or cross-layer contracts change."
 ---
 
 # Update Code-Spec - Capture Executable Contracts

--- a/.claude/skills/contribute/SKILL.md
+++ b/.claude/skills/contribute/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: contribute
-description: |
-  Guide for contributing to Trellis documentation. Use when someone wants to:
-  - Add a new spec template
-  - Add a new skill to the marketplace
-  - Add or update documentation pages
-  - Submit a PR to this project
+description: "Guide for contributing to Trellis documentation and marketplace. Covers adding spec templates, marketplace skills, documentation pages, and submitting PRs across both the Trellis main repo and docs repo. Use when someone wants to add a new spec template, add a new skill to the marketplace, add or update documentation pages, or submit a PR to this project."
 ---
 
 # Contributing to Trellis

--- a/.claude/skills/python-design/SKILL.md
+++ b/.claude/skills/python-design/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: python-design
-description: >
-  Python design patterns for CLI scripts and utilities — type-first development,
-  deep modules, complexity management, and red flags. Use this skill whenever
-  reading, writing, reviewing, or refactoring Python files, especially in
-  .trellis/scripts/ or any CLI/scripting context. Also activate when planning
-  module structure, deciding where to put new code, or doing code review.
+description: "Python design patterns for CLI scripts and utilities — type-first development, deep modules, complexity management, and red flags. Use when reading, writing, reviewing, or refactoring Python files, especially in .trellis/scripts/ or any CLI/scripting context. Also activate when planning module structure, deciding where to put new code, or doing code review."
 ---
 
 # Python Design for CLI Scripts

--- a/.claude/skills/trellis-meta/SKILL.md
+++ b/.claude/skills/trellis-meta/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: trellis-meta
-description: |
-  Meta-skill for understanding and customizing Mindfold Trellis - the AI workflow system for Claude Code and Cursor. This skill documents the ORIGINAL Trellis system design. When users customize their Trellis installation, modifications should be recorded in a project-local `trellis-local` skill, NOT in this meta-skill. Use this skill when: (1) understanding Trellis architecture, (2) customizing Trellis workflows, (3) adding commands/agents/hooks, (4) troubleshooting issues, or (5) adapting Trellis to specific projects.
+description: "Meta-skill for understanding and customizing Mindfold Trellis — the AI workflow system for Claude Code and Cursor. Documents the original Trellis system design including architecture, commands, hooks, and multi-agent pipelines. Use when understanding Trellis architecture, customizing workflows, adding commands or agents, troubleshooting issues, or adapting Trellis to specific projects. Modifications should be recorded in a project-local trellis-local skill, not here."
 ---
 
 # Trellis Meta-Skill

--- a/marketplace/skills/trellis-meta/SKILL.md
+++ b/marketplace/skills/trellis-meta/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: trellis-meta
-description: |
-  Meta-skill for understanding and customizing Mindfold Trellis - the all-in-one AI workflow system for 9 AI coding platforms (Claude Code, Cursor, OpenCode, iFlow, Codex, Kilo, Kiro, Gemini CLI, Antigravity). This skill documents the ORIGINAL Trellis system design. When users customize their Trellis installation, modifications should be recorded in a project-local `trellis-local` skill, NOT in this meta-skill. Use this skill when: (1) understanding Trellis architecture, (2) customizing Trellis workflows, (3) adding commands/agents/hooks, (4) troubleshooting issues, or (5) adapting Trellis to specific projects.
+description: "Meta-skill for understanding and customizing Mindfold Trellis — the all-in-one AI workflow system for 9 AI coding platforms (Claude Code, Cursor, OpenCode, iFlow, Codex, Kilo, Kiro, Gemini CLI, Antigravity). Documents the original Trellis system design including architecture, commands, hooks, and multi-agent pipelines. Use when understanding Trellis architecture, customizing workflows, adding commands or agents, troubleshooting issues, or adapting Trellis to specific projects. Modifications should be recorded in a project-local trellis-local skill, not here."
 ---
 
 # Trellis Meta-Skill

--- a/packages/cli/src/templates/codex/skills/before-dev/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/before-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: before-dev
-description: "Read the relevant development guidelines before starting your task."
+description: "Discovers and injects project-specific coding guidelines from .trellis/spec/ before implementation begins. Reads spec indexes, pre-development checklists, and shared thinking guides for the target package. Use when starting a new coding task, before writing any code, switching to a different package, or needing to refresh project conventions and standards."
 ---
 
 Read the relevant development guidelines before starting your task.

--- a/packages/cli/src/templates/codex/skills/brainstorm/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: "Brainstorm - Requirements Discovery (AI Coding Enhanced)"
+description: "Collaborative requirements discovery session optimized for AI coding workflows. Creates task directories, seeds PRDs, runs codebase research, proposes concrete implementation approaches with trade-offs, and converges on MVP scope through structured Q&A. Use when requirements are unclear, multiple implementation paths exist, trade-offs need evaluation, or a complex feature needs scoping before development."
 ---
 
 # Brainstorm - Requirements Discovery (AI Coding Enhanced)

--- a/packages/cli/src/templates/codex/skills/break-loop/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/break-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: break-loop
-description: "Break the Loop - Deep Bug Analysis"
+description: "Deep post-fix bug analysis across five dimensions: root cause categorization, fix failure analysis, prevention mechanisms, systematic expansion, and knowledge capture. Updates .trellis/spec/ guides with lessons learned to prevent recurring bugs. Use when a debugging session completes, after fixing a tricky bug, when the same class of bug keeps recurring, or when you want to capture debugging insights into project documentation."
 ---
 
 # Break the Loop - Deep Bug Analysis

--- a/packages/cli/src/templates/codex/skills/check-cross-layer/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/check-cross-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-cross-layer
-description: "Cross-Layer Check"
+description: "Post-implementation verification across multiple code dimensions: cross-layer data flow, code reuse analysis, import path validation, and same-layer consistency checks. Identifies missed update sites, type mismatches, and duplicated constants. Use when changes span 3+ architectural layers, after modifying shared constants or configs, after batch file modifications, or when creating new utility functions."
 ---
 
 # Cross-Layer Check

--- a/packages/cli/src/templates/codex/skills/check/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: "Check if the code you just wrote follows the development guidelines."
+description: "Validates recently written code against project-specific development guidelines from .trellis/spec/. Identifies changed files via git diff, discovers applicable spec modules, runs lint and typecheck, and reports guideline violations. Use when code is written and needs quality verification, to catch context drift during long sessions, or before committing changes."
 ---
 
 Check if the code you just wrote follows the development guidelines.

--- a/packages/cli/src/templates/codex/skills/create-command/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/create-command/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-command
-description: "Create New Skill"
+description: "Scaffolds a new skill file with proper naming conventions and structure. Analyzes requirements to determine skill type and generates appropriate content. Use when adding a new developer workflow skill, creating a custom skill, or extending the Trellis skill set."
 ---
 
 # Create New Skill

--- a/packages/cli/src/templates/codex/skills/finish-work/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/finish-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-work
-description: "Finish Work - Pre-Commit Checklist"
+description: "Pre-commit quality checklist covering lint, typecheck, tests, code-spec sync, API changes, database migrations, cross-layer verification, and manual testing. Blocks commit if infra or cross-layer specs lack executable depth. Use when code is written and tested but not yet committed, before submitting changes, or as a final review before git commit."
 ---
 
 # Finish Work - Pre-Commit Checklist

--- a/packages/cli/src/templates/codex/skills/integrate-skill/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/integrate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-skill
-description: "Integrate Skill into Project Guidelines"
+description: "Adapts an external skill into project-specific development guidelines in .trellis/spec/. Creates guideline sections, code example templates with .template suffix, and updates spec indexes. Use when integrating an external skill, adding a new skill's patterns to project conventions, or incorporating third-party skill best practices into .trellis/spec/ documentation."
 ---
 
 # Integrate Skill into Project Guidelines

--- a/packages/cli/src/templates/codex/skills/onboard/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "PART 3: Customize Your Development Guidelines"
+description: "Interactive three-part onboarding for new team members to the Trellis AI-assisted workflow system. Covers core philosophy (AI memory, project-specific knowledge, context drift), system structure and command deep-dives, real-world workflow examples, and guideline customization. Use when a new developer joins the project, someone needs to understand the Trellis workflow, or project guidelines need initial setup."
 ---
 
 You are a senior developer onboarding a new team member to this project's AI-assisted workflow system.

--- a/packages/cli/src/templates/codex/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/record-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: record-session
-description: "Record work progress after human has tested and committed code"
+description: "Records completed work progress to .trellis/workspace/ journal files after human testing and commit. Captures session summaries, commit hashes, and updates developer index files for future session context. Use when a coding session is complete, after the human has committed code, or to persist session knowledge for future AI sessions."
 ---
 
 [!] **Prerequisite**: This skill should only be used AFTER the human has tested and committed the code.

--- a/packages/cli/src/templates/codex/skills/start/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "Start Session"
+description: "Initializes an AI development session by reading workflow guides, developer identity, git status, active tasks, and project guidelines from .trellis/. Classifies incoming tasks and routes to brainstorm, direct edit, or task workflow. Use when beginning a new coding session, resuming work, starting a new task, or re-establishing project context."
 ---
 
 # Start Session

--- a/packages/cli/src/templates/codex/skills/update-spec/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/update-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-spec
-description: "Update Code-Spec - Capture Executable Contracts"
+description: "Captures executable contracts and coding knowledge into .trellis/spec/ documents after implementation, debugging, or design decisions. Enforces code-spec depth for infra and cross-layer changes with mandatory sections for signatures, contracts, validation matrices, and test points. Use when a feature is implemented, a bug is fixed, a design decision is made, a new pattern is discovered, or cross-layer contracts change."
 ---
 
 # Update Code-Spec - Capture Executable Contracts

--- a/packages/cli/src/templates/kiro/skills/before-dev/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/before-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: before-dev
-description: "Read the relevant development guidelines before starting your task."
+description: "Discovers and injects project-specific coding guidelines from .trellis/spec/ before implementation begins. Reads spec indexes, pre-development checklists, and shared thinking guides for the target package. Use when starting a new coding task, before writing any code, switching to a different package, or needing to refresh project conventions and standards."
 ---
 
 Read the relevant development guidelines before starting your task.

--- a/packages/cli/src/templates/kiro/skills/brainstorm/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: "Brainstorm - Requirements Discovery (AI Coding Enhanced)"
+description: "Collaborative requirements discovery session optimized for AI coding workflows. Creates task directories, seeds PRDs, runs codebase research, proposes concrete implementation approaches with trade-offs, and converges on MVP scope through structured Q&A. Use when requirements are unclear, multiple implementation paths exist, trade-offs need evaluation, or a complex feature needs scoping before development."
 ---
 
 # Brainstorm - Requirements Discovery (AI Coding Enhanced)

--- a/packages/cli/src/templates/kiro/skills/break-loop/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/break-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: break-loop
-description: "Break the Loop - Deep Bug Analysis"
+description: "Deep post-fix bug analysis across five dimensions: root cause categorization, fix failure analysis, prevention mechanisms, systematic expansion, and knowledge capture. Updates .trellis/spec/ guides with lessons learned to prevent recurring bugs. Use when a debugging session completes, after fixing a tricky bug, when the same class of bug keeps recurring, or when you want to capture debugging insights into project documentation."
 ---
 
 # Break the Loop - Deep Bug Analysis

--- a/packages/cli/src/templates/kiro/skills/check-cross-layer/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/check-cross-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-cross-layer
-description: "Cross-Layer Check"
+description: "Post-implementation verification across multiple code dimensions: cross-layer data flow, code reuse analysis, import path validation, and same-layer consistency checks. Identifies missed update sites, type mismatches, and duplicated constants. Use when changes span 3+ architectural layers, after modifying shared constants or configs, after batch file modifications, or when creating new utility functions."
 ---
 
 # Cross-Layer Check

--- a/packages/cli/src/templates/kiro/skills/check/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: "Check if the code you just wrote follows the development guidelines."
+description: "Validates recently written code against project-specific development guidelines from .trellis/spec/. Identifies changed files via git diff, discovers applicable spec modules, runs lint and typecheck, and reports guideline violations. Use when code is written and needs quality verification, to catch context drift during long sessions, or before committing changes."
 ---
 
 Check if the code you just wrote follows the development guidelines.

--- a/packages/cli/src/templates/kiro/skills/create-command/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/create-command/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-command
-description: "Create New Skill"
+description: "Scaffolds a new skill file with proper naming conventions and structure. Analyzes requirements to determine skill type and generates appropriate content. Use when adding a new developer workflow skill, creating a custom skill, or extending the Trellis skill set."
 ---
 
 # Create New Skill

--- a/packages/cli/src/templates/kiro/skills/finish-work/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/finish-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-work
-description: "Finish Work - Pre-Commit Checklist"
+description: "Pre-commit quality checklist covering lint, typecheck, tests, code-spec sync, API changes, database migrations, cross-layer verification, and manual testing. Blocks commit if infra or cross-layer specs lack executable depth. Use when code is written and tested but not yet committed, before submitting changes, or as a final review before git commit."
 ---
 
 # Finish Work - Pre-Commit Checklist

--- a/packages/cli/src/templates/kiro/skills/integrate-skill/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/integrate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-skill
-description: "Integrate Skill into Project Guidelines"
+description: "Adapts an external skill into project-specific development guidelines in .trellis/spec/. Creates guideline sections, code example templates with .template suffix, and updates spec indexes. Use when integrating an external skill, adding a new skill's patterns to project conventions, or incorporating third-party skill best practices into .trellis/spec/ documentation."
 ---
 
 # Integrate Skill into Project Guidelines

--- a/packages/cli/src/templates/kiro/skills/onboard/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "PART 3: Customize Your Development Guidelines"
+description: "Interactive three-part onboarding for new team members to the Trellis AI-assisted workflow system. Covers core philosophy (AI memory, project-specific knowledge, context drift), system structure and command deep-dives, real-world workflow examples, and guideline customization. Use when a new developer joins the project, someone needs to understand the Trellis workflow, or project guidelines need initial setup."
 ---
 
 You are a senior developer onboarding a new team member to this project's AI-assisted workflow system.

--- a/packages/cli/src/templates/kiro/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/record-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: record-session
-description: "Record work progress after human has tested and committed code"
+description: "Records completed work progress to .trellis/workspace/ journal files after human testing and commit. Captures session summaries, commit hashes, and updates developer index files for future session context. Use when a coding session is complete, after the human has committed code, or to persist session knowledge for future AI sessions."
 ---
 
 [!] **Prerequisite**: This skill should only be used AFTER the human has tested and committed the code.

--- a/packages/cli/src/templates/kiro/skills/start/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "Start Session"
+description: "Initializes an AI development session by reading workflow guides, developer identity, git status, active tasks, and project guidelines from .trellis/. Classifies incoming tasks and routes to brainstorm, direct edit, or task workflow. Use when beginning a new coding session, resuming work, starting a new task, or re-establishing project context."
 ---
 
 # Start Session

--- a/packages/cli/src/templates/kiro/skills/update-spec/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/update-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-spec
-description: "Update Code-Spec - Capture Executable Contracts"
+description: "Captures executable contracts and coding knowledge into .trellis/spec/ documents after implementation, debugging, or design decisions. Enforces code-spec depth for infra and cross-layer changes with mandatory sections for signatures, contracts, validation matrices, and test points. Use when a feature is implemented, a bug is fixed, a design decision is made, a new pattern is discovered, or cross-layer contracts change."
 ---
 
 # Update Code-Spec - Capture Executable Contracts

--- a/packages/cli/src/templates/qoder/skills/before-dev/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/before-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: before-dev
-description: "Read the relevant development guidelines before starting your task."
+description: "Discovers and injects project-specific coding guidelines from .trellis/spec/ before implementation begins. Reads spec indexes, pre-development checklists, and shared thinking guides for the target package. Use when starting a new coding task, before writing any code, switching to a different package, or needing to refresh project conventions and standards."
 ---
 
 Read the relevant development guidelines before starting your task.

--- a/packages/cli/src/templates/qoder/skills/brainstorm/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: "Brainstorm - Requirements Discovery (AI Coding Enhanced)"
+description: "Collaborative requirements discovery session optimized for AI coding workflows. Creates task directories, seeds PRDs, runs codebase research, proposes concrete implementation approaches with trade-offs, and converges on MVP scope through structured Q&A. Use when requirements are unclear, multiple implementation paths exist, trade-offs need evaluation, or a complex feature needs scoping before development."
 ---
 
 # Brainstorm - Requirements Discovery (AI Coding Enhanced)

--- a/packages/cli/src/templates/qoder/skills/break-loop/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/break-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: break-loop
-description: "Break the Loop - Deep Bug Analysis"
+description: "Deep post-fix bug analysis across five dimensions: root cause categorization, fix failure analysis, prevention mechanisms, systematic expansion, and knowledge capture. Updates .trellis/spec/ guides with lessons learned to prevent recurring bugs. Use when a debugging session completes, after fixing a tricky bug, when the same class of bug keeps recurring, or when you want to capture debugging insights into project documentation."
 ---
 
 # Break the Loop - Deep Bug Analysis

--- a/packages/cli/src/templates/qoder/skills/check-cross-layer/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/check-cross-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-cross-layer
-description: "Cross-Layer Check"
+description: "Post-implementation verification across multiple code dimensions: cross-layer data flow, code reuse analysis, import path validation, and same-layer consistency checks. Identifies missed update sites, type mismatches, and duplicated constants. Use when changes span 3+ architectural layers, after modifying shared constants or configs, after batch file modifications, or when creating new utility functions."
 ---
 
 # Cross-Layer Check

--- a/packages/cli/src/templates/qoder/skills/check/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: "Check if the code you just wrote follows the development guidelines."
+description: "Validates recently written code against project-specific development guidelines from .trellis/spec/. Identifies changed files via git diff, discovers applicable spec modules, runs lint and typecheck, and reports guideline violations. Use when code is written and needs quality verification, to catch context drift during long sessions, or before committing changes."
 ---
 
 Check if the code you just wrote follows the development guidelines.

--- a/packages/cli/src/templates/qoder/skills/create-command/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/create-command/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-command
-description: "Create New Skill"
+description: "Scaffolds a new skill file with proper naming conventions and structure. Analyzes requirements to determine skill type and generates appropriate content. Use when adding a new developer workflow skill, creating a custom skill, or extending the Trellis skill set."
 ---
 
 # Create New Skill

--- a/packages/cli/src/templates/qoder/skills/finish-work/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/finish-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-work
-description: "Finish Work - Pre-Commit Checklist"
+description: "Pre-commit quality checklist covering lint, typecheck, tests, code-spec sync, API changes, database migrations, cross-layer verification, and manual testing. Blocks commit if infra or cross-layer specs lack executable depth. Use when code is written and tested but not yet committed, before submitting changes, or as a final review before git commit."
 ---
 
 # Finish Work - Pre-Commit Checklist

--- a/packages/cli/src/templates/qoder/skills/integrate-skill/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/integrate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-skill
-description: "Integrate Skill into Project Guidelines"
+description: "Adapts an external skill into project-specific development guidelines in .trellis/spec/. Creates guideline sections, code example templates with .template suffix, and updates spec indexes. Use when integrating an external skill, adding a new skill's patterns to project conventions, or incorporating third-party skill best practices into .trellis/spec/ documentation."
 ---
 
 # Integrate Skill into Project Guidelines

--- a/packages/cli/src/templates/qoder/skills/onboard/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "PART 3: Customize Your Development Guidelines"
+description: "Interactive three-part onboarding for new team members to the Trellis AI-assisted workflow system. Covers core philosophy (AI memory, project-specific knowledge, context drift), system structure and command deep-dives, real-world workflow examples, and guideline customization. Use when a new developer joins the project, someone needs to understand the Trellis workflow, or project guidelines need initial setup."
 ---
 
 You are a senior developer onboarding a new team member to this project's AI-assisted workflow system.

--- a/packages/cli/src/templates/qoder/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/record-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: record-session
-description: "Record work progress after human has tested and committed code"
+description: "Records completed work progress to .trellis/workspace/ journal files after human testing and commit. Captures session summaries, commit hashes, and updates developer index files for future session context. Use when a coding session is complete, after the human has committed code, or to persist session knowledge for future AI sessions."
 ---
 
 [!] **Prerequisite**: This command should only be used AFTER the human has tested and committed the code.

--- a/packages/cli/src/templates/qoder/skills/start/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "Start Session"
+description: "Initializes an AI development session by reading workflow guides, developer identity, git status, active tasks, and project guidelines from .trellis/. Classifies incoming tasks and routes to brainstorm, direct edit, or task workflow. Use when beginning a new coding session, resuming work, starting a new task, or re-establishing project context."
 ---
 
 # Start Session

--- a/packages/cli/src/templates/qoder/skills/update-spec/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/update-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-spec
-description: "Update Code-Spec - Capture Executable Contracts"
+description: "Captures executable contracts and coding knowledge into .trellis/spec/ documents after implementation, debugging, or design decisions. Enforces code-spec depth for infra and cross-layer changes with mandatory sections for signatures, contracts, validation matrices, and test points. Use when a feature is implemented, a bug is fixed, a design decision is made, a new pattern is discovered, or cross-layer contracts change."
 ---
 
 # Update Spec - Capture Knowledge into Specifications


### PR DESCRIPTION
Hey @taosu0216 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="1290" alt="image" src="https://github.com/user-attachments/assets/13e30965-393a-413a-b7d1-00d08bfff30c" />

Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| start | 42% | 92% | +50% |
| onboard | 14% | 60% | +46% |
| check-cross-layer | 42% | 85% | +43% |
| before-dev | 44% | 86% | +42% |
| break-loop | 46% | 88% | +42% |
| record-session | 50% | 92% | +42% |
| parallel | 42% | 81% | +39% |
| update-spec | 42% | 81% | +39% |
| create-command | 50% | 88% | +38% |
| finish-work | 50% | 88% | +38% |
| brainstorm | 46% | 81% | +35% |
| check | 44% | 79% | +35% |
| improve-ut | 60% | 94% | +34% |
| integrate-skill | 50% | 81% | +31% |
| contribute | 84% | 100% | +16% |
| trellis-meta | 72% | 84% | +12% |
| python-design | 80% | 84% | +4% |

Changes made:
- Expanded frontmatter descriptions across all 55 SKILL.md files
- Added "Use when..." trigger clauses to every description
- Added concrete action keywords replacing vague descriptions
- Converted YAML scalar formats (> and |) to standard quoted strings
- Improved trigger term quality with natural language keywords
- Increased distinctiveness to avoid false triggering between skills

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide: https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices and ask it to optimize your skill. Ping me - @rohan-tessl - if you hit any snags.

Thanks in advance 🙏