### PR TITLE
ci: Tessl skill review + optimize on SKILL.md PRs

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,24 @@
+# Comment `/apply-optimize` on a PR to commit suggested optimizations from the review workflow.
+# Pairs with skill-review.yml (tesslio/skill-review-and-optimize).
+name: Apply Skill Optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: "apply"

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,23 @@
+# Tessl skill review + optional AI optimization suggestions on SKILL.md PRs.
+# Superset of tesslio/skill-review; uses TESSL_API_TOKEN for optimize. See:
+# https://github.com/giuseppe-trisciuoglio/developer-kit/pull/160
+name: Skill Review & Optimize
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: "true"
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
## Hey @taosu0216 👋

Following up on the skill content work in [#104](https://github.com/mindfold-ai/Trellis/pull/104), this adds **GitHub Actions** so future PRs that touch `**/SKILL.md`** get Tessl review (and optional optimization suggestions) automatically — same pattern as [developer-kit#160](https://github.com/giuseppe-trisciuoglio/developer-kit/pull/160).

### What this adds

**`.github/workflows/skill-review.yml`**
- Runs on PRs to `main` that change any `**/SKILL.md`**
- Uses [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) (SHA-pinned): same scoring/feedback as basic review, plus **optimization suggestions** in a collapsible PR comment when enabled
- Requires repository secret **`TESSL_API_TOKEN`**

**`.github/workflows/skill-apply-optimize.yml`**
- Contributors or maintainers can comment **`/apply-optimize`** on a PR to **commit** the suggested optimizations to the PR branch

This does **not** replace your existing `ci.yml` (CLI/build paths); it only runs when skill markdown changes.

### Maintainer setup

Add **Settings → Secrets → `TESSL_API_TOKEN`** with a Tessl API token so the optimize path can run.

### Disclosure

Honest disclosure — I work at [@tesslio](https://github.com/tesslio) where we build tooling around agent skills. This pairs well with the improvements from #104 so every skill PR gets consistent feedback.

Thanks in advance 🙏
