### PR TITLE
fix(codex): resolve PYTHON_CMD placeholder in hooks.json for Windows

### DIFF
--- a/packages/cli/src/configurators/codex.ts
+++ b/packages/cli/src/configurators/codex.ts
@@ -8,6 +8,7 @@ import {
   getHooksConfig,
 } from "../templates/codex/index.js";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
+import { resolvePlaceholders } from "./shared.js";
 
 /**
  * Configure Codex by writing:
@@ -61,7 +62,10 @@ export async function configureCodex(cwd: string): Promise<void> {
   }
 
   // Hooks config → .codex/hooks.json
-  await writeFile(path.join(codexRoot, "hooks.json"), getHooksConfig());
+  await writeFile(
+    path.join(codexRoot, "hooks.json"),
+    resolvePlaceholders(getHooksConfig()),
+  );
 
   // Config → .codex/config.toml
   const config = getConfigTemplate();

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -159,7 +159,10 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       for (const hook of getCodexHooks()) {
         files.set(`.codex/hooks/${hook.name}`, hook.content);
       }
-      files.set(".codex/hooks.json", getCodexHooksConfig());
+      files.set(
+        ".codex/hooks.json",
+        resolvePlaceholders(getCodexHooksConfig()),
+      );
       const config = getCodexConfigTemplate();
       files.set(`.codex/${config.targetPath}`, config.content);
       return files;

--- a/packages/cli/src/templates/codex/hooks.json
+++ b/packages/cli/src/templates/codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .codex/hooks/session-start.py",
+            "command": "{{PYTHON_CMD}} .codex/hooks/session-start.py",
             "timeout": 15,
             "statusMessage": "Loading Trellis context..."
           }

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import {
   getConfiguredPlatforms,
   configurePlatform,
+  collectPlatformTemplates,
   PLATFORM_IDS,
 } from "../../src/configurators/index.js";
 import { AI_TOOLS } from "../../src/types/ai-tools.js";
@@ -13,12 +14,14 @@ import {
   getAllAgents as getAllCodexAgents,
   getAllSkills,
   getConfigTemplate as getCodexConfigTemplate,
+  getHooksConfig as getCodexHooksConfig,
 } from "../../src/templates/codex/index.js";
 import { getAllWorkflows as getAllAntigravityWorkflows } from "../../src/templates/antigravity/index.js";
 import { getAllSkills as getAllKiroSkills } from "../../src/templates/kiro/index.js";
 import { getAllCommands as getAllGeminiCommands } from "../../src/templates/gemini/index.js";
 import { getAllSkills as getAllQoderSkills } from "../../src/templates/qoder/index.js";
 import { getAllCommands as getAllCodebuddyCommands } from "../../src/templates/codebuddy/index.js";
+import { resolvePlaceholders } from "../../src/configurators/shared.js";
 
 // =============================================================================
 // getConfiguredPlatforms — detects existing platform directories
@@ -219,6 +222,17 @@ describe("configurePlatform", () => {
     const configPath = path.join(tmpDir, ".codex", config.targetPath);
     expect(fs.existsSync(configPath)).toBe(true);
     expect(fs.readFileSync(configPath, "utf-8")).toBe(config.content);
+  });
+
+  it("configurePlatform('codex') resolves PYTHON_CMD in hooks.json", async () => {
+    await configurePlatform("codex", tmpDir);
+
+    const hooksPath = path.join(tmpDir, ".codex", "hooks.json");
+    expect(fs.existsSync(hooksPath)).toBe(true);
+    const content = fs.readFileSync(hooksPath, "utf-8");
+    const expectedPythonCmd = process.platform === "win32" ? "python" : "python3";
+    expect(content).toContain(`"command": "${expectedPythonCmd} .codex/hooks/session-start.py"`);
+    expect(content).not.toContain("{{PYTHON_CMD}}");
   });
 
   it("configurePlatform('kiro') creates .kiro/skills directory", async () => {
@@ -462,5 +476,18 @@ describe("configurePlatform", () => {
         fs.rmSync(platformDir, { recursive: true, force: true });
       }
     }
+  });
+
+  it("collectPlatformTemplates('codex') resolves placeholders in hooks.json", () => {
+    const templates = collectPlatformTemplates("codex");
+    expect(templates).toBeInstanceOf(Map);
+    expect(templates?.get(".codex/hooks.json")).toBe(
+      resolvePlaceholders(getCodexHooksConfig()),
+    );
+  });
+
+  it("codex hooks.json template keeps PYTHON_CMD placeholder", () => {
+    const rawTemplate = getCodexHooksConfig();
+    expect(rawTemplate).toContain("{{PYTHON_CMD}} .codex/hooks/session-start.py");
   });
 });


### PR DESCRIPTION
## Summary

- Codex `hooks.json` hardcoded `python3`, which doesn't exist on Windows (only `python`). The `claude-code` and `iflow` platforms already use `resolvePlaceholders()` from `shared.ts` — codex was simply missed.
- This fix covers **both** code paths: `trellis init --codex` (`codex.ts`) and `trellis update` (`index.ts` → `collectPlatformTemplates`). Without the latter, `trellis update` would detect a false diff between the resolved on-disk file and the raw template.

## Changes (4 files)

| File | Change |
|---|---|
| `packages/cli/src/templates/codex/hooks.json` | `python3` → `{{PYTHON_CMD}}` placeholder |
| `packages/cli/src/configurators/codex.ts` | Call `resolvePlaceholders()` when writing hooks.json during init |
| `packages/cli/src/configurators/index.ts` | Call `resolvePlaceholders()` in `collectPlatformTemplates("codex")` for update tracking |
| `packages/cli/test/configurators/platforms.test.ts` | 3 new tests: init resolves correctly, update templates match, raw template retains placeholder |

## Test plan

- [x] `vitest run test/configurators/platforms.test.ts` — 41/41 passed
- [ ] Manual: `trellis init --codex` on Windows → verify `.codex/hooks.json` contains `"python"` not `"python3"`
- [ ] Manual: `trellis update` after init → no false diff reported for hooks.json