### PR TITLE
fix: normalize .current-task refs before task resolution

### DIFF
--- a/.claude/hooks/inject-subagent-context.py
+++ b/.claude/hooks/inject-subagent-context.py
@@ -99,7 +99,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/.claude/hooks/ralph-loop.py
+++ b/.claude/hooks/ralph-loop.py
@@ -72,7 +72,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -65,23 +65,47 @@ def run_script(script_path: Path) -> str:
         return "No context available"
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _get_task_status(trellis_dir: Path) -> str:
     """Check current task status and return structured status string."""
     current_task_file = trellis_dir / ".current-task"
     if not current_task_file.is_file():
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    task_ref = current_task_file.read_text(encoding="utf-8").strip()
+    task_ref = _normalize_task_ref(current_task_file.read_text(encoding="utf-8").strip())
     if not task_ref:
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
     # Resolve task directory
-    if Path(task_ref).is_absolute():
-        task_dir = Path(task_ref)
-    elif task_ref.startswith(".trellis/"):
-        task_dir = trellis_dir.parent / task_ref
-    else:
-        task_dir = trellis_dir / "tasks" / task_ref
+    task_dir = _resolve_task_dir(trellis_dir, task_ref)
     if not task_dir.is_dir():
         return f"Status: STALE POINTER\nTask: {task_ref}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish"
 

--- a/.claude/hooks/statusline.py
+++ b/.claude/hooks/statusline.py
@@ -35,6 +35,35 @@ def _read_json(path: Path) -> dict:
         return {}
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _find_trellis_dir() -> Path | None:
     """Walk up from cwd to find .trellis/ directory."""
     current = Path.cwd()
@@ -47,12 +76,12 @@ def _find_trellis_dir() -> Path | None:
 
 def _get_current_task(trellis_dir: Path) -> dict | None:
     """Load current task info. Returns dict with title/status/priority or None."""
-    task_ref = _read_text(trellis_dir / ".current-task")
+    task_ref = _normalize_task_ref(_read_text(trellis_dir / ".current-task"))
     if not task_ref:
         return None
 
     # Resolve task directory
-    task_path = Path(task_ref) if Path(task_ref).is_absolute() else trellis_dir.parent / task_ref
+    task_path = _resolve_task_dir(trellis_dir, task_ref)
     task_data = _read_json(task_path / "task.json")
     if not task_data:
         return None

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -51,21 +51,45 @@ def run_script(script_path: Path) -> str:
         return "No context available"
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _get_task_status(trellis_dir: Path) -> str:
     current_task_file = trellis_dir / ".current-task"
     if not current_task_file.is_file():
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    task_ref = current_task_file.read_text(encoding="utf-8").strip()
+    task_ref = _normalize_task_ref(current_task_file.read_text(encoding="utf-8").strip())
     if not task_ref:
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    if Path(task_ref).is_absolute():
-        task_dir = Path(task_ref)
-    elif task_ref.startswith(".trellis/"):
-        task_dir = trellis_dir.parent / task_ref
-    else:
-        task_dir = trellis_dir / "tasks" / task_ref
+    task_dir = _resolve_task_dir(trellis_dir, task_ref)
     if not task_dir.is_dir():
         return f"Status: STALE POINTER\nTask: {task_ref}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish"
 

--- a/.opencode/lib/trellis-context.js
+++ b/.opencode/lib/trellis-context.js
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
-import { join } from "path"
+import { isAbsolute, join } from "path"
 import { homedir, platform } from "os"
 import { execSync } from "child_process"
 
@@ -191,10 +191,50 @@ export class TrellisContext {
       if (!existsSync(currentTaskPath)) {
         return null
       }
-      return readFileSync(currentTaskPath, "utf-8").trim()
+      const taskRef = readFileSync(currentTaskPath, "utf-8").trim()
+      const normalized = this.normalizeTaskRef(taskRef)
+      return normalized || null
     } catch {
       return null
     }
+  }
+
+  normalizeTaskRef(taskRef) {
+    if (!taskRef) {
+      return ""
+    }
+
+    if (isAbsolute(taskRef)) {
+      return taskRef.trim()
+    }
+
+    let normalized = taskRef.trim().replace(/\\/g, "/")
+    while (normalized.startsWith("./")) {
+      normalized = normalized.slice(2)
+    }
+
+    if (normalized.startsWith("tasks/")) {
+      return `.trellis/${normalized}`
+    }
+
+    return normalized
+  }
+
+  resolveTaskDir(taskRef) {
+    const normalized = this.normalizeTaskRef(taskRef)
+    if (!normalized) {
+      return null
+    }
+
+    if (isAbsolute(normalized)) {
+      return normalized
+    }
+
+    if (normalized.startsWith(".trellis/")) {
+      return join(this.directory, normalized)
+    }
+
+    return join(this.directory, ".trellis", "tasks", normalized)
   }
 
   // ============================================================

