### PR TITLE
fix(hooks): correct SubagentStop event field names in ralph-loop

### DIFF
--- a/.claude/hooks/ralph-loop.py
+++ b/.claude/hooks/ralph-loop.py
@@ -265,17 +265,18 @@ def main():
         sys.exit(0)
 
     # Get subagent info
-    subagent_type = input_data.get("subagent_type", "")
-    agent_output = input_data.get("agent_output", "")
-    original_prompt = input_data.get("prompt", "")
+    # Field names per Claude Code SubagentStop event schema:
+    #   agent_type, last_assistant_message, agent_id, agent_transcript_path, cwd
+    # The event does NOT carry a `prompt` field, so finish-phase detection
+    # based on a `[finish]` marker in the user prompt is no longer possible
+    # here; finish-phase skip logic should be reintroduced via task.json
+    # state (e.g. current_phase) in a follow-up.
+    agent_type = input_data.get("agent_type", "")
+    last_assistant_message = input_data.get("last_assistant_message", "")
     cwd = input_data.get("cwd", os.getcwd())
 
     # Only control check agent
-    if subagent_type != TARGET_AGENT:
-        sys.exit(0)
-
-    # Skip Ralph Loop for finish phase (already verified in check phase)
-    if "[finish]" in original_prompt.lower():
+    if agent_type != TARGET_AGENT:
         sys.exit(0)
 
     # Find repo root
@@ -357,7 +358,7 @@ def main():
     else:
         # No verify commands, fall back to completion markers
         markers = get_completion_markers(repo_root, task_dir)
-        all_complete, missing = check_completion(agent_output, markers)
+        all_complete, missing = check_completion(last_assistant_message, markers)
 
         if all_complete:
             # All checks complete, allow stop

--- a/packages/cli/src/templates/claude/hooks/ralph-loop.py
+++ b/packages/cli/src/templates/claude/hooks/ralph-loop.py
@@ -265,17 +265,18 @@ def main():
         sys.exit(0)
 
     # Get subagent info
-    subagent_type = input_data.get("subagent_type", "")
-    agent_output = input_data.get("agent_output", "")
-    original_prompt = input_data.get("prompt", "")
+    # Field names per Claude Code SubagentStop event schema:
+    #   agent_type, last_assistant_message, agent_id, agent_transcript_path, cwd
+    # The event does NOT carry a `prompt` field, so finish-phase detection
+    # based on a `[finish]` marker in the user prompt is no longer possible
+    # here; finish-phase skip logic should be reintroduced via task.json
+    # state (e.g. current_phase) in a follow-up.
+    agent_type = input_data.get("agent_type", "")
+    last_assistant_message = input_data.get("last_assistant_message", "")
     cwd = input_data.get("cwd", os.getcwd())
 
     # Only control check agent
-    if subagent_type != TARGET_AGENT:
-        sys.exit(0)
-
-    # Skip Ralph Loop for finish phase (already verified in check phase)
-    if "[finish]" in original_prompt.lower():
+    if agent_type != TARGET_AGENT:
         sys.exit(0)
 
     # Find repo root
@@ -357,7 +358,7 @@ def main():
     else:
         # No verify commands, fall back to completion markers
         markers = get_completion_markers(repo_root, task_dir)
-        all_complete, missing = check_completion(agent_output, markers)
+        all_complete, missing = check_completion(last_assistant_message, markers)
 
         if all_complete:
             # All checks complete, allow stop


### PR DESCRIPTION
## Summary

The Ralph Loop hook (`ralph-loop.py`) reads SubagentStop event fields that do not exist in the actual Claude Code event schema, so it never matches any event and `.trellis/.ralph-state.json` is never updated. As a result, **Ralph Loop does not exert any loop control for any trellis user today** — the mechanism is silently inert.

## Root cause

`main()` in `ralph-loop.py` reads three fields from the SubagentStop event payload that do not exist in the Claude Code hook API:

| Code reads (incorrect) | Actual Claude Code field |
|------------------------|--------------------------|
| `subagent_type` | `agent_type` |
| `agent_output` | `last_assistant_message` |
| `prompt` | (does not exist on SubagentStop) |

Because `input_data.get("subagent_type", "")` returns `""`, the very next line (`if subagent_type != TARGET_AGENT: sys.exit(0)`) evaluates `"" != "check"` → `True`, and the hook exits before any state-tracking / verify-command / completion-marker logic runs. The entire Ralph Loop mechanism is inert.

## Fix

Three field-name corrections in `main()`:

- `subagent_type` → `agent_type`
- `agent_output` → `last_assistant_message`
- `prompt` → removed (field does not exist)

Plus the one downstream call at line 360: `check_completion(agent_output, markers)` → `check_completion(last_assistant_message, markers)`.

Applied to **both** copies per the CONTRIBUTING.md guidance that changes to `.claude/` must be mirrored in `src/templates/`:

- `packages/cli/src/templates/claude/hooks/ralph-loop.py` (install template)
- `.claude/hooks/ralph-loop.py` (dogfood copy)

## Reproduction

On a clean install:

```bash
mkdir /tmp/trellis-repro && cd /tmp/trellis-repro && git init
npx @mindfoldhq/trellis@beta init --claude -u test-user -y

# Feed a realistic SubagentStop event:
echo '{
  "hook_event_name": "SubagentStop",
  "agent_type": "check",
  "last_assistant_message": "TYPECHECK_FINISH LINT_FINISH",
  "agent_id": "abc",
  "agent_transcript_path": "/tmp/t.jsonl",
  "cwd": "'"$(pwd)"'"
}' | python3 .claude/hooks/ralph-loop.py
```

**Before this fix:** hook exits immediately; no output; `.trellis/.ralph-state.json` is not created.

**After this fix:** hook processes the event, records state, and (if no verify commands are configured) checks completion markers — exactly the documented Ralph Loop behavior.

## Follow-up not in this PR: finish-phase skip semantics

The previous code had this skip at line 277-279:

```python
# Skip Ralph Loop for finish phase (already verified in check phase)
if "[finish]" in original_prompt.lower():
    sys.exit(0)
```

`original_prompt` came from the non-existent `prompt` field, so this check already never fired in practice. I removed the three lines in this PR rather than keeping dead code — but this does mean finish-phase check agents will now run through Ralph Loop just like any other check.

If you want finish-phase to remain skipped, the canonical signal would be `task.json` state (for example reading `current_phase` from the current task), since that information is still available to the hook via `get_current_task()`. I'm happy to add a second commit on this branch implementing that, or open a follow-up PR — whichever you prefer. I did not speculate on the exact `current_phase` semantics since I couldn't confirm from reading the code alone which values represent finish phase.

## Test plan

- [x] `py_compile` passes on both patched files
- [x] Manual reproduction above verified locally
- [ ] Existing trellis test suite (I didn't have a clean pnpm env for full test run — happy to run specific tests if you point me at the relevant ones)

## Related

- No existing issue or PR found via search for `ralph-loop`, `SubagentStop`, `agent_type` on this repo
- Affects anyone running implement / check / debug subagents, silently