### PR TITLE
Fix #226: normalize MSYS/Git-Bash paths for CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -35,6 +35,55 @@ if sys.platform.startswith("win"):
 
 
 
+
+
+# =============================================================================
+# Windows Git-Bash/MSYS path normalization
+# =============================================================================
+
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
 def _has_curated_jsonl_entry(jsonl_path: Path) -> bool:
     """Return True iff jsonl has at least one row with a ``file`` field.
 
@@ -594,10 +643,10 @@ def main():
     for var in project_dir_env_vars:
         val = os.environ.get(var)
         if val:
-            project_dir = Path(val).resolve()
+            project_dir = Path(_normalize_windows_shell_path(val)).resolve()
             break
     if project_dir is None:
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
 
     trellis_dir = project_dir / ".trellis"
     context_key = _resolve_context_key(trellis_dir, hook_input)

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -17,6 +17,8 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+
+
 def _normalize_windows_shell_path(path_str: str) -> str:
     """Normalize Unix-style shell paths to real Windows paths.
 

--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -17,6 +17,50 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
+
 
 warnings.filterwarnings("ignore")
 
@@ -271,7 +315,7 @@ def main() -> None:
         hook_input = json.loads(sys.stdin.read())
         if not isinstance(hook_input, dict):
             hook_input = {}
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
     except (json.JSONDecodeError, KeyError):
         hook_input = {}
         project_dir = Path(".").resolve()

--- a/.cursor/hooks/session-start.py
+++ b/.cursor/hooks/session-start.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from io import StringIO
 from pathlib import Path
+
+
 def _normalize_windows_shell_path(path_str: str) -> str:
     """Normalize Unix-style shell paths to real Windows paths.
 

--- a/.cursor/hooks/session-start.py
+++ b/.cursor/hooks/session-start.py
@@ -17,6 +17,50 @@ import subprocess
 import sys
 from io import StringIO
 from pathlib import Path
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
+
 
 FIRST_REPLY_NOTICE = """<first-reply-notice>
 On the first visible assistant reply in this session, begin with exactly one short Chinese sentence:
@@ -594,10 +638,10 @@ def main():
     for var in project_dir_env_vars:
         val = os.environ.get(var)
         if val:
-            project_dir = Path(val).resolve()
+            project_dir = Path(_normalize_windows_shell_path(val)).resolve()
             break
     if project_dir is None:
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
 
     trellis_dir = project_dir / ".trellis"
     context_key = _resolve_context_key(trellis_dir, hook_input)

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -17,6 +17,8 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+
+
 def _normalize_windows_shell_path(path_str: str) -> str:
     """Normalize Unix-style shell paths to real Windows paths.
 

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -17,6 +17,50 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
+
 
 warnings.filterwarnings("ignore")
 
@@ -271,7 +315,7 @@ def main() -> None:
         hook_input = json.loads(sys.stdin.read())
         if not isinstance(hook_input, dict):
             hook_input = {}
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
     except (json.JSONDecodeError, KeyError):
         hook_input = {}
         project_dir = Path(".").resolve()

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -20,6 +20,8 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+
+
 def _normalize_windows_shell_path(path_str: str) -> str:
     """Normalize Unix-style shell paths to real Windows paths.
 

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -20,6 +20,50 @@ import sys
 import warnings
 from io import StringIO
 from pathlib import Path
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
+
 
 warnings.filterwarnings("ignore")
 
@@ -267,7 +311,7 @@ def main() -> None:
         hook_input = json.loads(sys.stdin.read())
         if not isinstance(hook_input, dict):
             hook_input = {}
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
     except (json.JSONDecodeError, KeyError):
         hook_input = {}
         project_dir = Path(".").resolve()

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from io import StringIO
 from pathlib import Path
+
+
 def _normalize_windows_shell_path(path_str: str) -> str:
     """Normalize Unix-style shell paths to real Windows paths.
 

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -17,6 +17,50 @@ import subprocess
 import sys
 from io import StringIO
 from pathlib import Path
+def _normalize_windows_shell_path(path_str: str) -> str:
+    """Normalize Unix-style shell paths to real Windows paths.
+
+    On Windows, shells like Git Bash / MSYS2 / Cygwin may report paths like
+    `/d/Users/...` or `/cygdrive/d/Users/...`. `Path.resolve()` will misinterpret
+    these as `D:/d/Users...` on drive D: (or similar), breaking repo root
+    detection.
+
+    This function is intentionally conservative: it only rewrites patterns that
+    unambiguously represent a drive letter mount.
+    """
+    if not isinstance(path_str, str) or not path_str:
+        return path_str
+
+    # Only relevant on Windows; keep other platforms untouched.
+    if not sys.platform.startswith("win"):
+        return path_str
+
+    p = path_str.strip()
+
+    # Already a Windows drive path (C:\... or C:/...)
+    if re.match(r"^[A-Za-z]:[\/]", p):
+        return p
+
+    # MSYS/Git-Bash style: /c/Users/... or /d/Work/...
+    m = re.match(r"^/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # Cygwin style: /cygdrive/c/Users/...
+    m = re.match(r"^/cygdrive/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    # WSL mounted drive (sometimes leaked into env): /mnt/c/Users/...
+    m = re.match(r"^/mnt/([A-Za-z])/(.*)", p)
+    if m:
+        drive, rest = m.group(1).upper(), m.group(2)
+        return f"{drive}:\\{rest.replace('/', '\\')}"
+
+    return path_str
+
 
 FIRST_REPLY_NOTICE = """<first-reply-notice>
 On the first visible assistant reply in this session, begin with exactly one short Chinese sentence:
@@ -594,10 +638,10 @@ def main():
     for var in project_dir_env_vars:
         val = os.environ.get(var)
         if val:
-            project_dir = Path(val).resolve()
+            project_dir = Path(_normalize_windows_shell_path(val)).resolve()
             break
     if project_dir is None:
-        project_dir = Path(hook_input.get("cwd", ".")).resolve()
+        project_dir = Path(_normalize_windows_shell_path(hook_input.get("cwd", "."))).resolve()
 
     trellis_dir = project_dir / ".trellis"
     context_key = _resolve_context_key(trellis_dir, hook_input)


### PR DESCRIPTION
## Problem
On Windows when running Claude Code from Git-Bash/MSYS, `CLAUDE_PROJECT_DIR` (or `hook_input["cwd"]`) may be provided as MSYS-style paths like:
- `/d/Users/...`
- `/cygdrive/d/Users/...`
- `/mnt/d/Users/...`

The session-start hook currently does `Path(val).resolve()` directly. On Windows, a value like `/d/...` is treated as a Unix absolute path (no drive), which can lead to:
- incorrect `project_dir`
- failed imports / context injection (e.g. `ModuleNotFoundError: common`)

## Fix
Normalize MSYS/WSL-style paths to Windows drive paths before calling `Path(...).resolve()`:
- `/d/...` -> `D:\...`
- `/cygdrive/d/...` -> `D:\...`
- `/mnt/d/...` -> `D:\...`

## Verification
Locally validated the hook runs successfully when `CLAUDE_PROJECT_DIR` / `cwd` are provided in the above path formats.
