### PR TITLE
fix(session-start): remove redundant start.md injection

### DIFF
--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -365,20 +365,13 @@ Read and follow all instructions below carefully.
 
     output.write("</guidelines>\n\n")
 
-    output.write("<instructions>\n")
-    start_md = read_file(
-        claude_dir / "commands" / "trellis" / "start.md", "No start.md found"
-    )
-    output.write(start_md)
-    output.write("\n</instructions>\n\n")
-
     # Check task status and inject structured tag
     task_status = _get_task_status(trellis_dir)
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -193,21 +193,12 @@ Read and follow all instructions below carefully.
 
     output.write("</guidelines>\n\n")
 
-    # Inject start skill as instructions (Codex uses skills, not slash commands)
-    start_skill = codex_dir / "skills" / "start" / "SKILL.md"
-    if not start_skill.is_file():
-        start_skill = project_dir / ".agents" / "skills" / "start" / "SKILL.md"
-    if start_skill.is_file():
-        output.write("<instructions>\n")
-        output.write(read_file(start_skill))
-        output.write("\n</instructions>\n\n")
-
     task_status = _get_task_status(trellis_dir)
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/.opencode/plugins/session-start.js
+++ b/.opencode/plugins/session-start.js
@@ -82,20 +82,9 @@ Read and follow all instructions below carefully.
 
   parts.push("</guidelines>")
 
-  // 5. Session Instructions - try both .claude and .opencode
-  let startMd = ctx.readFile(join(claudeDir, "commands", "trellis", "start.md"))
-  if (!startMd) {
-    startMd = ctx.readFile(join(opencodeDir, "commands", "trellis", "start.md"))
-  }
-  if (startMd) {
-    parts.push("<instructions>")
-    parts.push(startMd)
-    parts.push("</instructions>")
-  }
-
   // 6. Final directive
   parts.push(`<ready>
-Context loaded. Wait for user's first message, then follow <instructions> to handle their request.
+Context loaded. Wait for user's first message, then follow the workflow to handle their request.
 </ready>`)
 
   return parts.join("\n\n")

--- a/packages/cli/src/templates/claude/hooks/session-start.py
+++ b/packages/cli/src/templates/claude/hooks/session-start.py
@@ -365,20 +365,13 @@ Read and follow all instructions below carefully.
 
     output.write("</guidelines>\n\n")
 
-    output.write("<instructions>\n")
-    start_md = read_file(
-        claude_dir / "commands" / "trellis" / "start.md", "No start.md found"
-    )
-    output.write(start_md)
-    output.write("\n</instructions>\n\n")
-
     # Check task status and inject structured tag
     task_status = _get_task_status(trellis_dir)
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -193,21 +193,12 @@ Read and follow all instructions below carefully.
 
     output.write("</guidelines>\n\n")
 
-    # Inject start skill as instructions (Codex uses skills, not slash commands)
-    start_skill = codex_dir / "skills" / "start" / "SKILL.md"
-    if not start_skill.is_file():
-        start_skill = project_dir / ".agents" / "skills" / "start" / "SKILL.md"
-    if start_skill.is_file():
-        output.write("<instructions>\n")
-        output.write(read_file(start_skill))
-        output.write("\n</instructions>\n\n")
-
     task_status = _get_task_status(trellis_dir)
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/iflow/hooks/session-start.py
+++ b/packages/cli/src/templates/iflow/hooks/session-start.py
@@ -354,20 +354,13 @@ Read and follow all instructions below carefully.
 
     output.write("</guidelines>\n\n")
 
-    output.write("<instructions>\n")
-    start_md = read_file(
-        iflow_dir / "commands" / "trellis" / "start.md", "No start.md found"
-    )
-    output.write(start_md)
-    output.write("\n</instructions>\n\n")
-
     # R2: Check task status and inject structured tag
     task_status = _get_task_status(trellis_dir)
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/opencode/plugins/session-start.js
+++ b/packages/cli/src/templates/opencode/plugins/session-start.js
@@ -306,17 +306,6 @@ Read and follow all instructions below carefully.
 
   parts.push("</guidelines>")
 
-  // 5. Session Instructions - try both .claude and .opencode
-  let startMd = ctx.readFile(join(claudeDir, "commands", "trellis", "start.md"))
-  if (!startMd) {
-    startMd = ctx.readFile(join(opencodeDir, "commands", "trellis", "start.md"))
-  }
-  if (startMd) {
-    parts.push("<instructions>")
-    parts.push(startMd)
-    parts.push("</instructions>")
-  }
-
   // 6. Task status
   const taskStatus = getTaskStatus(ctx)
   parts.push(`<task-status>\n${taskStatus}\n</task-status>`)
@@ -324,7 +313,7 @@ Read and follow all instructions below carefully.
   // 7. Final directive
   parts.push(`<ready>
 Context loaded. Steps 1-3 (workflow, context, guidelines) are already injected above — do NOT re-read them.
-Start from Step 4. Wait for user's first message, then follow <instructions> to handle their request.
+Start from Step 4. Wait for user's first message, then follow the workflow to handle their request.
 If there is an active task, ask whether to continue it.
 </ready>`)
 


### PR DESCRIPTION
The /trellis:start slash command is already expanded on demand by the
platform (Claude Code, Codex, iFlow, OpenCode), so pre-injecting the
11 KB start.md into every session wastes ~11 KB of the additionalContext
budget for no benefit and creates an inconsistency with other commands
that do not receive the same treatment.

Remove the <instructions> block from all session-start hooks and update
the <ready> message to no longer reference it.

Affected hooks: claude, codex, iflow (Python) and opencode (JS)
across both live hooks and src/templates.

Fixes mindfold-ai/Trellis#154 (Approach B)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>