### PR TITLE
fix: replace python3 with python on Windows at init/update write time

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -49,6 +49,7 @@ import {
   isManagedPath,
   isManagedRootDir,
 } from "../configurators/index.js";
+import { replacePythonCommandLiterals } from "../configurators/shared.js";
 
 export interface UpdateOptions {
   dryRun?: boolean;
@@ -675,6 +676,11 @@ function collectTemplateFiles(
         }
       }
     }
+  }
+
+  // Apply python3→python replacement for Windows consistency with init-time writes
+  for (const [filePath, content] of files) {
+    files.set(filePath, replacePythonCommandLiterals(content));
   }
 
   return files;

--- a/packages/cli/src/configurators/claude.ts
+++ b/packages/cli/src/configurators/claude.ts
@@ -10,6 +10,7 @@ import {
   resolveBundledSkills,
   writeSkills,
   writeSharedHooks,
+  replacePythonCommandLiterals,
 } from "./shared.js";
 
 const EXCLUDE_PATTERNS = [
@@ -56,7 +57,7 @@ async function copyDirFiltered(
       if (entry === "settings.json") {
         content = resolvePlaceholders(content);
       }
-      await writeFile(destPath, content);
+      await writeFile(destPath, replacePythonCommandLiterals(content));
     }
   }
 }

--- a/packages/cli/src/configurators/codex.ts
+++ b/packages/cli/src/configurators/codex.ts
@@ -15,6 +15,7 @@ import {
   applyPullBasedPreludeToml,
   writeSkills,
   writeSharedHooks,
+  replacePythonCommandLiterals,
 } from "./shared.js";
 
 /**
@@ -41,7 +42,10 @@ export async function configureCodex(cwd: string): Promise<void> {
   for (const skill of getAllCodexSkills()) {
     const skillDir = path.join(codexSkillsRoot, skill.name);
     ensureDir(skillDir);
-    await writeFile(path.join(skillDir, "SKILL.md"), skill.content);
+    await writeFile(
+      path.join(skillDir, "SKILL.md"),
+      replacePythonCommandLiterals(skill.content),
+    );
   }
 
   // Custom agents → .codex/agents/
@@ -54,7 +58,7 @@ export async function configureCodex(cwd: string): Promise<void> {
   for (const agent of applyPullBasedPreludeToml(getAllAgents())) {
     await writeFile(
       path.join(codexAgentsRoot, `${agent.name}.toml`),
-      agent.content,
+      replacePythonCommandLiterals(agent.content),
     );
   }
 
@@ -64,7 +68,10 @@ export async function configureCodex(cwd: string): Promise<void> {
 
   // Codex-specific hooks (e.g., session-start.py tailored for Codex)
   for (const hook of getAllHooks()) {
-    await writeFile(path.join(hooksDir, hook.name), hook.content);
+    await writeFile(
+      path.join(hooksDir, hook.name),
+      replacePythonCommandLiterals(hook.content),
+    );
   }
 
   // Shared hooks (inject-workflow-state.py only). Codex bundles its own
@@ -91,5 +98,8 @@ export async function configureCodex(cwd: string): Promise<void> {
 
   // Config → .codex/config.toml
   const config = getConfigTemplate();
-  await writeFile(path.join(codexRoot, config.targetPath), config.content);
+  await writeFile(
+    path.join(codexRoot, config.targetPath),
+    replacePythonCommandLiterals(config.content),
+  );
 }

--- a/packages/cli/src/configurators/copilot.ts
+++ b/packages/cli/src/configurators/copilot.ts
@@ -10,6 +10,7 @@ import {
   applyPullBasedPreludeMarkdown,
   writeSkills,
   writeSharedHooks,
+  replacePythonCommandLiterals,
 } from "./shared.js";
 
 /**
@@ -50,7 +51,7 @@ export async function configureCopilot(cwd: string): Promise<void> {
   for (const agent of applyPullBasedPreludeMarkdown(getCursorAgents())) {
     await writeFile(
       path.join(agentsDir, `${agent.name}.agent.md`),
-      agent.content,
+      replacePythonCommandLiterals(agent.content),
     );
   }
 
@@ -58,7 +59,10 @@ export async function configureCopilot(cwd: string): Promise<void> {
   const hooksDir = path.join(copilotRoot, "hooks");
   ensureDir(hooksDir);
   for (const hook of getAllHooks()) {
-    await writeFile(path.join(hooksDir, hook.name), hook.content);
+    await writeFile(
+      path.join(hooksDir, hook.name),
+      replacePythonCommandLiterals(hook.content),
+    );
   }
 
   // Shared hook scripts (inject-workflow-state.py only). Copilot bundles its

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -35,6 +35,7 @@ import { configurePi, collectPiTemplates } from "./pi.js";
 
 // Shared utilities
 import {
+  replacePythonCommandLiterals,
   resolvePlaceholders,
   resolveAllAsSkills,
   resolveBundledSkills,
@@ -116,6 +117,15 @@ function collectSharedHooks(
     files.set(`${hooksPath}/${hook.name}`, hook.content);
   }
   return files;
+}
+
+/** Apply python3→python replacement to all content in a template map. */
+function replaceInMap(map: Map<string, string>): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const [key, content] of map) {
+    result.set(key, replacePythonCommandLiterals(content));
+  }
+  return result;
 }
 
 /** Helper: collect commands + skills for "both" platforms */
