### PR TITLE
docs(workflow): complete task.py command table in workflow.md and start.md

### DIFF
--- a/.claude/commands/trellis/start.md
+++ b/.claude/commands/trellis/start.md
@@ -358,12 +358,29 @@ If yes, resume from the appropriate step (usually Step 7 or 8).
 | Script | Purpose |
 |--------|---------|
 | `python3 ./.trellis/scripts/get_context.py` | Get session context |
+| **Task lifecycle** | |
 | `python3 ./.trellis/scripts/task.py create` | Create task directory |
-| `python3 ./.trellis/scripts/task.py init-context` | Initialize jsonl files |
-| `python3 ./.trellis/scripts/task.py add-context` | Add code-spec/context file to jsonl |
-| `python3 ./.trellis/scripts/task.py start` | Set current task |
-| `python3 ./.trellis/scripts/task.py finish` | Clear current task |
+| `python3 ./.trellis/scripts/task.py start` | Set current task (writes `.current-task`, triggers `after_start` hooks) |
+| `python3 ./.trellis/scripts/task.py finish` | Clear current task (triggers `after_finish` hooks) |
 | `python3 ./.trellis/scripts/task.py archive` | Archive completed task |
+| `python3 ./.trellis/scripts/task.py list` | List active tasks (supports `--mine`, `--status`) |
+| `python3 ./.trellis/scripts/task.py list-archive` | List archived tasks |
+| **Code-spec context (jsonl injection)** | |
+| `python3 ./.trellis/scripts/task.py init-context` | Initialize implement/check/debug jsonl files |
+| `python3 ./.trellis/scripts/task.py add-context` | Add code-spec/context file to a jsonl |
+| `python3 ./.trellis/scripts/task.py list-context` | Show configured context files |
+| `python3 ./.trellis/scripts/task.py validate` | Validate jsonl references exist |
+| **Task metadata** | |
+| `python3 ./.trellis/scripts/task.py set-branch` | Set git branch for the task |
+| `python3 ./.trellis/scripts/task.py set-base-branch` | Set PR target branch |
+| `python3 ./.trellis/scripts/task.py set-scope` | Set task scope |
+| **Hierarchy** | |
+| `python3 ./.trellis/scripts/task.py add-subtask` | Link child task to parent |
+| `python3 ./.trellis/scripts/task.py remove-subtask` | Unlink child from parent |
+| **PR creation** | |
+| `python3 ./.trellis/scripts/task.py create-pr` | Create PR for current or specified task |
+
+> Run `python3 ./.trellis/scripts/task.py --help` to see the complete up-to-date list of subcommands and their arguments.
 
 ### Sub Agents `[AI]`
 

--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -313,13 +313,34 @@ tasks/
 
 **Commands**:
 ```bash
-python3 ./.trellis/scripts/task.py create "<title>" [--slug <name>]   # Create task directory
+# Task lifecycle
+python3 ./.trellis/scripts/task.py create "<title>" [--slug <name>] [--parent <dir>]   # Create task directory
 python3 ./.trellis/scripts/task.py start <name>    # Set as current task (writes .current-task, triggers after_start hooks)
 python3 ./.trellis/scripts/task.py finish          # Clear current task (triggers after_finish hooks)
 python3 ./.trellis/scripts/task.py archive <name>  # Archive to archive/{year-month}/
-python3 ./.trellis/scripts/task.py list            # List active tasks
+python3 ./.trellis/scripts/task.py list [--mine] [--status <s>]   # List active tasks
 python3 ./.trellis/scripts/task.py list-archive    # List archived tasks
+
+# Code-spec context (injected into implement/check/debug agents via JSONL)
+python3 ./.trellis/scripts/task.py init-context <name> <type>     # Initialize jsonl files (type: backend|frontend|fullstack|test|docs)
+python3 ./.trellis/scripts/task.py add-context <name> <action> <file> <reason>   # Add entry to <action>.jsonl
+python3 ./.trellis/scripts/task.py list-context <name> [action]   # Show configured context files
+python3 ./.trellis/scripts/task.py validate <name>                # Validate jsonl references exist
+
+# Task metadata
+python3 ./.trellis/scripts/task.py set-branch <name> <branch>     # Set git branch for the task
+python3 ./.trellis/scripts/task.py set-base-branch <name> <branch>  # Set PR target branch
+python3 ./.trellis/scripts/task.py set-scope <name> <scope>       # Set task scope
+
+# Hierarchy (parent/child tasks)
+python3 ./.trellis/scripts/task.py add-subtask <parent> <child>   # Link child task to parent
+python3 ./.trellis/scripts/task.py remove-subtask <parent> <child>  # Unlink child from parent
+
+# PR creation
+python3 ./.trellis/scripts/task.py create-pr [name] [--dry-run]   # Create PR for current or specified task
 ```
