### PR TITLE
fix(session-start): replace workflow.md full injection with compact ToC

### DIFF
--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -288,6 +288,32 @@ def _resolve_spec_scope(
     return None  # Unknown scope type: full scan
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main():
     if should_skip_injection():
         sys.exit(0)
@@ -320,8 +346,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -125,6 +125,32 @@ def _get_task_status(trellis_dir: Path) -> str:
     return f"Status: READY\nTask: {task_title}\nNext: Continue with implement or check"
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main() -> None:
     if should_skip_injection():
         sys.exit(0)
@@ -154,8 +180,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/.opencode/plugins/session-start.js
+++ b/.opencode/plugins/session-start.js
@@ -47,11 +47,20 @@ Read and follow all instructions below carefully.
     }
   }
 
-  // 3. Workflow Guide
-  const workflow = ctx.readProjectFile(".trellis/workflow.md")
-  if (workflow) {
+  // 3. Workflow Guide (ToC only — lazy-load the full file on demand)
+  const workflowContent = ctx.readProjectFile(".trellis/workflow.md")
+  if (workflowContent) {
+    const tocLines = [
+      "# Development Workflow — Section Index",
+      "Full guide: .trellis/workflow.md  (read on demand)",
+      "",
+    ]
+    for (const line of workflowContent.split("\n")) {
+      if (line.startsWith("## ")) tocLines.push(line)
+    }
+    tocLines.push("", "To read a section: use the Read tool on .trellis/workflow.md")
     parts.push("<workflow>")
-    parts.push(workflow)
+    parts.push(tocLines.join("\n"))
     parts.push("</workflow>")
   }
 

--- a/packages/cli/src/templates/claude/hooks/session-start.py
+++ b/packages/cli/src/templates/claude/hooks/session-start.py
@@ -288,6 +288,32 @@ def _resolve_spec_scope(
     return None  # Unknown scope type: full scan
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main():
     if should_skip_injection():
         sys.exit(0)
@@ -320,8 +346,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -125,6 +125,32 @@ def _get_task_status(trellis_dir: Path) -> str:
     return f"Status: READY\nTask: {task_title}\nNext: Continue with implement or check"
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main() -> None:
     if should_skip_injection():
         sys.exit(0)
@@ -154,8 +180,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -125,6 +125,32 @@ def _get_task_status(trellis_dir: Path) -> str:
     return f"Status: READY\nTask: {task_title}\nNext: Continue with implement or check"
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main() -> None:
     if should_skip_injection():
         sys.exit(0)
@@ -153,8 +179,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/packages/cli/src/templates/iflow/hooks/session-start.py
+++ b/packages/cli/src/templates/iflow/hooks/session-start.py
@@ -278,6 +278,32 @@ def _resolve_spec_scope(
     return None
 
 
+def _build_workflow_toc(workflow_path: Path) -> str:
+    """Build a compact section index for workflow.md (lazy-load the full file on demand).
+
+    Replaces full-file injection to keep additionalContext payload small.
+    The full file is accessible via: Read tool on .trellis/workflow.md
+    """
+    content = read_file(workflow_path)
+    if not content:
+        return "No workflow.md found"
+
+    toc_lines = [
+        "# Development Workflow — Section Index",
+        "Full guide: .trellis/workflow.md  (read on demand)",
+        "",
+    ]
+    for line in content.splitlines():
+        if line.startswith("## "):
+            toc_lines.append(line)
+
+    toc_lines += [
+        "",
+        "To read a section: use the Read tool on .trellis/workflow.md",
+    ]
+    return "\n".join(toc_lines)
+
+
 def main():
     if should_skip_injection():
         sys.exit(0)
@@ -311,8 +337,7 @@ Read and follow all instructions below carefully.
     output.write("\n</current-state>\n\n")
 
     output.write("<workflow>\n")
-    workflow_content = read_file(trellis_dir / "workflow.md", "No workflow.md found")
-    output.write(workflow_content)
+    output.write(_build_workflow_toc(trellis_dir / "workflow.md"))
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")

--- a/packages/cli/src/templates/opencode/plugins/session-start.js
+++ b/packages/cli/src/templates/opencode/plugins/session-start.js
@@ -241,11 +241,20 @@ Read and follow all instructions below carefully.
     }
   }
 
-  // 3. Workflow Guide
-  const workflow = ctx.readProjectFile(".trellis/workflow.md")
-  if (workflow) {
+  // 3. Workflow Guide (ToC only — lazy-load the full file on demand)
+  const workflowContent = ctx.readProjectFile(".trellis/workflow.md")
+  if (workflowContent) {
+    const tocLines = [
+      "# Development Workflow — Section Index",
+      "Full guide: .trellis/workflow.md  (read on demand)",
+      "",
+    ]
+    for (const line of workflowContent.split("\n")) {
+      if (line.startsWith("## ")) tocLines.push(line)
+    }
+    tocLines.push("", "To read a section: use the Read tool on .trellis/workflow.md")
     parts.push("<workflow>")
-    parts.push(workflow)
+    parts.push(tocLines.join("\n"))
     parts.push("</workflow>")
   }
 


### PR DESCRIPTION
Injecting the full workflow.md (12-16 KB) into every session exceeded Claude Code's ~20 KB additionalContext limit, silently truncating task state. Replace it with a dynamically-built section index (~500 bytes) that lists only the ## headings and points to the full file path for on-demand reading.

Affected hooks: claude, codex, copilot, iflow (Python) and opencode (JS) across both live hooks and src/templates.

Fixes mindfold-ai/Trellis#154 (Approach A)