### PR TITLE
fix: use platform-aware Python command in agent prelude and session-start hooks

### DIFF
--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -357,18 +357,19 @@ export function buildPullBasedPrelude(agentType: SubAgentType): string {
   // JSONL filenames stay as implement.jsonl / check.jsonl — they are internal
   // context buckets keyed by role (not by platform-visible agent name).
   const jsonl = agentType === "check" ? "check.jsonl" : "implement.jsonl";
+  const pythonCmd = getPythonCommandForPlatform();
 
   return `## Required: Load Trellis Context First
 
 This platform does NOT auto-inject task context via hook. Before doing anything else, you MUST load context yourself:
 
-1. Run \`python3 ./.trellis/scripts/task.py current --source\` to find the active task path and source (e.g. \`Current task: .trellis/tasks/04-17-foo\`).
+1. Run \`${pythonCmd} ./.trellis/scripts/task.py current --source\` to find the active task path and source (e.g. \`Current task: .trellis/tasks/04-17-foo\`).
 2. Read the task's \`prd.md\` (requirements) and \`info.md\` if it exists (technical design).
 3. Read \`<task-path>/${jsonl}\` — JSONL list of dev spec files relevant to this agent.
 4. For each entry in the JSONL, Read its \`file\` path — these are the dev specs you must follow.
    **Skip rows without a \`"file"\` field** (e.g. \`{"_example": "..."}\` seed rows left over from \`task.py create\` before the curator ran).
 
-If \`${jsonl}\` has no curated entries (only a seed row, or the file is missing), fall back to: read \`prd.md\`, list available specs with \`python3 ./.trellis/scripts/get_context.py --mode packages\`, and pick the specs that match the task domain yourself. Do NOT block on the missing jsonl — proceed with prd-only context plus your spec judgment.
+If \`${jsonl}\` has no curated entries (only a seed row, or the file is missing), fall back to: read \`prd.md\`, list available specs with \`${pythonCmd} ./.trellis/scripts/get_context.py --mode packages\`, and pick the specs that match the task domain yourself. Do NOT block on the missing jsonl — proceed with prd-only context plus your spec judgment.
 
 If there is no active task or the task has no \`prd.md\`, ask the user what to work on; do NOT proceed without context.
 

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -258,6 +258,16 @@ def _build_workflow_toc(workflow_path: Path) -> str:
     return "\n".join(out_lines).rstrip()
 
 
+def _emit_platform_info(output):
+    """Emit platform-specific command information."""
+    python_cmd = "python" if sys.platform.startswith("win") else "python3"
+    output.write("<platform-info>\n")
+    output.write(f"OS: {sys.platform}\n")
+    output.write(f"Python command: {python_cmd}\n")
+    output.write(f"IMPORTANT: When executing Python scripts, always use `{python_cmd}` not the other variant.\n")
+    output.write("</platform-info>\n\n")
+
+
 def main() -> None:
     if should_skip_injection():
         sys.exit(0)
@@ -287,6 +297,8 @@ Read and follow all instructions below carefully.
 """)
     output.write(FIRST_REPLY_NOTICE)
     output.write("\n\n")
+
+    _emit_platform_info(output)
 
     output.write("<current-state>\n")
     context_script = trellis_dir / "scripts" / "get_context.py"

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -254,6 +254,16 @@ def _build_workflow_toc(workflow_path: Path) -> str:
     return "\n".join(out_lines).rstrip()
 
 
+def _emit_platform_info(output):
+    """Emit platform-specific command information."""
+    python_cmd = "python" if sys.platform.startswith("win") else "python3"
+    output.write("<platform-info>\n")
+    output.write(f"OS: {sys.platform}\n")
+    output.write(f"Python command: {python_cmd}\n")
+    output.write(f"IMPORTANT: When executing Python scripts, always use `{python_cmd}` not the other variant.\n")
+    output.write("</platform-info>\n\n")
+
+
 def main() -> None:
     if should_skip_injection():
         sys.exit(0)
@@ -281,6 +291,8 @@ Read and follow all instructions below carefully.
 </session-context>
 
 """)
+
+    _emit_platform_info(output)
 
     output.write("<current-state>\n")
     context_script = trellis_dir / "scripts" / "get_context.py"

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -562,6 +562,16 @@ def _build_workflow_overview(workflow_path: Path) -> str:
     return "\n".join(out_lines).rstrip()
 
 
+def _emit_platform_info(output):
+    """Emit platform-specific command information."""
+    python_cmd = "python" if sys.platform.startswith("win") else "python3"
+    output.write("<platform-info>\n")
+    output.write(f"OS: {sys.platform}\n")
+    output.write(f"Python command: {python_cmd}\n")
+    output.write(f"IMPORTANT: When executing Python scripts, always use `{python_cmd}` not the other variant.\n")
+    output.write("</platform-info>\n\n")
+
+
 def main():
     if should_skip_injection():
         sys.exit(0)
@@ -614,6 +624,8 @@ Read and follow all instructions below carefully.
 """)
     output.write(FIRST_REPLY_NOTICE)
     output.write("\n\n")
+
+    _emit_platform_info(output)
 
     # Legacy migration warning
     legacy_warning = _check_legacy_spec(trellis_dir, is_mono, packages)

--- a/packages/cli/src/templates/trellis/workflow.md
+++ b/packages/cli/src/templates/trellis/workflow.md
@@ -1,5 +1,7 @@
 # Development Workflow
 
+> **Platform Note**: All `python3` commands in this document should be run as `python` on Windows.
+
 ---
 
 ## Core Principles


### PR DESCRIPTION
## Summary
  Fix: #218 hardcoded `python3` commands that break on Windows (where Python is `python`).

  ## Problem

  Trellis templates hardcode `python3` in agent preludes, session-start hooks, and workflow.md. On
  Windows the Python command is `python`, so AI agents executing template commands hit `'python3' is not
  recognized` errors.

  An existing `getPythonCommandForPlatform()` helper and `{{PYTHON_CMD}}` placeholder system already
  handle JSON config files correctly, but several code paths bypass the placeholder pipeline entirely.

  ## Lightweight Fix (5 files, +41/-2)

  ### 1. Code-level: `buildPullBasedPrelude()` type safety
  `packages/cli/src/configurators/shared.ts`

  The function that generates agent prelude text for 7 pull-based platforms (Codex, Copilot, Gemini,
  Qoder, CodeBuddy, Droid, Pi) now calls `getPythonCommandForPlatform()` instead of hardcoding `python3`.
   This is the only code-level fix — agent files written by `trellis init`/`trellis update` now contain
  the correct command.

  ### 2. Cognitive injection: session-start hooks
  `packages/cli/src/templates/shared-hooks/session-start.py`
  `packages/cli/src/templates/codex/hooks/session-start.py`
  `packages/cli/src/templates/copilot/hooks/session-start.py`

  Each hook now emits a `<platform-info>` block at session start telling the AI which Python command to
  use on the current OS. The AI adapts hardcoded `python3` references in templates accordingly.

  ### 3. Static hint: workflow.md
  `packages/cli/src/templates/trellis/workflow.md`

  Added a platform note below the title so AI agents reading the workflow guide know to remap commands on
   Windows.

  ## Platform coverage

  | Platform | Mechanism |
  |----------|-----------|
  | Codex, Copilot, Gemini, Qoder, CodeBuddy, Droid, Pi | pull-based prelude + session-start + workflow
  note |
  | Claude Code, Cursor, Kiro | session-start + workflow note |
  | Kilo, Antigravity, Windsurf | workflow note |
  | OpenCode | already has JS `PYTHON_CMD` detection |

  ## Verification

  - [x] Build passes
  - [x] TypeCheck passes
  - [x] Lint passes (eslint + prettier)
  - [x] Existing tests pass (763 passed, 24 pre-existing CRLF failures unrelated)
  - [x] Manually verified on Windows: AI correctly uses `python` instead of `python3`

  |----------|-----------|
  | Codex, Copilot, Gemini, Qoder, CodeBuddy, Droid, Pi | pull-based prelude + session-start + workflow

  | Platform | Mechanism |
  |----------|-----------|
  | Codex, Copilot, Gemini, Qoder, CodeBuddy, Droid, Pi | pull-based prelude + session-start + workflow
  note |
  | Claude Code, Cursor, Kiro | session-start + workflow note |
  | Kilo, Antigravity, Windsurf | workflow note |
  | OpenCode | already has JS `PYTHON_CMD` detection |

  ## Verification

  - [x] Build passes
  - [x] TypeCheck passes
  - [x] Lint passes (eslint + prettier)
  - [x] Existing tests pass (763 passed, 24 pre-existing CRLF failures unrelated)
  - [x] Manually verified on Windows: AI correctly uses `python` instead of `python3`

  ## Test plan

  1. On Windows, run `trellis init` — check that agent files contain `python` not `python3`
  2. Start an AI session — check session-start hook output contains `<platform-info>OS: win32`
  3. Verify `.trellis/workflow.md` has the platform note