+
+> Run `python3 ./.trellis/scripts/task.py --help` to see the complete up-to-date list.
 
 **Current task mechanism**: `task.py start <name>` writes the selected task path to `.trellis/.current-task`. The SessionStart hook reads this file to inject `## CURRENT TASK` into every new session's context, so the AI immediately knows what you're working on without being told. Run `task.py finish` when you're done — subsequent sessions will show `(none)` until you start another task.
 

--- a/packages/cli/src/templates/claude/commands/trellis/start.md
+++ b/packages/cli/src/templates/claude/commands/trellis/start.md
@@ -367,12 +367,29 @@ If yes, resume from the appropriate step (usually Step 7 or 8).
 | Script | Purpose |
 |--------|---------|
 | `python3 ./.trellis/scripts/get_context.py` | Get session context |
+| **Task lifecycle** | |
 | `python3 ./.trellis/scripts/task.py create` | Create task directory |
-| `python3 ./.trellis/scripts/task.py init-context` | Initialize jsonl files |
-| `python3 ./.trellis/scripts/task.py add-context` | Add code-spec/context file to jsonl |
-| `python3 ./.trellis/scripts/task.py start` | Set current task |
-| `python3 ./.trellis/scripts/task.py finish` | Clear current task |
+| `python3 ./.trellis/scripts/task.py start` | Set current task (writes `.current-task`, triggers `after_start` hooks) |
+| `python3 ./.trellis/scripts/task.py finish` | Clear current task (triggers `after_finish` hooks) |
 | `python3 ./.trellis/scripts/task.py archive` | Archive completed task |
+| `python3 ./.trellis/scripts/task.py list` | List active tasks (supports `--mine`, `--status`) |
+| `python3 ./.trellis/scripts/task.py list-archive` | List archived tasks |
+| **Code-spec context (jsonl injection)** | |
+| `python3 ./.trellis/scripts/task.py init-context` | Initialize implement/check/debug jsonl files |
+| `python3 ./.trellis/scripts/task.py add-context` | Add code-spec/context file to a jsonl |
+| `python3 ./.trellis/scripts/task.py list-context` | Show configured context files |
+| `python3 ./.trellis/scripts/task.py validate` | Validate jsonl references exist |
+| **Task metadata** | |
+| `python3 ./.trellis/scripts/task.py set-branch` | Set git branch for the task |
+| `python3 ./.trellis/scripts/task.py set-base-branch` | Set PR target branch |
+| `python3 ./.trellis/scripts/task.py set-scope` | Set task scope |
+| **Hierarchy** | |
+| `python3 ./.trellis/scripts/task.py add-subtask` | Link child task to parent |
+| `python3 ./.trellis/scripts/task.py remove-subtask` | Unlink child from parent |
+| **PR creation** | |
+| `python3 ./.trellis/scripts/task.py create-pr` | Create PR for current or specified task |
+
+> Run `python3 ./.trellis/scripts/task.py --help` to see the complete up-to-date list of subcommands and their arguments.
 
 ### Sub Agents `[AI]`
 