--- a/.trellis/scripts/common/__init__.py
+++ b/.trellis/scripts/common/__init__.py
@@ -75,6 +75,8 @@ from .paths import (
     count_lines,
     get_current_task,
     get_current_task_abs,
+    normalize_task_ref,
+    resolve_task_ref,
     set_current_task,
     clear_current_task,
     has_current_task,

--- a/.trellis/scripts/common/paths.py
+++ b/.trellis/scripts/common/paths.py
@@ -221,6 +221,50 @@ def _get_current_task_file(repo_root: Path | None = None) -> Path:
     return repo_root / DIR_WORKFLOW / FILE_CURRENT_TASK
 
 
+def normalize_task_ref(task_ref: str) -> str:
+    """Normalize a task ref for stable storage in .current-task.
+
+    Stored refs should prefer repo-relative POSIX paths like
+    `.trellis/tasks/03-27-my-task`, even on Windows. Absolute paths are preserved
+    unless they can later be converted back to repo-relative form by callers.
+    """
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith(f"{DIR_TASKS}/"):
+        return f"{DIR_WORKFLOW}/{normalized}"
+
+    return normalized
+
+
+def resolve_task_ref(task_ref: str, repo_root: Path | None = None) -> Path | None:
+    """Resolve a task ref from .current-task to an absolute task directory path."""
+    if repo_root is None:
+        repo_root = get_repo_root()
+
+    normalized = normalize_task_ref(task_ref)
+    if not normalized:
+        return None
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+
+    if normalized.startswith(f"{DIR_WORKFLOW}/"):
+        return repo_root / path_obj
+
+    return repo_root / DIR_WORKFLOW / DIR_TASKS / path_obj
+
+
 def get_current_task(repo_root: Path | None = None) -> str | None:
     """Get current task directory path (relative to repo_root).
 
@@ -236,7 +280,8 @@ def get_current_task(repo_root: Path | None = None) -> str | None:
         return None
 
     try:
-        return current_file.read_text(encoding="utf-8").strip()
+        content = current_file.read_text(encoding="utf-8").strip()
+        return normalize_task_ref(content) if content else None
     except (OSError, IOError):
         return None
 
@@ -255,7 +300,7 @@ def get_current_task_abs(repo_root: Path | None = None) -> Path | None:
 
     relative = get_current_task(repo_root)
     if relative:
-        return repo_root / relative
+        return resolve_task_ref(relative, repo_root)
     return None
 
 
@@ -272,18 +317,24 @@ def set_current_task(task_path: str, repo_root: Path | None = None) -> bool:
     if repo_root is None:
         repo_root = get_repo_root()
 
-    if not task_path:
+    normalized = normalize_task_ref(task_path)
+    if not normalized:
         return False
 
     # Verify task directory exists
-    full_path = repo_root / task_path
-    if not full_path.is_dir():
+    full_path = resolve_task_ref(normalized, repo_root)
+    if full_path is None or not full_path.is_dir():
         return False
+
+    try:
+        normalized = full_path.relative_to(repo_root).as_posix()
+    except ValueError:
+        normalized = str(full_path)
 
     current_file = _get_current_task_file(repo_root)
 
     try:
-        current_file.write_text(task_path, encoding="utf-8")
+        current_file.write_text(normalized, encoding="utf-8")
         return True
     except (OSError, IOError):
         return False

--- a/.trellis/scripts/common/task_utils.py
+++ b/.trellis/scripts/common/task_utils.py
@@ -37,23 +37,25 @@ def is_safe_task_path(task_path: str, repo_root: Path | None = None) -> bool:
     if repo_root is None:
         repo_root = get_repo_root()
 
+    normalized = task_path.replace("\\", "/")
+
     # Check empty or null
-    if not task_path or task_path == "null":
+    if not normalized or normalized == "null":
         print("Error: empty or null task path", file=sys.stderr)
         return False
 
     # Reject absolute paths
-    if task_path.startswith("/"):
+    if Path(task_path).is_absolute():
         print(f"Error: absolute path not allowed: {task_path}", file=sys.stderr)
         return False
 
     # Reject ".", "..", paths starting with "./" or "../", or containing ".."
-    if task_path in (".", "..") or task_path.startswith("./") or task_path.startswith("../") or ".." in task_path:
+    if normalized in (".", "..") or normalized.startswith("./") or normalized.startswith("../") or ".." in normalized:
         print(f"Error: path traversal not allowed: {task_path}", file=sys.stderr)
         return False
 
     # Final check: ensure resolved path is not the repo root
-    abs_path = repo_root / task_path
+    abs_path = repo_root / Path(normalized)
     if abs_path.exists():
         try:
             resolved = abs_path.resolve()
@@ -187,13 +189,17 @@ def resolve_task_dir(target_dir: str, repo_root: Path) -> Path:
     if not target_dir:
         return Path()
 
+    normalized = target_dir.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
     # Absolute path
-    if target_dir.startswith("/"):
+    if Path(target_dir).is_absolute():
         return Path(target_dir)
 
     # Relative path (contains path separator or starts with .trellis)
-    if "/" in target_dir or target_dir.startswith(".trellis"):
-        return repo_root / target_dir
+    if "/" in normalized or normalized.startswith(".trellis"):
+        return repo_root / Path(normalized)
 
     # Task name - try to find in tasks directory
     tasks_dir = get_tasks_dir(repo_root)
@@ -202,7 +208,7 @@ def resolve_task_dir(target_dir: str, repo_root: Path) -> Path:
         return found
 
     # Fallback to treating as relative path
-    return repo_root / target_dir
+    return repo_root / Path(normalized)
 
 
 # =============================================================================

--- a/.trellis/scripts/multi_agent/start.py
+++ b/.trellis/scripts/multi_agent/start.py
@@ -202,12 +202,16 @@ def main() -> int:
     project_root = get_repo_root()
 
     # Normalize paths
-    if task_dir_arg.startswith("/"):
-        task_dir_relative = task_dir_arg[len(str(project_root)) + 1 :]
-        task_dir_abs = Path(task_dir_arg)
+    task_dir_path = Path(task_dir_arg)
+    if task_dir_path.is_absolute():
+        task_dir_abs = task_dir_path
     else:
-        task_dir_relative = task_dir_arg
-        task_dir_abs = project_root / task_dir_arg
+        task_dir_abs = project_root / task_dir_path
+
+    try:
+        task_dir_relative = task_dir_abs.relative_to(project_root).as_posix()
+    except ValueError:
+        task_dir_relative = str(task_dir_abs)
 
     task_json_path = task_dir_abs / FILE_TASK_JSON
 

--- a/.trellis/scripts/task.py
+++ b/.trellis/scripts/task.py
@@ -84,7 +84,7 @@ def cmd_start(args: argparse.Namespace) -> int:
 
     # Convert to relative path for storage
     try:
-        task_dir = str(full_path.relative_to(repo_root))
+        task_dir = full_path.relative_to(repo_root).as_posix()
     except ValueError:
         task_dir = str(full_path)
 

--- a/packages/cli/src/templates/claude/hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/claude/hooks/inject-subagent-context.py
@@ -99,7 +99,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/packages/cli/src/templates/claude/hooks/ralph-loop.py
+++ b/packages/cli/src/templates/claude/hooks/ralph-loop.py
@@ -72,7 +72,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/packages/cli/src/templates/claude/hooks/session-start.py
+++ b/packages/cli/src/templates/claude/hooks/session-start.py
@@ -65,23 +65,47 @@ def run_script(script_path: Path) -> str:
         return "No context available"
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _get_task_status(trellis_dir: Path) -> str:
     """Check current task status and return structured status string."""
     current_task_file = trellis_dir / ".current-task"
     if not current_task_file.is_file():
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    task_ref = current_task_file.read_text(encoding="utf-8").strip()
+    task_ref = _normalize_task_ref(current_task_file.read_text(encoding="utf-8").strip())
     if not task_ref:
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
     # Resolve task directory
-    if Path(task_ref).is_absolute():
-        task_dir = Path(task_ref)
-    elif task_ref.startswith(".trellis/"):
-        task_dir = trellis_dir.parent / task_ref
-    else:
-        task_dir = trellis_dir / "tasks" / task_ref
+    task_dir = _resolve_task_dir(trellis_dir, task_ref)
     if not task_dir.is_dir():
         return f"Status: STALE POINTER\nTask: {task_ref}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish"
 

--- a/packages/cli/src/templates/claude/hooks/statusline.py
+++ b/packages/cli/src/templates/claude/hooks/statusline.py
@@ -35,6 +35,35 @@ def _read_json(path: Path) -> dict:
         return {}
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _find_trellis_dir() -> Path | None:
     """Walk up from cwd to find .trellis/ directory."""
     current = Path.cwd()
@@ -47,12 +76,12 @@ def _find_trellis_dir() -> Path | None:
 
 def _get_current_task(trellis_dir: Path) -> dict | None:
     """Load current task info. Returns dict with title/status/priority or None."""
-    task_ref = _read_text(trellis_dir / ".current-task")
+    task_ref = _normalize_task_ref(_read_text(trellis_dir / ".current-task"))
     if not task_ref:
         return None
 
     # Resolve task directory
-    task_path = Path(task_ref) if Path(task_ref).is_absolute() else trellis_dir.parent / task_ref
+    task_path = _resolve_task_dir(trellis_dir, task_ref)
     task_data = _read_json(task_path / "task.json")
     if not task_data:
         return None

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -51,21 +51,45 @@ def run_script(script_path: Path) -> str:
         return "No context available"
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _get_task_status(trellis_dir: Path) -> str:
     current_task_file = trellis_dir / ".current-task"
     if not current_task_file.is_file():
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    task_ref = current_task_file.read_text(encoding="utf-8").strip()
+    task_ref = _normalize_task_ref(current_task_file.read_text(encoding="utf-8").strip())
     if not task_ref:
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    if Path(task_ref).is_absolute():
-        task_dir = Path(task_ref)
-    elif task_ref.startswith(".trellis/"):
-        task_dir = trellis_dir.parent / task_ref
-    else:
-        task_dir = trellis_dir / "tasks" / task_ref
+    task_dir = _resolve_task_dir(trellis_dir, task_ref)
     if not task_dir.is_dir():
         return f"Status: STALE POINTER\nTask: {task_ref}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish"
 

--- a/packages/cli/src/templates/iflow/hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/iflow/hooks/inject-subagent-context.py
@@ -99,7 +99,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/packages/cli/src/templates/iflow/hooks/ralph-loop.py
+++ b/packages/cli/src/templates/iflow/hooks/ralph-loop.py
@@ -72,7 +72,14 @@ def get_current_task(repo_root: str) -> str | None:
     try:
         with open(current_task_file, "r", encoding="utf-8") as f:
             content = f.read().strip()
-            return content if content else None
+            if not content:
+                return None
+            normalized = content.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized.startswith("tasks/"):
+                normalized = f".trellis/{normalized}"
+            return normalized
     except Exception:
         return None
 

--- a/packages/cli/src/templates/iflow/hooks/session-start.py
+++ b/packages/cli/src/templates/iflow/hooks/session-start.py
@@ -66,23 +66,47 @@ def run_script(script_path: Path) -> str:
         return "No context available"
 
 
+def _normalize_task_ref(task_ref: str) -> str:
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith("tasks/"):
+        return f".trellis/{normalized}"
+
+    return normalized
+
+
+def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
+    normalized = _normalize_task_ref(task_ref)
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+    if normalized.startswith(".trellis/"):
+        return trellis_dir.parent / path_obj
+    return trellis_dir / "tasks" / path_obj
+
+
 def _get_task_status(trellis_dir: Path) -> str:
     """Check current task status and return structured status string."""
     current_task_file = trellis_dir / ".current-task"
     if not current_task_file.is_file():
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
-    task_ref = current_task_file.read_text(encoding="utf-8").strip()
+    task_ref = _normalize_task_ref(current_task_file.read_text(encoding="utf-8").strip())
     if not task_ref:
         return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
 
     # Resolve task directory
-    if Path(task_ref).is_absolute():
-        task_dir = Path(task_ref)
-    elif task_ref.startswith(".trellis/"):
-        task_dir = trellis_dir.parent / task_ref
-    else:
-        task_dir = trellis_dir / "tasks" / task_ref
+    task_dir = _resolve_task_dir(trellis_dir, task_ref)
     if not task_dir.is_dir():
         return f"Status: STALE POINTER\nTask: {task_ref}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish"
 

--- a/packages/cli/src/templates/opencode/lib/trellis-context.js
+++ b/packages/cli/src/templates/opencode/lib/trellis-context.js
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
-import { join } from "path"
+import { isAbsolute, join } from "path"
 import { homedir, platform } from "os"
 import { execSync } from "child_process"
 
@@ -191,10 +191,50 @@ export class TrellisContext {
       if (!existsSync(currentTaskPath)) {
         return null
       }
-      return readFileSync(currentTaskPath, "utf-8").trim()
+      const taskRef = readFileSync(currentTaskPath, "utf-8").trim()
+      const normalized = this.normalizeTaskRef(taskRef)
+      return normalized || null
     } catch {
       return null
     }
+  }
+
+  normalizeTaskRef(taskRef) {
+    if (!taskRef) {
+      return ""
+    }
+
+    if (isAbsolute(taskRef)) {
+      return taskRef.trim()
+    }
+
+    let normalized = taskRef.trim().replace(/\\/g, "/")
+    while (normalized.startsWith("./")) {
+      normalized = normalized.slice(2)
+    }
+
+    if (normalized.startsWith("tasks/")) {
+      return `.trellis/${normalized}`
+    }
+
+    return normalized
+  }
+
+  resolveTaskDir(taskRef) {
+    const normalized = this.normalizeTaskRef(taskRef)
+    if (!normalized) {
+      return null
+    }
+
+    if (isAbsolute(normalized)) {
+      return normalized
+    }
+
+    if (normalized.startsWith(".trellis/")) {
+      return join(this.directory, normalized)
+    }
+
+    return join(this.directory, ".trellis", "tasks", normalized)
   }
 
   // ============================================================

--- a/packages/cli/src/templates/opencode/plugins/session-start.js
+++ b/packages/cli/src/templates/opencode/plugins/session-start.js
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "fs"
-import { join } from "path"
+import { basename, join } from "path"
 import { execFileSync } from "child_process"
 import { platform } from "os"
 import { TrellisContext, contextCollector, debugLog } from "../lib/trellis-context.js"
@@ -23,36 +23,16 @@ const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
  * Check current task status and return structured status string.
  * JavaScript equivalent of _get_task_status in Claude's session-start.py.
  */
-function getTaskStatus(directory) {
-  const trellisDir = join(directory, ".trellis")
-  const currentTaskFile = join(trellisDir, ".current-task")
-
-  if (!existsSync(currentTaskFile)) {
-    return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
-  }
-
-  let taskRef
-  try {
-    taskRef = readFileSync(currentTaskFile, "utf-8").trim()
-  } catch {
-    return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
-  }
-
+function getTaskStatus(ctx) {
+  const taskRef = ctx.getCurrentTask()
   if (!taskRef) {
     return "Status: NO ACTIVE TASK\nNext: Describe what you want to work on"
   }
 
   // Resolve task directory
-  let taskDir
-  if (taskRef.startsWith("/")) {
-    taskDir = taskRef
-  } else if (taskRef.startsWith(".trellis/")) {
-    taskDir = join(directory, taskRef)
-  } else {
-    taskDir = join(trellisDir, "tasks", taskRef)
-  }
+  const taskDir = ctx.resolveTaskDir(taskRef)
 
-  if (!existsSync(taskDir)) {
+  if (!taskDir || !existsSync(taskDir)) {
     return `Status: STALE POINTER\nTask: ${taskRef}\nNext: Task directory not found. Run: python3 ./.trellis/scripts/task.py finish`
   }
 
@@ -71,7 +51,7 @@ function getTaskStatus(directory) {
   const taskStatus = taskData.status || "unknown"
 
   if (taskStatus === "completed") {
-    const dirName = taskDir.split("/").pop()
+    const dirName = basename(taskDir)
     return `Status: COMPLETED\nTask: ${taskTitle}\nNext: Archive with \`python3 ./.trellis/scripts/task.py archive ${dirName}\` or start a new task`
   }
 
@@ -354,7 +334,7 @@ Read and follow all instructions below carefully.
   }
 
   // 6. Task status (R2: check task state for session resume)
-  const taskStatus = getTaskStatus(directory)
+  const taskStatus = getTaskStatus(ctx)
   parts.push(`<task-status>\n${taskStatus}\n</task-status>`)
 
   // 7. Final directive (R3: active, not passive)

--- a/packages/cli/src/templates/trellis/scripts/common/__init__.py
+++ b/packages/cli/src/templates/trellis/scripts/common/__init__.py
@@ -75,6 +75,8 @@ from .paths import (
     count_lines,
     get_current_task,
     get_current_task_abs,
+    normalize_task_ref,
+    resolve_task_ref,
     set_current_task,
     clear_current_task,
     has_current_task,

--- a/packages/cli/src/templates/trellis/scripts/common/paths.py
+++ b/packages/cli/src/templates/trellis/scripts/common/paths.py
@@ -221,6 +221,50 @@ def _get_current_task_file(repo_root: Path | None = None) -> Path:
     return repo_root / DIR_WORKFLOW / FILE_CURRENT_TASK
 
 
+def normalize_task_ref(task_ref: str) -> str:
+    """Normalize a task ref for stable storage in .current-task.
+
+    Stored refs should prefer repo-relative POSIX paths like
+    `.trellis/tasks/03-27-my-task`, even on Windows. Absolute paths are preserved
+    unless they can later be converted back to repo-relative form by callers.
+    """
+    normalized = task_ref.strip()
+    if not normalized:
+        return ""
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    normalized = normalized.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
+    if normalized.startswith(f"{DIR_TASKS}/"):
+        return f"{DIR_WORKFLOW}/{normalized}"
+
+    return normalized
+
+
+def resolve_task_ref(task_ref: str, repo_root: Path | None = None) -> Path | None:
+    """Resolve a task ref from .current-task to an absolute task directory path."""
+    if repo_root is None:
+        repo_root = get_repo_root()
+
+    normalized = normalize_task_ref(task_ref)
+    if not normalized:
+        return None
+
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        return path_obj
+
+    if normalized.startswith(f"{DIR_WORKFLOW}/"):
+        return repo_root / path_obj
+
+    return repo_root / DIR_WORKFLOW / DIR_TASKS / path_obj
+
+
 def get_current_task(repo_root: Path | None = None) -> str | None:
     """Get current task directory path (relative to repo_root).
 
@@ -236,7 +280,8 @@ def get_current_task(repo_root: Path | None = None) -> str | None:
         return None
 
     try:
-        return current_file.read_text(encoding="utf-8").strip()
+        content = current_file.read_text(encoding="utf-8").strip()
+        return normalize_task_ref(content) if content else None
     except (OSError, IOError):
         return None
 
@@ -255,7 +300,7 @@ def get_current_task_abs(repo_root: Path | None = None) -> Path | None:
 
     relative = get_current_task(repo_root)
     if relative:
-        return repo_root / relative
+        return resolve_task_ref(relative, repo_root)
     return None
 
 
@@ -272,18 +317,24 @@ def set_current_task(task_path: str, repo_root: Path | None = None) -> bool:
     if repo_root is None:
         repo_root = get_repo_root()
 
-    if not task_path:
+    normalized = normalize_task_ref(task_path)
+    if not normalized:
         return False
 
     # Verify task directory exists
-    full_path = repo_root / task_path
-    if not full_path.is_dir():
+    full_path = resolve_task_ref(normalized, repo_root)
+    if full_path is None or not full_path.is_dir():
         return False
+
+    try:
+        normalized = full_path.relative_to(repo_root).as_posix()
+    except ValueError:
+        normalized = str(full_path)
 
     current_file = _get_current_task_file(repo_root)
 
     try:
-        current_file.write_text(task_path, encoding="utf-8")
+        current_file.write_text(normalized, encoding="utf-8")
         return True
     except (OSError, IOError):
         return False

--- a/packages/cli/src/templates/trellis/scripts/common/task_utils.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_utils.py
@@ -37,23 +37,25 @@ def is_safe_task_path(task_path: str, repo_root: Path | None = None) -> bool:
     if repo_root is None:
         repo_root = get_repo_root()
 
+    normalized = task_path.replace("\\", "/")
+
     # Check empty or null
-    if not task_path or task_path == "null":
+    if not normalized or normalized == "null":
         print("Error: empty or null task path", file=sys.stderr)
         return False
 
     # Reject absolute paths
-    if task_path.startswith("/"):
+    if Path(task_path).is_absolute():
         print(f"Error: absolute path not allowed: {task_path}", file=sys.stderr)
         return False
 
     # Reject ".", "..", paths starting with "./" or "../", or containing ".."
-    if task_path in (".", "..") or task_path.startswith("./") or task_path.startswith("../") or ".." in task_path:
+    if normalized in (".", "..") or normalized.startswith("./") or normalized.startswith("../") or ".." in normalized:
         print(f"Error: path traversal not allowed: {task_path}", file=sys.stderr)
         return False
 
     # Final check: ensure resolved path is not the repo root
-    abs_path = repo_root / task_path
+    abs_path = repo_root / Path(normalized)
     if abs_path.exists():
         try:
             resolved = abs_path.resolve()
@@ -187,13 +189,17 @@ def resolve_task_dir(target_dir: str, repo_root: Path) -> Path:
     if not target_dir:
         return Path()
 
+    normalized = target_dir.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+
     # Absolute path
-    if target_dir.startswith("/"):
+    if Path(target_dir).is_absolute():
         return Path(target_dir)
 
     # Relative path (contains path separator or starts with .trellis)
-    if "/" in target_dir or target_dir.startswith(".trellis"):
-        return repo_root / target_dir
+    if "/" in normalized or normalized.startswith(".trellis"):
+        return repo_root / Path(normalized)
 
     # Task name - try to find in tasks directory
     tasks_dir = get_tasks_dir(repo_root)
@@ -202,7 +208,7 @@ def resolve_task_dir(target_dir: str, repo_root: Path) -> Path:
         return found
 
     # Fallback to treating as relative path
-    return repo_root / target_dir
+    return repo_root / Path(normalized)
 
 
 # =============================================================================

--- a/packages/cli/src/templates/trellis/scripts/multi_agent/start.py
+++ b/packages/cli/src/templates/trellis/scripts/multi_agent/start.py
@@ -202,12 +202,16 @@ def main() -> int:
     project_root = get_repo_root()
 
     # Normalize paths
-    if task_dir_arg.startswith("/"):
-        task_dir_relative = task_dir_arg[len(str(project_root)) + 1 :]
-        task_dir_abs = Path(task_dir_arg)
+    task_dir_path = Path(task_dir_arg)
+    if task_dir_path.is_absolute():
+        task_dir_abs = task_dir_path
     else:
-        task_dir_relative = task_dir_arg
-        task_dir_abs = project_root / task_dir_arg
+        task_dir_abs = project_root / task_dir_path
+
+    try:
+        task_dir_relative = task_dir_abs.relative_to(project_root).as_posix()
+    except ValueError:
+        task_dir_relative = str(task_dir_abs)
 
     task_json_path = task_dir_abs / FILE_TASK_JSON
 

--- a/packages/cli/src/templates/trellis/scripts/task.py
+++ b/packages/cli/src/templates/trellis/scripts/task.py
@@ -84,7 +84,7 @@ def cmd_start(args: argparse.Namespace) -> int:
 
     # Convert to relative path for storage
     try:
-        task_dir = str(full_path.relative_to(repo_root))
+        task_dir = full_path.relative_to(repo_root).as_posix()
     except ValueError:
         task_dir = str(full_path)
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -38,6 +38,7 @@ import {
   settingsTemplate as iflowSettingsTemplate,
   getAllHooks as getIflowHooks,
 } from "../src/templates/iflow/index.js";
+import { getAllHooks as getCodexHooks } from "../src/templates/codex/index.js";
 import {
   commonInit,
   taskScript,
@@ -58,6 +59,7 @@ import {
 } from "../src/configurators/index.js";
 import { guidesIndexContent, workspaceIndexContent } from "../src/templates/markdown/index.js";
 import * as markdownExports from "../src/templates/markdown/index.js";
+import { TrellisContext } from "../src/templates/opencode/lib/trellis-context.js";
 
 afterEach(() => {
   clearManifestCache();
@@ -516,9 +518,8 @@ describe("regression: resolve_task_dir path handling", () => {
     expect(commonTaskUtils).toContain('.startswith(".trellis")');
   });
 
-  it("[potential] resolve_task_dir path check includes '/' separator check", () => {
-    // resolve_task_dir should detect relative paths containing '/'
-    expect(commonTaskUtils).toContain('"/" in target_dir');
+  it("[current-task] resolve_task_dir normalizes backslash separators before path classification", () => {
+    expect(commonTaskUtils).toContain('target_dir.replace("\\\\", "/")');
   });
 });
 
@@ -829,6 +830,164 @@ describe("regression: SessionStart reinject on clear/compact (MIN-231)", () => {
         ).toContain("session-start.py");
       }
     }
+  });
+});
+
+describe("regression: current-task path normalization", () => {
+  let tmpDir: string;
+  const pythonCmd = process.platform === "win32" ? "python" : "python3";
+  const claudeSessionStart = getClaudeHooks().find(
+    (hook) => hook.targetPath === "hooks/session-start.py",
+  )?.content;
+  const iflowSessionStart = getIflowHooks().find(
+    (hook) => hook.targetPath === "hooks/session-start.py",
+  )?.content;
+  const codexSessionStart = getCodexHooks().find(
+    (hook) => hook.name === "session-start.py",
+  )?.content;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-current-task-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTrellisScripts(): void {
+    const scriptsDir = path.join(tmpDir, ".trellis", "scripts");
+    for (const [relativePath, content] of getAllScripts()) {
+      const absPath = path.join(scriptsDir, relativePath);
+      fs.mkdirSync(path.dirname(absPath), { recursive: true });
+      fs.writeFileSync(absPath, content, "utf-8");
+    }
+  }
+
+  function writeProjectFile(relativePath: string, content: string): void {
+    const absPath = path.join(tmpDir, relativePath);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, content, "utf-8");
+  }
+
+  function setupTaskRepo(taskRef = ".trellis\\tasks\\issue-106"): void {
+    writeTrellisScripts();
+    writeProjectFile(
+      path.join(".trellis", ".developer"),
+      "name=test-dev\ninitialized_at=2026-03-27T00:00:00\n",
+    );
+    writeProjectFile(path.join(".trellis", "workflow.md"), "# Workflow\n");
+    writeProjectFile(
+      path.join(".trellis", "spec", "guides", "index.md"),
+      "# Guides\n",
+    );
+    writeProjectFile(path.join(".trellis", ".current-task"), `${taskRef}\n`);
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "task.json"),
+      JSON.stringify(
+        {
+          title: "Issue 106 task",
+          status: "in_progress",
+          package: null,
+        },
+        null,
+        2,
+      ),
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "prd.md"),
+      "# PRD\n",
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/example.ts","reason":"runtime regression"}\n',
+    );
+  }
+
+  function runPython(relativeScriptPath: string, input?: string): string {
+    const scriptPath = path.join(tmpDir, relativeScriptPath);
+    return execSync(`${pythonCmd} ${JSON.stringify(scriptPath)}`, {
+      cwd: tmpDir,
+      input,
+      encoding: "utf-8",
+    });
+  }
+
+  function expectTemplateContent(
+    content: string | undefined,
+    label: string,
+  ): string {
+    expect(content, `${label} template should exist`).toBeTruthy();
+    return content ?? "";
+  }
+
+  it("[current-task] task.py start canonicalizes Windows-style task refs before writing", () => {
+    setupTaskRepo("");
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} start ${JSON.stringify(".trellis\\\\tasks\\\\issue-106")}`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      },
+    );
+
+    expect(output).toContain(".trellis/tasks/issue-106");
+    expect(
+      fs.readFileSync(path.join(tmpDir, ".trellis", ".current-task"), "utf-8").trim(),
+    ).toBe(".trellis/tasks/issue-106");
+  });
+
+  it("[current-task] Python session-start hooks resolve legacy backslash refs without stale pointer", () => {
+    setupTaskRepo();
+
+    writeProjectFile(
+      path.join(".claude", "hooks", "session-start.py"),
+      expectTemplateContent(claudeSessionStart, "claude session-start"),
+    );
+    writeProjectFile(
+      path.join(".iflow", "hooks", "session-start.py"),
+      expectTemplateContent(iflowSessionStart, "iflow session-start"),
+    );
+    writeProjectFile(
+      path.join(".codex", "hooks", "session-start.py"),
+      expectTemplateContent(codexSessionStart, "codex session-start"),
+    );
+
+    const claudeOutput = runPython(path.join(".claude", "hooks", "session-start.py"));
+    const iflowOutput = runPython(path.join(".iflow", "hooks", "session-start.py"));
+    const codexOutput = runPython(
+      path.join(".codex", "hooks", "session-start.py"),
+      JSON.stringify({ cwd: tmpDir }),
+    );
+
+    for (const output of [claudeOutput, iflowOutput]) {
+      expect(output).toContain("Status: READY");
+      expect(output).not.toContain("STALE POINTER");
+    }
+
+    const codexPayload = JSON.parse(codexOutput) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+    expect(codexPayload.hookSpecificOutput.additionalContext).toContain(
+      "Status: READY",
+    );
+    expect(codexPayload.hookSpecificOutput.additionalContext).not.toContain(
+      "STALE POINTER",
+    );
+  });
+
+  it("[current-task] OpenCode context layer normalizes backslash refs for downstream plugins", () => {
+    setupTaskRepo();
+
+    const ctx = new TrellisContext(tmpDir) as TrellisContext & {
+      resolveTaskDir: (taskRef: string) => string | null;
+    };
+
+    expect(ctx.getCurrentTask()).toBe(".trellis/tasks/issue-106");
+    expect(ctx.resolveTaskDir(".trellis\\tasks\\issue-106")).toBe(
+      path.join(tmpDir, ".trellis", "tasks", "issue-106"),
+    );
   });
 });
 


### PR DESCRIPTION
﻿## Summary

Fix `.trellis/.current-task` path ref normalization across Trellis scripts, Python hooks, and OpenCode helpers so Windows-style backslash refs no longer resolve to stale task pointers.

## Root Cause

`.current-task` is a task pointer file, but its read/write conventions drifted:

- writers stored raw path strings, which can use `\` on Windows
- several readers only recognized `.trellis/` and otherwise treated the value as a bare task name under `.trellis/tasks/`
- a valid ref like `.trellis\tasks\03-27-foo` could therefore be mis-resolved and reported as `STALE POINTER`

## What Changed

- added canonical task-ref normalization and resolution helpers in `common/paths.py`
- normalized `.current-task` writes in `task.py` and `multi_agent/start.py` to repo-relative POSIX refs
- updated direct `.current-task` readers in Claude, Codex, and iFlow hooks to accept legacy backslash refs
- normalized OpenCode task-ref handling in `TrellisContext` and session-start task resolution
- added regression coverage for canonical writes, legacy hook reads, and OpenCode task-ref normalization

## Testing

Passed:

- `pnpm --filter @mindfoldhq/trellis exec vitest run test/regression.test.ts -t "current-task|resolve_task_dir"`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis lint:py`
- `pnpm --filter @mindfoldhq/trellis build`

Note:

- On my Windows environment, `pnpm --filter @mindfoldhq/trellis test` still reports several pre-existing unrelated failures outside this change surface. The new regression coverage added here passes, and all modified files pass lint/typecheck/build gates.