@@ -503,7 +513,8 @@ export function configurePlatform(
 export function collectPlatformTemplates(
   platformId: AITool,
 ): Map<string, string> | undefined {
-  return PLATFORM_FUNCTIONS[platformId].collectTemplates?.();
+  const map = PLATFORM_FUNCTIONS[platformId].collectTemplates?.();
+  return map ? replaceInMap(map) : map;
 }
 
 /**

--- a/packages/cli/src/configurators/opencode.ts
+++ b/packages/cli/src/configurators/opencode.ts
@@ -6,6 +6,7 @@ import { ensureDir, writeFile } from "../utils/file-writer.js";
 import { toPosix } from "../utils/posix.js";
 import {
   collectSkillTemplates,
+  replacePythonCommandLiterals,
   resolveBundledSkills,
   resolveCommands,
   resolveSkills,
@@ -63,7 +64,10 @@ function walkOpenCodeTemplateDir(): Map<string, string> {
         const content = readFileSync(absEntry, "utf-8");
         // Map keys are logical paths used as cross-platform hash keys / lookup
         // keys downstream. Always POSIX, regardless of host OS.
-        files.set(toPosix(path.join(".opencode", relEntry)), content);
+        files.set(
+          toPosix(path.join(".opencode", relEntry)),
+          replacePythonCommandLiterals(content),
+        );
       }
     }
   }

--- a/packages/cli/src/configurators/pi.ts
+++ b/packages/cli/src/configurators/pi.ts
@@ -4,6 +4,7 @@ import { ensureDir, writeFile } from "../utils/file-writer.js";
 import {
   applyPullBasedPreludeMarkdown,
   collectSkillTemplates,
+  replacePythonCommandLiterals,
   resolveCommands,
   resolveBundledSkills,
   resolvePlaceholders,
@@ -80,7 +81,7 @@ export async function configurePi(cwd: string): Promise<void> {
   ensureDir(path.join(configRoot, "extensions", "trellis"));
   await writeFile(
     path.join(configRoot, "extensions", "trellis", "index.ts"),
-    getExtensionTemplate(),
+    replacePythonCommandLiterals(getExtensionTemplate()),
   );
 
   const settings = getSettingsTemplate();

--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -18,6 +18,26 @@ export function getPythonCommandForPlatform(
 }
 
 /**
+ * Replace literal `python3` with `python` on Windows, excluding shebang lines.
+ *
+ * Applied at init/update write time so that all file types (including .py, .md,
+ * .toml, .json) get the correct command for the host platform without needing
+ * template-level changes or runtime detection code.
+ *
+ * On non-Windows platforms this is a no-op (returns content unchanged).
+ * The replacement is idempotent: running it twice produces the same result.
+ */
+export function replacePythonCommandLiterals(content: string): string {
+  if (process.platform !== "win32") return content;
+  return content
+    .split("\n")
+    .map((line) =>
+      line.startsWith("#!") ? line : line.replaceAll("python3", "python"),
+    )
+    .join("\n");
+}
+
+/**
  * Resolve platform-specific placeholders in template content.
  *
  * When called without a context, only resolves {{PYTHON_CMD}} (legacy behavior
@@ -62,7 +82,9 @@ export function resolvePlaceholders(
   content: string,
   context?: TemplateContext,
 ): string {
-  let result = content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform());
+  let result = replacePythonCommandLiterals(
+    content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform()),
+  );
 
   if (!context) return result;
 
@@ -306,12 +328,18 @@ export async function writeSkills(
   for (const skill of skills) {
     const skillDir = path.join(skillsRoot, skill.name);
     ensureDir(skillDir);
-    await writeFile(path.join(skillDir, "SKILL.md"), skill.content);
+    await writeFile(
+      path.join(skillDir, "SKILL.md"),
+      replacePythonCommandLiterals(skill.content),
+    );
   }
   for (const skillFile of bundledSkills) {
     const targetPath = path.join(skillsRoot, skillFile.relativePath);
     ensureDir(path.dirname(targetPath));
-    await writeFile(targetPath, skillFile.content);
+    await writeFile(
+      targetPath,
+      replacePythonCommandLiterals(skillFile.content),
+    );
   }
 }
 
@@ -323,7 +351,10 @@ export async function writeAgents(
 ): Promise<void> {
   ensureDir(agentsDir);
   for (const agent of agents) {
-    await writeFile(path.join(agentsDir, `${agent.name}${ext}`), agent.content);
+    await writeFile(
+      path.join(agentsDir, `${agent.name}${ext}`),
+      replacePythonCommandLiterals(agent.content),
+    );
   }
 }
 
@@ -336,7 +367,10 @@ export async function writeSharedHooks(
     await import("../templates/shared-hooks/index.js");
   ensureDir(hooksDir);
   for (const hook of getSharedHookScriptsForPlatform(platform)) {
-    await writeFile(path.join(hooksDir, hook.name), hook.content);
+    await writeFile(
+      path.join(hooksDir, hook.name),
+      replacePythonCommandLiterals(hook.content),
+    );
   }
 }
 
@@ -358,7 +392,7 @@ export function buildPullBasedPrelude(agentType: SubAgentType): string {
   // context buckets keyed by role (not by platform-visible agent name).
   const jsonl = agentType === "check" ? "check.jsonl" : "implement.jsonl";
 
-  return `## Required: Load Trellis Context First
+  return replacePythonCommandLiterals(`## Required: Load Trellis Context First
 
 This platform does NOT auto-inject task context via hook. Before doing anything else, you MUST load context yourself:
 
@@ -374,7 +408,7 @@ If there is no active task or the task has no \`prd.md\`, ask the user what to w
 
 ---
 
-`;
+`);
 }
 
 /** Insert prelude into a markdown agent definition (after YAML frontmatter). */

--- a/packages/cli/src/configurators/workflow.ts
+++ b/packages/cli/src/configurators/workflow.ts
@@ -35,6 +35,7 @@ import {
 } from "../templates/markdown/index.js";
 
 import { writeFile, ensureDir } from "../utils/file-writer.js";
+import { replacePythonCommandLiterals } from "./shared.js";
 import {
   sanitizePkgName,
   type ProjectType,
@@ -93,7 +94,7 @@ export async function createWorkflowStructure(
   // Copy workflow.md from templates
   await writeFile(
     path.join(cwd, PATHS.WORKFLOW_GUIDE_FILE),
-    workflowMdTemplate,
+    replacePythonCommandLiterals(workflowMdTemplate),
   );
 
   // Copy .gitignore from templates
@@ -112,7 +113,7 @@ export async function createWorkflowStructure(
   ensureDir(path.join(cwd, PATHS.WORKSPACE));
   await writeFile(
     path.join(cwd, PATHS.WORKSPACE, "index.md"),
-    agentProgressIndexContent,
+    replacePythonCommandLiterals(agentProgressIndexContent),
   );
 
   // Create tasks/ directory

--- a/packages/cli/src/templates/extract.ts
+++ b/packages/cli/src/templates/extract.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
+import { replacePythonCommandLiterals } from "../configurators/shared.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -133,7 +134,9 @@ async function copyDirRecursive(
       const content = fs.readFileSync(srcPath, "utf-8");
       const isExecutable =
         options?.executable && (entry.endsWith(".sh") || entry.endsWith(".py"));
-      await writeFile(destPath, content, { executable: isExecutable });
+      await writeFile(destPath, replacePythonCommandLiterals(content), {
+        executable: isExecutable,
+      });
     }
   }
 }

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -691,9 +691,11 @@ describe("update() integration", () => {
       "hooks",
       "statusline.py",
     );
+    const expectedPythonCmd =
+      process.platform === "win32" ? "python" : "python3";
     const statusLineConfig = {
       type: "command",
-      command: "python3 .claude/hooks/statusline.py",
+      command: `${expectedPythonCmd} .claude/hooks/statusline.py`,
     };
 
     const settings = JSON.parse(

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -32,6 +32,7 @@ import {
   resolveCommands,
   resolveSkills,
   wrapWithCommandFrontmatter,
+  replacePythonCommandLiterals,
 } from "../../src/configurators/shared.js";
 
 const BUNDLED_SKILL_NAME = "trellis-meta";
@@ -306,14 +307,16 @@ describe("configurePlatform", () => {
           expect(written).toContain(originalBody);
         }
       } else {
-        expect(written).toBe(agent.content);
+        expect(written).toBe(replacePythonCommandLiterals(agent.content));
       }
     }
 
     const config = getCodexConfigTemplate();
     const configPath = path.join(tmpDir, ".codex", config.targetPath);
     expect(fs.existsSync(configPath)).toBe(true);
-    expect(fs.readFileSync(configPath, "utf-8")).toBe(config.content);
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(
+      replacePythonCommandLiterals(config.content),
+    );
   });
 
   it("configurePlatform('codex') resolves PYTHON_CMD in hooks.json", async () => {
@@ -616,7 +619,9 @@ describe("configurePlatform", () => {
         hook.name,
       );
       expect(fs.existsSync(hookPath)).toBe(true);
-      expect(fs.readFileSync(hookPath, "utf-8")).toBe(hook.content);
+      expect(fs.readFileSync(hookPath, "utf-8")).toBe(
+        replacePythonCommandLiterals(hook.content),
+      );
     }
   });
 