--- a/packages/cli/src/templates/trellis/workflow.md
+++ b/packages/cli/src/templates/trellis/workflow.md
@@ -323,13 +323,34 @@ tasks/
 
 **Commands**:
 ```bash
-python3 ./.trellis/scripts/task.py create "<title>" [--slug <name>]   # Create task directory
+# Task lifecycle
+python3 ./.trellis/scripts/task.py create "<title>" [--slug <name>] [--parent <dir>]   # Create task directory
 python3 ./.trellis/scripts/task.py start <name>    # Set as current task (writes .current-task, triggers after_start hooks)
 python3 ./.trellis/scripts/task.py finish          # Clear current task (triggers after_finish hooks)
 python3 ./.trellis/scripts/task.py archive <name>  # Archive to archive/{year-month}/
-python3 ./.trellis/scripts/task.py list            # List active tasks
+python3 ./.trellis/scripts/task.py list [--mine] [--status <s>]   # List active tasks
 python3 ./.trellis/scripts/task.py list-archive    # List archived tasks
+
+# Code-spec context (injected into implement/check/debug agents via JSONL)
+python3 ./.trellis/scripts/task.py init-context <name> <type>     # Initialize jsonl files (type: backend|frontend|fullstack|test|docs)
+python3 ./.trellis/scripts/task.py add-context <name> <action> <file> <reason>   # Add entry to <action>.jsonl
+python3 ./.trellis/scripts/task.py list-context <name> [action]   # Show configured context files
+python3 ./.trellis/scripts/task.py validate <name>                # Validate jsonl references exist
+
+# Task metadata
+python3 ./.trellis/scripts/task.py set-branch <name> <branch>     # Set git branch for the task
+python3 ./.trellis/scripts/task.py set-base-branch <name> <branch>  # Set PR target branch
+python3 ./.trellis/scripts/task.py set-scope <name> <scope>       # Set task scope
+
+# Hierarchy (parent/child tasks)
+python3 ./.trellis/scripts/task.py add-subtask <parent> <child>   # Link child task to parent
+python3 ./.trellis/scripts/task.py remove-subtask <parent> <child>  # Unlink child from parent
+
+# PR creation
+python3 ./.trellis/scripts/task.py create-pr [name] [--dry-run]   # Create PR for current or specified task
 ```
+
+> Run `python3 ./.trellis/scripts/task.py --help` to see the complete up-to-date list.
 
 **Current task mechanism**: `task.py start <name>` writes the selected task path to `.trellis/.current-task`. The SessionStart hook reads this file to inject `## CURRENT TASK` into every new session's context, so the AI immediately knows what you're working on without being told. Run `task.py finish` when you're done — subsequent sessions will show `(none)` until you start another task.
 


### PR DESCRIPTION
## Summary

The **Commands** block in `workflow.md` and the **AI Scripts** table in `start.md` currently list only **6 of the 16** subcommands that `task.py` actually exposes. AI agents reading these docs don't discover `init-context`, `add-context`, `validate`, `list-context`, `set-branch`, `set-base-branch`, `set-scope`, `create-pr`, `add-subtask`, `remove-subtask` — so when they need to configure context injection, set a PR target branch, or link subtasks, they fall back to hand-editing `task.json` when a legitimate subcommand would have done the job.

## Problem

### Before this PR: `workflow.md` → **Task Tracking → Commands**

```bash
python3 ./.trellis/scripts/task.py create …
python3 ./.trellis/scripts/task.py start <name>
python3 ./.trellis/scripts/task.py finish
python3 ./.trellis/scripts/task.py archive <name>
python3 ./.trellis/scripts/task.py list
python3 ./.trellis/scripts/task.py list-archive
```

**6 commands.**

### Before this PR: `start.md` → **Commands Reference → AI Scripts**

```
create | init-context | add-context | start | finish | archive   (+ get_context)
```

**6 + 1 commands.**

### Actual `task.py --help` output

```
create | init-context | add-context | validate | list-context |
start | finish | set-branch | set-base-branch | set-scope |
create-pr | archive | list | add-subtask | remove-subtask | list-archive
```

**16 subcommands.**

## Downstream visible impact

