### PR TITLE
fix(hooks): add Windows GBK encoding fix to statusline.py

### DIFF
--- a/.claude/hooks/statusline.py
+++ b/.claude/hooks/statusline.py
@@ -11,11 +11,18 @@ Info line: model · ctx% · branch · duration · developer · tasks · rate lim
 """
 from __future__ import annotations
 
+import io
 import json
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+# Fix: Windows Python defaults to GBK encoding, which corrupts UTF-8
+# characters like the middle dot (·). Wrap stdout/stderr with UTF-8.
+if sys.platform == "win32":
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding="utf-8")
 
 
 def _read_text(path: Path) -> str:

--- a/packages/cli/src/templates/claude/hooks/statusline.py
+++ b/packages/cli/src/templates/claude/hooks/statusline.py
@@ -11,11 +11,18 @@ Info line: model · ctx% · branch · duration · developer · tasks · rate lim
 """
 from __future__ import annotations
 
+import io
 import json
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+# Fix: Windows Python defaults to GBK encoding, which corrupts UTF-8
+# characters like the middle dot (·). Wrap stdout/stderr with UTF-8.
+if sys.platform == "win32":
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding="utf-8")
 
 
 def _read_text(path: Path) -> str:


### PR DESCRIPTION
修复claude code windows状态栏乱码显示<img width="1237" height="353" alt="windows乱码显示" src="https://github.com/user-attachments/assets/02bccc47-1cd2-4d03-bf69-06bd28ef5dcb" />
修复后
<img width="1239" height="462" alt="image" src="https://github.com/user-attachments/assets/212f4f75-af59-44a2-8b1e-f207f2aa634a" />
