### PR TITLE
fix(cli): compress spec index injection and fix CLI distribution regression (#177)

### DIFF
--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -324,7 +324,11 @@ def main():
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)

--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -321,6 +321,11 @@ def main():
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", ".")).resolve()
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)
     allowed_pkgs = _resolve_spec_scope(is_mono, packages, scope_config, task_pkg, default_pkg)
@@ -349,8 +354,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -363,7 +371,7 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
@@ -371,7 +379,7 @@ Read and follow all instructions below carefully.
             if index_file.is_file():
                 # Flat spec dir (single-repo layer like spec/backend/)
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 # Nested package dirs (monorepo: spec/<pkg>/<layer>/index.md)
@@ -384,7 +392,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -394,8 +402,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -164,6 +164,11 @@ def main() -> None:
 
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     output = StringIO()
 
     output.write("""<session-context>
@@ -183,8 +188,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -196,14 +204,14 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
             index_file = sub / "index.md"
             if index_file.is_file():
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 for nested in sorted(sub.iterdir()):
@@ -212,7 +220,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -221,8 +229,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -167,7 +167,11 @@ def main() -> None:
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     output = StringIO()
 

--- a/.trellis/scripts/common/spec_index_toc.py
+++ b/.trellis/scripts/common/spec_index_toc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Condensed spec index.md text for SessionStart additionalContext.
+
+Extracts the primary ``Guide`` markdown table, a short Pre-Development Checklist
+excerpt, and all ``##`` headings so models can lazy-load full files via Read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def spec_index_display_path(project_dir: Path, spec_index_path: Path) -> str:
+    """Path to show in injected context (relative to repo root when possible)."""
+    try:
+        rel = spec_index_path.resolve().relative_to(project_dir.resolve())
+        return str(rel).replace("\\", "/")
+    except ValueError:
+        return str(spec_index_path).replace("\\", "/")
+
+
+def _md_row_first_cell(line: str) -> str | None:
+    """First logical cell of a markdown pipe table row (handles padded columns)."""
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    parts = [p.strip() for p in stripped.split("|")]
+    while parts and parts[0] == "":
+        parts.pop(0)
+    while parts and parts[-1] == "":
+        parts.pop(-1)
+    if not parts:
+        return None
+    return parts[0]
+
+
+def build_spec_index_toc(spec_index_path: Path, project_dir: Path) -> str:
+    """Build condensed text for one spec ``index.md`` (full file via Read)."""
+    try:
+        content = spec_index_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+    lines = content.splitlines()
+    display = spec_index_display_path(project_dir, spec_index_path)
+    toc_lines: list[str] = [
+        f"Full index: {display}  (read on demand with the Read tool)",
+        "",
+    ]
+
+    in_guide_table = False
+    for line in lines:
+        first = _md_row_first_cell(line)
+        if not in_guide_table and first == "Guide":
+            in_guide_table = True
+        if in_guide_table:
+            stripped = line.strip()
+            # Markdown horizontal rule (---) ends the table; do not treat pipe-table
+            # alignment rows like "| ----------------------------------------------- |" as HR.
+            if stripped.startswith("---") and not stripped.startswith("|"):
+                break
+            if line.startswith("## "):
+                break
+            toc_lines.append(line)
+
+    for i, line in enumerate(lines):
+        if line.strip() == "## Pre-Development Checklist":
+            toc_lines.append("")
+            for j in range(i + 1, min(i + 10, len(lines))):
+                sj = lines[j].strip()
+                if (sj.startswith("---") and not sj.startswith("|")) or lines[j].startswith(
+                    "## "
+                ):
+                    break
+                if lines[j].strip():
+                    toc_lines.append(lines[j])
+            break
+
+    headings = [ln for ln in lines if ln.startswith("## ")]
+    if headings:
+        toc_lines.append("")
+        toc_lines.append("Section headings in this index:")
+        toc_lines.extend(headings)
+
+    return "\n".join(toc_lines)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Browse available templates and learn how to publish your own on the [Spec Templa
 <details>
 <summary><strong>How is this different from <code>CLAUDE.md</code>, <code>AGENTS.md</code>, or <code>.cursorrules</code>?</strong></summary>
 
-Those files are useful, but they tend to become monolithic. Trellis adds structure around them: layered specs, task context, workspace memory, and platform-aware workflow wiring.
+Those files are useful, but they tend to become monolithic. Trellis adds structure around them: layered specs, task context, workspace memory, and platform-aware workflow wiring. Rather than loading all specs at once, Trellis injects spec indexes as compact tables of contents — the full guidelines are accessible on demand via the `Read` tool when you need them.
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -146,7 +146,7 @@ trellis init --registry https://github.com/your-org/your-spec-templates
 <details>
 <summary><strong>它和 <code>CLAUDE.md</code>、<code>AGENTS.md</code>、<code>.cursorrules</code> 有什么区别？</strong></summary>
 
-这些文件当然有用，但它们很容易越写越大、越写越散。Trellis 在它们之外补上了结构：分层 Spec、任务上下文、workspace 记忆，以及按平台接入的工作流。
+这些文件当然有用，但它们很容易越写越大、越写越散。Trellis 在它们之外补上了结构：分层 Spec、任务上下文、workspace 记忆，以及按平台接入的工作流。Trellis 不一次性加载全部规范，而是将 spec 索引作为紧凑的目录表注入——完整的指南在你需要时通过 `Read` 工具按需读取。
 
 </details>
 

--- a/packages/cli/src/templates/claude/hooks/session-start.py
+++ b/packages/cli/src/templates/claude/hooks/session-start.py
@@ -324,7 +324,11 @@ def main():
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)

--- a/packages/cli/src/templates/claude/hooks/session-start.py
+++ b/packages/cli/src/templates/claude/hooks/session-start.py
@@ -321,6 +321,11 @@ def main():
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", ".")).resolve()
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)
     allowed_pkgs = _resolve_spec_scope(is_mono, packages, scope_config, task_pkg, default_pkg)
@@ -349,8 +354,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -363,7 +371,7 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
@@ -371,7 +379,7 @@ Read and follow all instructions below carefully.
             if index_file.is_file():
                 # Flat spec dir (single-repo layer like spec/backend/)
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 # Nested package dirs (monorepo: spec/<pkg>/<layer>/index.md)
@@ -384,7 +392,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -394,8 +402,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -164,6 +164,11 @@ def main() -> None:
 
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     output = StringIO()
 
     output.write("""<session-context>
@@ -183,8 +188,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -196,14 +204,14 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
             index_file = sub / "index.md"
             if index_file.is_file():
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 for nested in sorted(sub.iterdir()):
@@ -212,7 +220,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -221,8 +229,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -167,7 +167,11 @@ def main() -> None:
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     output = StringIO()
 

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -164,6 +164,11 @@ def main() -> None:
 
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     output = StringIO()
 
     output.write("""<session-context>
@@ -183,8 +188,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -196,14 +204,14 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
             index_file = sub / "index.md"
             if index_file.is_file():
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 for nested in sorted(sub.iterdir()):
@@ -212,7 +220,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -221,8 +229,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -167,7 +167,11 @@ def main() -> None:
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     output = StringIO()
 

--- a/packages/cli/src/templates/iflow/hooks/session-start.py
+++ b/packages/cli/src/templates/iflow/hooks/session-start.py
@@ -312,6 +312,11 @@ def main():
     project_dir = Path(".").resolve()
     trellis_dir = project_dir / ".trellis"
 
+    scripts_dir = trellis_dir / "scripts"
+    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from common.spec_index_toc import build_spec_index_toc
+
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)
     allowed_pkgs = _resolve_spec_scope(is_mono, packages, scope_config, task_pkg, default_pkg)
@@ -340,8 +345,11 @@ Read and follow all instructions below carefully.
     output.write("\n</workflow>\n\n")
 
     output.write("<guidelines>\n")
-    output.write("**Note**: The guidelines below are index files — they list available guideline documents and their locations.\n")
-    output.write("During actual development, you MUST read the specific guideline files listed in each index's Pre-Development Checklist.\n\n")
+    output.write(
+        "**Note**: Each block below is a **condensed** spec index: the primary `Guide` table (when present), "
+        "a short **Pre-Development Checklist** excerpt (when present), and all `##` section headings. "
+        "Before coding, use the Read tool on the `Full index:` path and on any linked guideline files you need.\n\n"
+    )
 
     spec_dir = trellis_dir / "spec"
     if spec_dir.is_dir():
@@ -354,14 +362,14 @@ Read and follow all instructions below carefully.
                 index_file = sub / "index.md"
                 if index_file.is_file():
                     output.write(f"## {sub.name}\n")
-                    output.write(read_file(index_file))
+                    output.write(build_spec_index_toc(index_file, project_dir))
                     output.write("\n\n")
                 continue
 
             index_file = sub / "index.md"
             if index_file.is_file():
                 output.write(f"## {sub.name}\n")
-                output.write(read_file(index_file))
+                output.write(build_spec_index_toc(index_file, project_dir))
                 output.write("\n\n")
             else:
                 # Apply scope filter for monorepo packages
@@ -373,7 +381,7 @@ Read and follow all instructions below carefully.
                     nested_index = nested / "index.md"
                     if nested_index.is_file():
                         output.write(f"## {sub.name}/{nested.name}\n")
-                        output.write(read_file(nested_index))
+                        output.write(build_spec_index_toc(nested_index, project_dir))
                         output.write("\n\n")
 
     output.write("</guidelines>\n\n")
@@ -383,8 +391,11 @@ Read and follow all instructions below carefully.
     output.write(f"<task-status>\n{task_status}\n</task-status>\n\n")
 
     output.write("""<ready>
-Context loaded. Workflow index, project state, and guidelines are already injected above — do NOT re-read them.
-Wait for the user's first message, then handle it following the workflow guide.
+Context loaded: workflow section index, current project state, and condensed spec indexes are injected above.
+
+Full `.trellis/workflow.md` and spec `index.md` files are not fully inlined. When you need details, use the Read tool on `.trellis/workflow.md` or on the `Full index:` paths shown under `.trellis/spec/`.
+
+Wait for the user's first message, then follow the workflow guide.
 If there is an active task, ask whether to continue it.
 </ready>""")
 

--- a/packages/cli/src/templates/iflow/hooks/session-start.py
+++ b/packages/cli/src/templates/iflow/hooks/session-start.py
@@ -315,7 +315,11 @@ def main():
     scripts_dir = trellis_dir / "scripts"
     if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
         sys.path.insert(0, str(scripts_dir))
-    from common.spec_index_toc import build_spec_index_toc
+    try:
+        from common.spec_index_toc import build_spec_index_toc
+    except ImportError:
+        def build_spec_index_toc(path, project_dir):  # type: ignore[misc]
+            return read_file(path)
 
     # Load config for scope filtering and legacy detection
     is_mono, packages, scope_config, task_pkg, default_pkg = _load_trellis_config(trellis_dir)

--- a/packages/cli/src/templates/trellis/index.ts
+++ b/packages/cli/src/templates/trellis/index.ts
@@ -57,6 +57,9 @@ export const commonSessionContext = readTemplate(
 export const commonPackagesContext = readTemplate(
   "scripts/common/packages_context.py",
 );
+export const commonSpecIndexToc = readTemplate(
+  "scripts/common/spec_index_toc.py",
+);
 
 // Python scripts - multi_agent
 export const multiAgentInit = readTemplate("scripts/multi_agent/__init__.py");
@@ -120,6 +123,7 @@ export function getAllScripts(): Map<string, string> {
   scripts.set("common/task_store.py", commonTaskStore);
   scripts.set("common/session_context.py", commonSessionContext);
   scripts.set("common/packages_context.py", commonPackagesContext);
+  scripts.set("common/spec_index_toc.py", commonSpecIndexToc);
 
   // Multi-agent
   scripts.set("multi_agent/__init__.py", multiAgentInit);

--- a/packages/cli/src/templates/trellis/scripts/common/spec_index_toc.py
+++ b/packages/cli/src/templates/trellis/scripts/common/spec_index_toc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Condensed spec index.md text for SessionStart additionalContext.
+
+Extracts the primary ``Guide`` markdown table, a short Pre-Development Checklist
+excerpt, and all ``##`` headings so models can lazy-load full files via Read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def spec_index_display_path(project_dir: Path, spec_index_path: Path) -> str:
+    """Path to show in injected context (relative to repo root when possible)."""
+    try:
+        rel = spec_index_path.resolve().relative_to(project_dir.resolve())
+        return str(rel).replace("\\", "/")
+    except ValueError:
+        return str(spec_index_path).replace("\\", "/")
+
+
+def _md_row_first_cell(line: str) -> str | None:
+    """First logical cell of a markdown pipe table row (handles padded columns)."""
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    parts = [p.strip() for p in stripped.split("|")]
+    while parts and parts[0] == "":
+        parts.pop(0)
+    while parts and parts[-1] == "":
+        parts.pop(-1)
+    if not parts:
+        return None
+    return parts[0]
+
+
+def build_spec_index_toc(spec_index_path: Path, project_dir: Path) -> str:
+    """Build condensed text for one spec ``index.md`` (full file via Read)."""
+    try:
+        content = spec_index_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+    lines = content.splitlines()
+    display = spec_index_display_path(project_dir, spec_index_path)
+    toc_lines: list[str] = [
+        f"Full index: {display}  (read on demand with the Read tool)",
+        "",
+    ]
+
+    in_guide_table = False
+    for line in lines:
+        first = _md_row_first_cell(line)
+        if not in_guide_table and first == "Guide":
+            in_guide_table = True
+        if in_guide_table:
+            stripped = line.strip()
+            # Markdown horizontal rule (---) ends the table; do not treat pipe-table
+            # alignment rows like "| ----------------------------------------------- |" as HR.
+            if stripped.startswith("---") and not stripped.startswith("|"):
+                break
+            if line.startswith("## "):
+                break
+            toc_lines.append(line)
+
+    for i, line in enumerate(lines):
+        if line.strip() == "## Pre-Development Checklist":
+            toc_lines.append("")
+            for j in range(i + 1, min(i + 10, len(lines))):
+                sj = lines[j].strip()
+                if (sj.startswith("---") and not sj.startswith("|")) or lines[j].startswith(
+                    "## "
+                ):
+                    break
+                if lines[j].strip():
+                    toc_lines.append(lines[j])
+            break
+
+    headings = [ln for ln in lines if ln.startswith("## ")]
+    if headings:
+        toc_lines.append("")
+        toc_lines.append("Section headings in this index:")
+        toc_lines.extend(headings)
+
+    return "\n".join(toc_lines)


### PR DESCRIPTION
## What

Fixes #177.

The README FAQ described spec guidance as loaded on-demand, but
`session-start` was inlining the full content of every `index.md` on
every session start. This PR implements the described behavior and fixes
a distribution bug introduced in the process.

## Changes

**`5e046d7` — feat(session-start): compress spec index injection via spec_index_toc**

- Add `spec_index_toc.py` — extracts a condensed TOC from each spec
  `index.md`: Guide table, Pre-Development Checklist excerpt (≤10 lines),
  all `##` headings, and a `Full index:` path for on-demand reading
- Replace `read_file(index_file)` with `build_spec_index_toc()` across
  all 6 session-start hook variants (`.claude`, `.codex`, and the
  `claude` / `codex` / `copilot` / `iflow` CLI templates)
- Update `README.md` and `README_CN.md` FAQ to match actual behavior

**`950dd07` — fix(cli): register spec_index_toc in getAllScripts and add ImportError fallback**

- Export `commonSpecIndexToc` and register `common/spec_index_toc.py`
  in `getAllScripts()` (`packages/cli/src/templates/trellis/index.ts`),
  which is the single source of truth for both `trellis init` and
  `trellis update` — without this, the file would never reach user projects
- Wrap the runtime import in `try/except ImportError` across all 6 hook
  variants; missing file degrades silently to full `index.md` injection

## Validation

Measured on this repo:

| | Before | After |
|:--|--:|--:|
| Total `additionalContext` | 12 063 chars | 5 797 chars |
| `<guidelines>` section | 10 932 chars | 4 475 chars |
| Reduction | | **−59 %** |

Compatibility verified:

| Scenario | Result |
|:--|:--|
| `trellis init` (new users) | ✅ file written, TOC injected |
| `trellis update` (existing users) | ✅ file added as new, auto-written |
| Users who do not update | ✅ old hooks untouched |
| Hook updated, file missing | ✅ `ImportError` fallback, full injection |
| Spec index without `Guide` table | ✅ checklist + headings still extracted |
| Empty / unreadable `index.md` | ✅ returns `""`, hook continues |

## Checklist

- [x] Changes limited to `packages/cli` and hook files, no user data touched
- [x] Both `.claude` and `.codex` hooks updated in sync with CLI templates
- [x] `getAllScripts()` registration confirmed as single source of truth
  (verified in `packages/cli/src/commands/update.ts` line 357–360)
- [x] Backward-compatible — `ImportError` fallback ensures no breakage
  on older installs