An AI agent following `start.md` Phase 2 will hit `init-context` / `add-context` — those two are mentioned in the prose body of `start.md` (Steps 6–7), so they get discovered incidentally. But the rest (`validate`, `list-context`, `set-branch`, `set-base-branch`, `set-scope`, `add-subtask`, `remove-subtask`, `create-pr`) appear nowhere in the quick-reference tables. If the agent's working context later drops the Phase 2 prose (common under auto-compaction), it has to rediscover them by reading Python source or running `--help` — which, in practice, is exactly what happened to me in the session that motivated this PR.

The impact is mildly worse for `list-context` and `validate`, which have no mention anywhere else in either file — so they're effectively invisible to agents who read only the two command tables.

## Root cause

The tables in `workflow.md` (Task Tracking → Commands) and `start.md` (Commands Reference → AI Scripts) haven't been updated as `task.py` grew. `task.py --help` enumerates all 16 subcommands correctly; these two Markdown tables were not kept in sync.

No code change is required — only the documentation tables.

## Fix

Replace both tables with a complete, grouped list:

- **Task lifecycle** (create / start / finish / archive / list / list-archive)
- **Code-spec context (jsonl injection)** (init-context / add-context / list-context / validate)
- **Task metadata** (set-branch / set-base-branch / set-scope)
- **Hierarchy** (add-subtask / remove-subtask)
- **PR creation** (create-pr)

Added a single pointer line after each table:

> \`Run \`python3 ./.trellis/scripts/task.py --help\` to see the complete up-to-date list.\`

…so the docs degrade gracefully if new subcommands are added in the future before the tables are next touched.

Applied to all four locations per CONTRIBUTING guidance that changes to \`.claude/\` and \`.trellis/\` must be mirrored in \`src/templates/\`:

- \`.trellis/workflow.md\` (dogfood copy)
- \`packages/cli/src/templates/trellis/workflow.md\` (install template)
- \`.claude/commands/trellis/start.md\` (dogfood copy)
- \`packages/cli/src/templates/claude/commands/trellis/start.md\` (install template)

## Reproduction

```bash
git clone https://github.com/mindfold-ai/Trellis.git /tmp/trellis-repro
cd /tmp/trellis-repro

# Count subcommands visible in Task Tracking → Commands block of workflow.md
grep -A 10 '^\*\*Commands\*\*:' .trellis/workflow.md | grep -c 'task\.py'
# Output: 6

# Count subcommands task.py actually exposes
python3 ./.trellis/scripts/task.py --help 2>&1 | grep -oE '\{[^}]+\}' | tr ',' '\n' | wc -l
# Output: 16
```

**Before this PR:** `6 ≠ 16` (10 subcommands invisible in the quick-reference tables).
**After this PR:** `16 = 16`.

## Follow-up not in this PR: other AI tool templates

Only the `claude` template is touched. The `cursor`, `opencode`, `codebuddy`, `droid`, `iflow`, `kilo`, and `windsurf` templates under `packages/cli/src/templates/*/` each have their own \`start.md\` (or \`trellis-start.md\`) with similar task.py reference tables that are likely to have the same gap. I kept this PR minimal so reviewer can block/approve the pattern once; happy to open a follow-up PR covering the other templates if desired.

## Scope

- 4 files: 2 \`workflow.md\` copies (dogfood + template), 2 \`start.md\` copies (claude dogfood + claude template)
- 88 insertions, 12 deletions
- No code changes — docs only
- No API, type, or schema changes

## Test plan

- [x] \`pnpm lint\` — not relevant (markdown-only PR, ESLint only lints \`.ts\`)
- [x] \`pnpm typecheck\` — not relevant (no TypeScript touched)
- [x] Pre-commit hooks — not triggered (they apply to staged \`.ts\` only per CONTRIBUTING)
- [x] Manual verification: every subcommand listed in the new tables appears in \`python3 ./.trellis/scripts/task.py --help\`

## Related

- No existing issue or PR found via search for \`workflow.md\`, \`task.py\`, \`AI Scripts\`, \`Commands Reference\`, \`init-context\` on this repo
- Surfaced during a real Trellis session where Claude needed to advance a task's phase and status; spent several minutes rediscovering \`task.py start\` by reading source because it wasn't in the visible command table