@@ -825,7 +830,7 @@ describe("configurePlatform", () => {
         path.join(tmpDir, ".pi", "extensions", "trellis", "index.ts"),
         "utf-8",
       ),
-    ).toBe(getPiExtensionTemplate());
+    ).toBe(replacePythonCommandLiterals(getPiExtensionTemplate()));
 
     for (const agent of getPiAgents()) {
       const content = fs.readFileSync(
@@ -835,7 +840,7 @@ describe("configurePlatform", () => {
       if (["trellis-implement", "trellis-check"].includes(agent.name)) {
         expect(content).toContain("Required: Load Trellis Context First");
       } else {
-        expect(content).toBe(agent.content);
+        expect(content).toBe(replacePythonCommandLiterals(agent.content));
       }
     }
   });
@@ -856,7 +861,7 @@ describe("configurePlatform", () => {
       "Required: Load Trellis Context First",
     );
     expect(templates?.get(".pi/extensions/trellis/index.ts")).toBe(
-      getPiExtensionTemplate(),
+      replacePythonCommandLiterals(getPiExtensionTemplate()),
     );
     expect(templates?.get(".pi/settings.json")).toBe(
       resolvePlaceholders(getPiSettings().content),

--- a/packages/cli/test/configurators/shared.test.ts
+++ b/packages/cli/test/configurators/shared.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   getPythonCommandForPlatform,
+  replacePythonCommandLiterals,
   resolvePlaceholders,
 } from "../../src/configurators/shared.js";
 import type { TemplateContext } from "../../src/types/ai-tools.js";
@@ -38,6 +39,98 @@ const cursorCtx: TemplateContext = {
 
 // ---------------------------------------------------------------------------
 // Tests
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// replacePythonCommandLiterals — platform-mocked unit tests
+// ---------------------------------------------------------------------------
+
+describe("replacePythonCommandLiterals", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    // Restore original platform descriptor
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  function mockPlatform(platform: string) {
+    Object.defineProperty(process, "platform", { value: platform });
+  }
+
+  it("replaces python3 with python on win32", () => {
+    mockPlatform("win32");
+    expect(replacePythonCommandLiterals("run python3 script.py")).toBe(
+      "run python script.py",
+    );
+  });
+
+  it("replaces multiple occurrences on win32", () => {
+    mockPlatform("win32");
+    expect(
+      replacePythonCommandLiterals("python3 a.py && python3 b.py"),
+    ).toBe("python a.py && python b.py");
+  });
+
+  it("preserves shebang lines on win32", () => {
+    mockPlatform("win32");
+    const input = "#!/usr/bin/env python3\npython3 script.py";
+    const result = replacePythonCommandLiterals(input);
+    expect(result).toBe("#!/usr/bin/env python3\npython script.py");
+  });
+
+  it("does not replace python3 on non-Windows platforms", () => {
+    mockPlatform("linux");
+    expect(replacePythonCommandLiterals("run python3 script.py")).toBe(
+      "run python3 script.py",
+    );
+  });
+
+  it("preserves shebang lines on non-Windows platforms", () => {
+    mockPlatform("darwin");
+    const input = "#!/usr/bin/env python3\npython3 script.py";
+    expect(replacePythonCommandLiterals(input)).toBe(input);
+  });
+
+  it("is idempotent on win32", () => {
+    mockPlatform("win32");
+    const once = replacePythonCommandLiterals("python3 script.py");
+    const twice = replacePythonCommandLiterals(once);
+    expect(once).toBe("python script.py");
+    expect(twice).toBe("python script.py");
+  });
+
+  it("handles empty string", () => {
+    mockPlatform("win32");
+    expect(replacePythonCommandLiterals("")).toBe("");
+  });
+
+  it("does not replace python3 that is part of a longer word", () => {
+    mockPlatform("win32");
+    // "python3" as a standalone token is replaced; "python3x" contains "python3"
+    // so it WILL be replaced to "pythonx" — this is expected behavior
+    expect(replacePythonCommandLiterals("python3x")).toBe("pythonx");
+  });
+
+  it("handles multiline content with mixed shebangs and commands", () => {
+    mockPlatform("win32");
+    const input = [
+      "#!/usr/bin/env python3",
+      "# comment about python3",
+      "exec python3 \"$0\" \"$@\"",
+      "python3 ./.trellis/scripts/task.py",
+    ].join("\n");
+    const expected = [
+      "#!/usr/bin/env python3",
+      "# comment about python",
+      "exec python \"$0\" \"$@\"",
+      "python ./.trellis/scripts/task.py",
+    ].join("\n");
+    expect(replacePythonCommandLiterals(input)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPythonCommandForPlatform
 // ---------------------------------------------------------------------------
 
 describe("getPythonCommandForPlatform", () => {


### PR DESCRIPTION
> fix:  #218 

## Summary

  - Windows does not have a `python3` executable, but Trellis templates hardcode `python3` in hook
  scripts and commands, causing failures on Windows.
  - Add `replacePythonCommandLiterals()` that replaces literal `python3` → `python` on `win32`, excluding
   shebang lines (`#!`).
  - Replacement happens at write time only (init/update), template source files remain unchanged.

  ## Changed files

  - `shared.ts` — core `replacePythonCommandLiterals()` function, integrated into
  `resolvePlaceholders()`, `writeSkills()`, `writeAgents()`, `writeSharedHooks()`
  - `claude.ts`, `codex.ts`, `copilot.ts`, `opencode.ts`, `pi.ts` — wrap content with replacement before
  `writeFile()`
  - `workflow.ts`, `extract.ts` — wrap workflow templates and copied `.py` scripts
  - `index.ts` — `replaceInMap()` in `collectPlatformTemplates()` for update-path consistency
  - `update.ts` — apply replacement in `collectTemplateFiles()` for `.trellis/` files
  - Test files updated to match platform-appropriate python command

  ## Design decisions

  - **Write-time only**: Template source files (`src/templates/`) keep `python3`. Replacement runs at the
   moment content is written to disk.
  - **Shebang-safe**: Lines starting with `#!` are excluded from replacement (e.g., `#!/usr/bin/env
  python3`).
  - **Idempotent**: Running replacement multiple times is safe — `python` does not contain `python3`.
  - **Both paths covered**: The configure path (init) and collect path (update) produce identical output
  (byte-for-byte test passes).

  ## Test plan

  - [x] All fix-related tests pass (763/788)
  - [x] Byte-for-byte consistency test (init vs update) passes on Windows
  - [x] 24 pre-existing Windows test failures confirmed unrelated to this change