### PR TITLE
fix(update): parse name from .developer when creating migration task

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1802,11 +1802,23 @@ export async function update(options: UpdateOptions): Promise<void> {
       if (!fs.existsSync(taskDir)) {
         fs.mkdirSync(taskDir, { recursive: true });
 
-        // Get current developer for assignee
+        // Get current developer for assignee.
+        // `.developer` is a key=value file (written by init_developer.py):
+        //   name=<developer-name>
+        //   initialized_at=<iso8601>
+        // Reading it raw and .trim()-ing embeds the entire file contents
+        // (including the `name=` prefix and the `initialized_at` line) into
+        // the assignee field, producing bogus assignees like
+        // "name=suyuan\ninitialized_at=2026-04-07T23:41:21.978312" that
+        // later break session-start task rendering.
         const developerFile = path.join(cwd, DIR_NAMES.WORKFLOW, ".developer");
         let currentDeveloper = "unknown";
         if (fs.existsSync(developerFile)) {
-          currentDeveloper = fs.readFileSync(developerFile, "utf-8").trim();
+          const raw = fs.readFileSync(developerFile, "utf-8");
+          const nameMatch = raw.match(/^\s*name\s*=\s*(.+?)\s*$/m);
+          if (nameMatch) {
+            currentDeveloper = nameMatch[1];
+          }
         }
 
         // Build task.json


### PR DESCRIPTION
## Summary

When `trellis update --migrate` creates the auto-generated migration task after a breaking-change upgrade, it reads `.trellis/.developer` as a plain string and writes the entire file contents verbatim into the new task's `assignee` field.

`.developer` is a key=value file (written by `init_developer.py`):

```
name=<developer-name>
initialized_at=<iso8601-timestamp>
```

Reading it raw and `.trim()`-ing embeds the whole thing — including the `name=` prefix and the timestamp line — into `assignee`. The resulting `task.json` looks like:

```json
{
  "assignee": "name=suyuan\ninitialized_at=2026-04-07T23:41:21.978312"
}
```

instead of the intended:

```json
{
  "assignee": "suyuan"
}
```

## Downstream visible impact

`session-start.py` reads `.trellis/tasks/*/task.json` to render the Active Tasks block. The multi-line assignee bleeds into that render, so users see:

```
## ACTIVE TASKS
- 04-07-migrate-to-0.4.0-beta.8/ (planning) @name=suyuan
  initialized_at=2026-04-07T23:41:21.978312
- 04-08-other-task/ (planning) @suyuan
```

The timestamp line leaks as if it were a separate task entry, breaking the task-list layout for anyone who has run `trellis update --migrate` on a project with breaking changes.

## Root cause

`packages/cli/src/commands/update.ts` around line 1809:

```typescript
const developerFile = path.join(cwd, DIR_NAMES.WORKFLOW, ".developer");
let currentDeveloper = "unknown";
if (fs.existsSync(developerFile)) {
  currentDeveloper = fs.readFileSync(developerFile, "utf-8").trim();
}
```

`.trim()` only strips surrounding whitespace — it doesn't parse the key=value format.

## Fix

Parse the `name=` line with a regex and extract only the value, falling back to `"unknown"` (the same pre-existing default) if the line is missing or malformed. No behavior change when `.developer` is absent.

## Reproduction

```bash
mkdir /tmp/repro && cd /tmp/repro && git init
npx @mindfoldhq/trellis@0.3.10 init --claude -u john -y
npx @mindfoldhq/trellis@beta update --force --migrate -y
cat .trellis/tasks/*migrate*/task.json | jq .assignee
```

**Before this fix:** `"name=john\ninitialized_at=2026-04-..."`
**After this fix:** `"john"`

## Scope

- 1 file: `packages/cli/src/commands/update.ts`
- 14 insertions, 2 deletions
- No API / type / schema changes
- Isolated to the migration-task-creation code path; does not touch any other `.developer` reader

## Test plan

- [x] `pnpm lint` passes (no output)
- [x] `pnpm typecheck` passes (no output)
- [x] Pre-commit hooks (eslint --fix, prettier --write) pass without touching the patch
- [x] Reproduction above verified in a clean `/tmp` repo

## Related

- Discovered while running a clean `beta.8 → beta.9` upgrade flow
- No existing issue or PR found via search for `assignee`, `migrate`, `.developer` on this repo