### PR TITLE
feat(cli): add branch context to .trellis session and journal records…

### DIFF
--- a/.agents/skills/record-session/SKILL.md
+++ b/.agents/skills/record-session/SKILL.md
@@ -42,6 +42,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 
 ---

--- a/.trellis/scripts/add_session.py
+++ b/.trellis/scripts/add_session.py
@@ -5,17 +5,23 @@ Add a new session to journal file and update index.md.
 
 Usage:
     python3 add_session.py --title "Title" --commit "hash" --summary "Summary" [--package cli]
+    python3 add_session.py --title "Title" --branch "feat/my-branch"
 
     # Pipe detailed content via stdin (use --stdin to opt in):
     cat << 'EOF' | python3 add_session.py --stdin --title "Title" --summary "Summary"
     <session content here>
     EOF
+
+Branch resolution order:
+    1. --branch CLI arg (explicit)
+    2. task.json branch field (from active task)
+    3. git branch --show-current (auto-detect)
+    4. None (omitted gracefully)
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import subprocess
 import sys
@@ -30,6 +36,7 @@ from common.paths import (
     get_workspace_dir,
 )
 from common.developer import ensure_developer
+from common.git import run_git
 from common.tasks import load_task
 from common.config import (
     get_packages,
@@ -139,6 +146,7 @@ def generate_session_content(
     extra_content: str,
     today: str,
     package: str | None = None,
+    branch: str | None = None,
 ) -> str:
     """Generate session content."""
     if commit and commit != "-":
@@ -151,13 +159,14 @@ def generate_session_content(
         commit_table = "(No commits - planning session)"
 
     package_line = f"\n**Package**: {package}" if package else ""
+    branch_line = f"\n**Branch**: `{branch}`" if branch else ""
 
     return f"""
 
 ## Session {session_num}: {title}
 
 **Date**: {today}
-**Task**: {title}{package_line}
+**Task**: {title}{package_line}{branch_line}
 
 ### Summary
 
@@ -192,7 +201,8 @@ def update_index(
     commit: str,
     new_session: int,
     active_file: str,
-    today: str
+    today: str,
+    branch: str | None = None,
 ) -> bool:
     """Update index.md with new session info."""
     # Format commit for display
@@ -271,10 +281,25 @@ def update_index(
             continue
 
         if in_session_history:
-            new_lines.append(line)
-            if re.match(r"^\|\s*-", line) and not header_written:
-                new_lines.append(f"| {new_session} | {today} | {title} | {commit_display} |")
+            # Migrate old 4/6-column headers to 5-column Branch-only history.
+            if re.match(
+                r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*Base Branch\s*\|\s*$",
+                line,
+            ):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*$", line):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*$", line):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|[-| ]+\|\s*$", line) and not header_written:
+                new_lines.append("|---|------|-------|---------|--------|")
+                new_lines.append(f"| {new_session} | {today} | {title} | {commit_display} | `{branch or '-'}` |")
                 header_written = True
+                continue
+            new_lines.append(line)
             continue
 
         new_lines.append(line)
@@ -323,6 +348,7 @@ def add_session(
     extra_content: str = "(Add details)",
     auto_commit: bool = True,
     package: str | None = None,
+    branch: str | None = None,
 ) -> int:
     """Add a new session."""
     repo_root = get_repo_root()
@@ -348,7 +374,8 @@ def add_session(
     new_session = current_session + 1
 
     session_content = generate_session_content(
-        new_session, title, commit, summary, extra_content, today, package
+        new_session, title, commit, summary, extra_content, today, package,
+        branch,
     )
     content_lines = len(session_content.splitlines())
 
@@ -385,7 +412,16 @@ def add_session(
 
     # Update index.md
     active_file = f"{FILE_JOURNAL_PREFIX}{target_num}.md"
-    if not update_index(index_file, dev_dir, title, commit, new_session, active_file, today):
+    if not update_index(
+        index_file,
+        dev_dir,
+        title,
+        commit,
+        new_session,
+        active_file,
+        today,
+        branch,
+    ):
         return 1
 
     print("", file=sys.stderr)
@@ -419,6 +455,7 @@ def main() -> int:
     parser.add_argument("--summary", default="(Add summary)", help="Brief summary")
     parser.add_argument("--content-file", help="Path to file with detailed content")
     parser.add_argument("--package", help="Package name tag (e.g., cli, docs-site)")
+    parser.add_argument("--branch", help="Branch name (auto-detected if omitted)")
     parser.add_argument("--no-commit", action="store_true",
                         help="Skip auto-commit of workspace changes")
     parser.add_argument("--stdin", action="store_true",
@@ -434,8 +471,11 @@ def main() -> int:
     elif args.stdin:
         extra_content = sys.stdin.read()
 
-    # Resolve package: CLI → active task → default_package → None
+    # Load active task once — shared by package and branch resolution
     repo_root = get_repo_root()
+    current = get_current_task(repo_root)
+    task_data = load_task(repo_root / current) if current else None
+
     package = args.package
     if package:
         # CLI source: fail-fast in monorepo, ignore in single-repo
@@ -449,18 +489,26 @@ def main() -> int:
             return 1
     else:
         # Inferred: active task's task.json.package → default_package → None
-        task_package = None
-        current = get_current_task(repo_root)
-        if current:
-            ct = load_task(repo_root / current)
-            if ct and ct.package:
-                task_package = ct.package
+        task_package = task_data.package if task_data else None
         package = resolve_package(task_package, repo_root)
+
+    # Resolve branch: CLI → task.json → git auto-detect → None
+    branch = args.branch
+
+    if not branch:
+        if task_data and task_data.raw.get("branch"):
+            branch = task_data.raw["branch"]
+        else:
+            _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+            detected = branch_out.strip()
+            if detected:
+                branch = detected
 
     return add_session(
         args.title, args.commit, args.summary, extra_content,
         auto_commit=not args.no_commit,
         package=package,
+        branch=branch,
     )
 
 

--- a/.trellis/scripts/common/developer.py
+++ b/.trellis/scripts/common/developer.py
@@ -123,8 +123,8 @@ def init_developer(name: str, repo_root: Path | None = None) -> bool:
 ## Session History
 
 <!-- @@@auto:session-history -->
-| # | Date | Title | Commits |
-|---|------|-------|---------|
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
 <!-- @@@/auto:session-history -->
 
 ---

--- a/.trellis/workspace/index.md
+++ b/.trellis/workspace/index.md
@@ -73,6 +73,7 @@ This will:
 
 Each session should include:
 - Summary: One-line description
+- Branch: Which branch the work was done on
 - Main Changes: What was modified
 - Git Commits: Commit hashes and messages
 - Next Steps: What to do next
@@ -88,6 +89,7 @@ Use this template when recording sessions:
 
 **Date**: YYYY-MM-DD
 **Task**: {task-name}
+**Branch**: `{branch-name}`
 
 ### Summary
 

--- a/packages/cli/src/templates/claude/commands/trellis/record-session.md
+++ b/packages/cli/src/templates/claude/commands/trellis/record-session.md
@@ -46,6 +46,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -56,6 +57,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/codex/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/record-session/SKILL.md
@@ -51,6 +51,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -61,6 +62,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/cursor/commands/trellis-record-session.md
+++ b/packages/cli/src/templates/cursor/commands/trellis-record-session.md
@@ -46,6 +46,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -56,6 +57,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/gemini/commands/trellis/record-session.toml
+++ b/packages/cli/src/templates/gemini/commands/trellis/record-session.toml
@@ -49,6 +49,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -59,7 +60,7 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |
 """

--- a/packages/cli/src/templates/iflow/commands/trellis/record-session.md
+++ b/packages/cli/src/templates/iflow/commands/trellis/record-session.md
@@ -46,6 +46,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -56,6 +57,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/kilo/workflows/record-session.md
+++ b/packages/cli/src/templates/kilo/workflows/record-session.md
@@ -46,6 +46,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -56,6 +57,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/kiro/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/kiro/skills/record-session/SKILL.md
@@ -51,6 +51,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -61,6 +62,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/markdown/workspace-index.md
+++ b/packages/cli/src/templates/markdown/workspace-index.md
@@ -73,6 +73,7 @@ This will:
 
 Each session should include:
 - Summary: One-line description
+- Branch: Which branch the work was done on
 - Main Changes: What was modified
 - Git Commits: Commit hashes and messages
 - Next Steps: What to do next
@@ -88,6 +89,7 @@ Use this template when recording sessions:
 
 **Date**: YYYY-MM-DD
 **Task**: {task-name}
+**Branch**: `{branch-name}`
 
 ### Summary
 

--- a/packages/cli/src/templates/opencode/commands/trellis/record-session.md
+++ b/packages/cli/src/templates/opencode/commands/trellis/record-session.md
@@ -46,6 +46,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -56,6 +57,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/qoder/skills/record-session/SKILL.md
+++ b/packages/cli/src/templates/qoder/skills/record-session/SKILL.md
@@ -51,6 +51,7 @@ EOF
 **Auto-completes**:
 - [OK] Appends session to journal-N.md
 - [OK] Auto-detects line count, creates new file if >2000 lines
+- [OK] Auto-detects Branch context (`--branch` override; otherwise Branch = task.json -> current git branch; missing values are omitted gracefully)
 - [OK] Updates index.md (Total Sessions +1, Last Active, line stats, history)
 - [OK] Auto-commits .trellis/workspace and .trellis/tasks changes
 
@@ -61,6 +62,6 @@ EOF
 | Command | Purpose |
 |---------|---------|
 | `python3 ./.trellis/scripts/get_context.py --mode record` | Get context for record-session |
-| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended)** |
+| `python3 ./.trellis/scripts/add_session.py --title "..." --commit "..."` | **One-click add session (recommended, branch auto-complete)** |
 | `python3 ./.trellis/scripts/task.py archive <name>` | Archive completed task (auto-commits) |
 | `python3 ./.trellis/scripts/task.py list` | List active tasks |

--- a/packages/cli/src/templates/trellis/scripts/add_session.py
+++ b/packages/cli/src/templates/trellis/scripts/add_session.py
@@ -5,17 +5,23 @@ Add a new session to journal file and update index.md.
 
 Usage:
     python3 add_session.py --title "Title" --commit "hash" --summary "Summary" [--package cli]
+    python3 add_session.py --title "Title" --branch "feat/my-branch"
 
     # Pipe detailed content via stdin (use --stdin to opt in):
     cat << 'EOF' | python3 add_session.py --stdin --title "Title" --summary "Summary"
     <session content here>
     EOF
+
+Branch resolution order:
+    1. --branch CLI arg (explicit)
+    2. task.json branch field (from active task)
+    3. git branch --show-current (auto-detect)
+    4. None (omitted gracefully)
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import subprocess
 import sys
@@ -30,6 +36,7 @@ from common.paths import (
     get_workspace_dir,
 )
 from common.developer import ensure_developer
+from common.git import run_git
 from common.tasks import load_task
 from common.config import (
     get_packages,
@@ -139,6 +146,7 @@ def generate_session_content(
     extra_content: str,
     today: str,
     package: str | None = None,
+    branch: str | None = None,
 ) -> str:
     """Generate session content."""
     if commit and commit != "-":
@@ -151,13 +159,14 @@ def generate_session_content(
         commit_table = "(No commits - planning session)"
 
     package_line = f"\n**Package**: {package}" if package else ""
+    branch_line = f"\n**Branch**: `{branch}`" if branch else ""
 
     return f"""
 
 ## Session {session_num}: {title}
 
 **Date**: {today}
-**Task**: {title}{package_line}
+**Task**: {title}{package_line}{branch_line}
 
 ### Summary
 
@@ -192,7 +201,8 @@ def update_index(
     commit: str,
     new_session: int,
     active_file: str,
-    today: str
+    today: str,
+    branch: str | None = None,
 ) -> bool:
     """Update index.md with new session info."""
     # Format commit for display
@@ -271,10 +281,25 @@ def update_index(
             continue
 
         if in_session_history:
-            new_lines.append(line)
-            if re.match(r"^\|\s*-", line) and not header_written:
-                new_lines.append(f"| {new_session} | {today} | {title} | {commit_display} |")
+            # Migrate old 4/6-column headers to 5-column Branch-only history.
+            if re.match(
+                r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*Base Branch\s*\|\s*$",
+                line,
+            ):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*$", line):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*$", line):
+                new_lines.append("| # | Date | Title | Commits | Branch |")
+                continue
+            if re.match(r"^\|[-| ]+\|\s*$", line) and not header_written:
+                new_lines.append("|---|------|-------|---------|--------|")
+                new_lines.append(f"| {new_session} | {today} | {title} | {commit_display} | `{branch or '-'}` |")
                 header_written = True
+                continue
+            new_lines.append(line)
             continue
 
         new_lines.append(line)
@@ -323,6 +348,7 @@ def add_session(
     extra_content: str = "(Add details)",
     auto_commit: bool = True,
     package: str | None = None,
+    branch: str | None = None,
 ) -> int:
     """Add a new session."""
     repo_root = get_repo_root()
@@ -348,7 +374,8 @@ def add_session(
     new_session = current_session + 1
 
     session_content = generate_session_content(
-        new_session, title, commit, summary, extra_content, today, package
+        new_session, title, commit, summary, extra_content, today, package,
+        branch,
     )
     content_lines = len(session_content.splitlines())
 
@@ -385,7 +412,16 @@ def add_session(
 
     # Update index.md
     active_file = f"{FILE_JOURNAL_PREFIX}{target_num}.md"
-    if not update_index(index_file, dev_dir, title, commit, new_session, active_file, today):
+    if not update_index(
+        index_file,
+        dev_dir,
+        title,
+        commit,
+        new_session,
+        active_file,
+        today,
+        branch,
+    ):
         return 1
 
     print("", file=sys.stderr)
@@ -419,6 +455,7 @@ def main() -> int:
     parser.add_argument("--summary", default="(Add summary)", help="Brief summary")
     parser.add_argument("--content-file", help="Path to file with detailed content")
     parser.add_argument("--package", help="Package name tag (e.g., cli, docs-site)")
+    parser.add_argument("--branch", help="Branch name (auto-detected if omitted)")
     parser.add_argument("--no-commit", action="store_true",
                         help="Skip auto-commit of workspace changes")
     parser.add_argument("--stdin", action="store_true",
@@ -434,8 +471,11 @@ def main() -> int:
     elif args.stdin:
         extra_content = sys.stdin.read()
 
-    # Resolve package: CLI → active task → default_package → None
+    # Load active task once — shared by package and branch resolution
     repo_root = get_repo_root()
+    current = get_current_task(repo_root)
+    task_data = load_task(repo_root / current) if current else None
+
     package = args.package
     if package:
         # CLI source: fail-fast in monorepo, ignore in single-repo
@@ -449,18 +489,26 @@ def main() -> int:
             return 1
     else:
         # Inferred: active task's task.json.package → default_package → None
-        task_package = None
-        current = get_current_task(repo_root)
-        if current:
-            ct = load_task(repo_root / current)
-            if ct and ct.package:
-                task_package = ct.package
+        task_package = task_data.package if task_data else None
         package = resolve_package(task_package, repo_root)
+
+    # Resolve branch: CLI → task.json → git auto-detect → None
+    branch = args.branch
+
+    if not branch:
+        if task_data and task_data.raw.get("branch"):
+            branch = task_data.raw["branch"]
+        else:
+            _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+            detected = branch_out.strip()
+            if detected:
+                branch = detected
 
     return add_session(
         args.title, args.commit, args.summary, extra_content,
         auto_commit=not args.no_commit,
         package=package,
+        branch=branch,
     )
 
 

--- a/packages/cli/src/templates/trellis/scripts/common/developer.py
+++ b/packages/cli/src/templates/trellis/scripts/common/developer.py
@@ -123,8 +123,8 @@ def init_developer(name: str, repo_root: Path | None = None) -> bool:
 ## Session History
 
 <!-- @@@auto:session-history -->
-| # | Date | Title | Commits |
-|---|------|-------|---------|
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
 <!-- @@@/auto:session-history -->
 
 ---

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -49,13 +49,14 @@ import {
   commonCliAdapter,
   commonWorktree,
   commonTaskUtils,
+  commonDeveloper,
   getAllScripts,
 } from "../src/templates/trellis/index.js";
 import {
   collectPlatformTemplates,
   PLATFORM_IDS,
 } from "../src/configurators/index.js";
-import { guidesIndexContent } from "../src/templates/markdown/index.js";
+import { guidesIndexContent, workspaceIndexContent } from "../src/templates/markdown/index.js";
 import * as markdownExports from "../src/templates/markdown/index.js";
 
 afterEach(() => {
@@ -115,11 +116,328 @@ describe("regression: Windows encoding (beta.10, beta.11, beta.16)", () => {
     expect(taskScript).toContain("from common");
   });
 
-  it("[rc.2] add_session.py table separator matching tolerates formatted markdown", () => {
+  it("[rc.2] add_session.py table separator detection uses regex (not startswith)", () => {
     // Bug: startswith("|---") breaks when formatters add spaces: "| ---- |"
-    // Fix: use re.match(r"^\\|\\s*-", line) to allow optional whitespace
+    // Fix: use re.match with a character-class pattern to allow optional whitespace/spaces
     expect(addSessionScript).not.toContain('startswith("|---")');
-    expect(addSessionScript).toContain(String.raw`re.match(r"^\|\s*-", line)`);
+    expect(addSessionScript).toContain(String.raw`re.match(r"^\|[-| ]+\|\s*$", line)`);
+  });
+});
+
+describe("regression: branch context in session records (issue-106)", () => {
+  it("[issue-106] add_session.py accepts --branch CLI arg", () => {
+    expect(addSessionScript).toContain("--branch");
+    expect(addSessionScript).not.toContain("--base-branch");
+  });
+
+  it("[issue-106] add_session.py auto-detects branch via git branch --show-current", () => {
+    expect(addSessionScript).toContain("branch --show-current");
+  });
+
+  it("[issue-106] add_session.py reads branch from task.json when available", () => {
+    expect(addSessionScript).toContain('task_data.raw.get("branch")');
+    expect(addSessionScript).not.toContain('task_data.raw.get("base_branch")');
+  });
+
+  it("[issue-106] add_session.py session content includes **Branch** field only", () => {
+    expect(addSessionScript).toContain("**Branch**");
+    expect(addSessionScript).not.toContain("**Base Branch**");
+  });
+
+  it("[issue-106] add_session.py index table header has 5 columns including Branch", () => {
+    expect(addSessionScript).toContain(
+      "| # | Date | Title | Commits | Branch |",
+    );
+    expect(addSessionScript).not.toContain(
+      "| # | Date | Title | Commits | Branch | Base Branch |",
+    );
+  });
+
+  it("[issue-106] add_session.py migrates old 4/6-column headers to 5-column", () => {
+    expect(addSessionScript).toContain(
+      String.raw`re.match(
+                r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*Base Branch\s*\|\s*$",`,
+    );
+    expect(addSessionScript).toContain(
+      String.raw`re.match(r"^\|\s*#\s*\|\s*Date\s*\|\s*Title\s*\|\s*Commits\s*\|\s*Branch\s*\|\s*$", line)`,
+    );
+  });
+
+  it("[issue-106] developer.py init template has 5-column session history table", () => {
+    expect(commonDeveloper).toContain(
+      "| # | Date | Title | Commits | Branch |",
+    );
+    expect(commonDeveloper).toContain(
+      "|---|------|-------|---------|--------|",
+    );
+  });
+
+  it("[issue-106] workspace-index.md template documents Branch field only for session records", () => {
+    expect(workspaceIndexContent).toContain("Branch: Which branch the work was done on");
+    expect(workspaceIndexContent).toContain("**Branch**: `{branch-name}`");
+    expect(workspaceIndexContent).not.toContain("**Base Branch**: `{base-branch-name}`");
+  });
+});
+
+describe("regression: add_session.py runtime branch context (issue-106)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTrellisScripts(): void {
+    const scriptsDir = path.join(tmpDir, ".trellis", "scripts");
+    for (const [relativePath, content] of getAllScripts()) {
+      const absPath = path.join(scriptsDir, relativePath);
+      fs.mkdirSync(path.dirname(absPath), { recursive: true });
+      fs.writeFileSync(absPath, content);
+    }
+  }
+
+  function createWorkspaceIndex(
+    headerMode: "legacy4" | "legacy6" | "current5",
+  ): void {
+    let header = "| # | Date | Title | Commits | Branch |";
+    let separator = "|---|------|-------|---------|--------|";
+    if (headerMode === "legacy4") {
+      header = "| # | Date | Title | Commits |";
+      separator = "|---|------|-------|---------|";
+    } else if (headerMode === "legacy6") {
+      header = "| # | Date | Title | Commits | Branch | Base Branch |";
+      separator = "|---|------|-------|---------|--------|-------------|";
+    }
+    const indexContent = `# Workspace Index - test-dev
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: \`journal-1.md\`
+- **Total Sessions**: 0
+- **Last Active**: -
+<!-- @@@/auto:current-status -->
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| \`journal-1.md\` | ~0 | Active |
+<!-- @@@/auto:active-documents -->
+
+## Session History
+
+<!-- @@@auto:session-history -->
+${header}
+${separator}
+<!-- @@@/auto:session-history -->
+`;
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      indexContent,
+      "utf-8",
+    );
+  }
+
+  function setupSessionRepo(options?: {
+    gitBranch?: string;
+    headerMode?: "legacy4" | "legacy6" | "current5";
+    taskBranch?: string;
+    taskBaseBranch?: string;
+  }): void {
+    writeTrellisScripts();
+
+    fs.mkdirSync(path.join(tmpDir, ".trellis", "workspace", "test-dev"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", ".developer"),
+      "name=test-dev\ninitialized_at=2026-03-22T00:00:00\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "# Journal - test-dev (Part 1)\n\n---\n",
+      "utf-8",
+    );
+    createWorkspaceIndex(options?.headerMode ?? "current5");
+
+    if (options?.taskBranch || options?.taskBaseBranch) {
+      const taskDir = path.join(tmpDir, ".trellis", "tasks", "issue-106");
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, ".trellis", ".current-task"),
+        ".trellis/tasks/issue-106\n",
+        "utf-8",
+      );
+      fs.writeFileSync(
+        path.join(taskDir, "task.json"),
+        JSON.stringify(
+          {
+            title: "Issue 106 task",
+            status: "in_progress",
+            package: null,
+            branch: options.taskBranch ?? null,
+            base_branch: options.taskBaseBranch ?? null,
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+    }
+
+    if (options?.gitBranch) {
+      execSync("git init -q", { cwd: tmpDir });
+      execSync(`git branch -m ${JSON.stringify(options.gitBranch)}`, {
+        cwd: tmpDir,
+      });
+    }
+  }
+
+  function runAddSession(
+    title: string,
+    options?: { branch?: string },
+  ): void {
+    const command = [
+      "python3",
+      JSON.stringify(path.join(tmpDir, ".trellis", "scripts", "add_session.py")),
+      "--title",
+      JSON.stringify(title),
+      "--summary",
+      JSON.stringify("Regression test session"),
+      "--no-commit",
+    ];
+    if (options?.branch) {
+      command.push("--branch", JSON.stringify(options.branch));
+    }
+
+    execSync(command.join(" "), {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+  }
+
+  it("[issue-106] prefers explicit CLI branch over task.json and git", () => {
+    setupSessionRepo({
+      gitBranch: "feature/from-git",
+      taskBranch: "task/from-task",
+      taskBaseBranch: "main",
+    });
+
+    runAddSession("CLI branch wins", { branch: "cli/from-arg" });
+
+    const journal = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "utf-8",
+    );
+    const index = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      "utf-8",
+    );
+
+    expect(journal).toContain("**Branch**: `cli/from-arg`");
+    expect(journal).not.toContain("**Base Branch**:");
+    expect(journal).not.toContain("task/from-task");
+    expect(journal).not.toContain("feature/from-git");
+    expect(index).toContain("`cli/from-arg` |");
+    expect(index).not.toContain("`task/from-task`");
+    expect(index).not.toContain("`feature/from-git`");
+  });
+
+  it("[issue-106] prefers task.json branch over current git branch and ignores task base_branch", () => {
+    setupSessionRepo({
+      gitBranch: "feature/from-git",
+      taskBranch: "task/from-task",
+      taskBaseBranch: "main",
+    });
+
+    runAddSession("Task branch wins");
+
+    const journal = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "utf-8",
+    );
+    const index = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      "utf-8",
+    );
+
+    expect(journal).toContain("**Branch**: `task/from-task`");
+    expect(journal).not.toContain("**Base Branch**:");
+    expect(journal).not.toContain("feature/from-git");
+    expect(index).toContain("`task/from-task` |");
+    expect(index).not.toContain("`feature/from-git`");
+  });
+
+  it("[issue-106] falls back to git branch and migrates old 6-column session history", () => {
+    setupSessionRepo({
+      gitBranch: "feature/from-git",
+      headerMode: "legacy6",
+    });
+
+    runAddSession("Git branch fallback");
+
+    const journal = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "utf-8",
+    );
+    const index = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      "utf-8",
+    );
+
+    expect(journal).toContain("**Branch**: `feature/from-git`");
+    expect(journal).not.toContain("**Base Branch**:");
+    expect(index).toContain("| # | Date | Title | Commits | Branch |");
+    expect(index).toContain("|---|------|-------|---------|--------|");
+    expect(index).toContain("`feature/from-git` |");
+    expect(index).not.toContain(
+      "| # | Date | Title | Commits | Branch | Base Branch |\n|---|------|-------|---------|--------|-------------|",
+    );
+  });
+
+  it("[issue-106] migrates old 4-column session history directly to 5 columns", () => {
+    setupSessionRepo({
+      headerMode: "legacy4",
+    });
+
+    runAddSession("Legacy 4-column migration");
+
+    const index = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      "utf-8",
+    );
+
+    expect(index).toContain("| # | Date | Title | Commits | Branch |");
+    expect(index).toContain("|---|------|-------|---------|--------|");
+    expect(index).not.toContain(
+      "| # | Date | Title | Commits |\n|---|------|-------|---------|",
+    );
+  });
+
+  it("[issue-106] records a session even when no branch information is available", () => {
+    setupSessionRepo();
+
+    runAddSession("No branch available");
+
+    const journal = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "utf-8",
+    );
+    const index = fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "index.md"),
+      "utf-8",
+    );
+
+    expect(journal).not.toContain("**Branch**:");
+    expect(journal).not.toContain("**Base Branch**:");
+    expect(index).toContain("`-` |");
+    expect(index).toContain("- **Total Sessions**: 1");
   });
 });
 


### PR DESCRIPTION
 ## Summary
  - 为 `.trellis` 的 session / journal 记录补充当前工作分支信息，避免会话记录里混入或误用 `base_branch`。
  - 解决 session 历史中 `Branch` / `Base Branch` 语义混乱的问题，让开发记录更准确，也方便后续排查和回溯。

  ## Changes
  - 在 `add_session.py` 中新增 `--branch` 支持，并实现分支解析优先级：CLI 显式传入 > 当前任务 `task.json.branch` > `git branch --show-current` > 无法
  获取时省略。
  - 调整 session 内容和 workspace index，只保留 `Branch` 字段；同时兼容并迁移旧的 4 列 / 6 列历史表头到新的 5 列格式。
  - 同步更新 developer/workspace 模板和各平台 `record-session` 模板文案，并补充 `issue-106` 回归测试，覆盖 CLI 显式传参、task branch、git fallback、
  旧表头迁移和无分支场景。

  ## Validation
  - [x] 本地自测通过
  - [x] 关键场景已验证
  - [x] 无明显回归

  验证说明：
  - 已执行 `pnpm --filter @mindfoldhq/trellis test -- --runInBand -t issue-106`
  - 实际通过：`25` 个测试文件，`492` 个测试用例全部通过

  ## Related Issue
  Closes #106

  ## Screenshots
  ### Before
  - N/A，本次改动仅涉及 CLI / session 记录逻辑，无 UI 变更

  ### After
  - N/A，本次改动仅涉及 CLI / session 记录逻辑，无 UI 变更

  ### Notes
  - 本次改动会自动兼容旧的 session history 表头格式，并在写入新记录时迁移为统一的 `Branch` 结构。
  - 如果后续有依赖旧 `Base Branch` 文案的外部脚本，可能需要一并调整。