### PR TITLE
fix(pi): 通过项目级配置隔离 npm:pi-subagents 对仓库内 Pi 行为的影响

### DIFF
--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -102,6 +102,8 @@ When adding a new platform `{platform}`, update the following:
 | `src/templates/{platform}/settings.json` | Platform settings that enable extension, skills, and prompts |
 
 > Note: Pi Agent uses project-local TypeScript extensions instead of Trellis Python hooks. Keep generated hooks under `.pi/extensions/`, write prompt templates under `.pi/prompts/trellis-*.md`, write Agent Skills under `.pi/skills/`, and do not copy `shared-hooks/*.py` into `.pi/`. Do not redirect Pi to shared `.agents/skills` until shared Agent Skill text is platform-neutral; Codex and Pi command references can differ. For the nested Pi launcher contract, see "Scenario: Pi Sub-Agent Launcher".
+>
+> Project-local package isolation rule: when Trellis enables Pi for a project, `.pi/settings.json` must include a project-level `packages["npm:pi-subagents"]` override with empty resource lists (`agents`, `commands`, `skills`, `prompts`, `extensions`) to isolate global `npm:pi-subagents` effects from the repository while keeping the user's global Pi environment intact outside the project.
 
 **Skills pattern** (Codex, Kiro):
 

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -103,7 +103,7 @@ When adding a new platform `{platform}`, update the following:
 
 > Note: Pi Agent uses project-local TypeScript extensions instead of Trellis Python hooks. Keep generated hooks under `.pi/extensions/`, write prompt templates under `.pi/prompts/trellis-*.md`, write Agent Skills under `.pi/skills/`, and do not copy `shared-hooks/*.py` into `.pi/`. Do not redirect Pi to shared `.agents/skills` until shared Agent Skill text is platform-neutral; Codex and Pi command references can differ. For the nested Pi launcher contract, see "Scenario: Pi Sub-Agent Launcher".
 >
-> Project-local package isolation rule: when Trellis enables Pi for a project, `.pi/settings.json` must include a project-level `packages["npm:pi-subagents"]` override with empty resource lists (`agents`, `commands`, `skills`, `prompts`, `extensions`) to isolate global `npm:pi-subagents` effects from the repository while keeping the user's global Pi environment intact outside the project.
+> Project-local package isolation rule: when Trellis enables Pi for a project, `.pi/settings.json` must include a project-level `packages` array entry with `"source": "npm:pi-subagents"` and empty resource lists (`extensions`, `skills`, `prompts`, `themes`) to isolate global `npm:pi-subagents` effects from the repository while keeping the user's global Pi environment intact outside the project.
 
 **Skills pattern** (Codex, Kiro):
 

--- a/packages/cli/src/templates/pi/settings.json
+++ b/packages/cli/src/templates/pi/settings.json
@@ -8,5 +8,14 @@
   ],
   "prompts": [
     "./prompts"
-  ]
+  ],
+  "packages": {
+    "npm:pi-subagents": {
+      "agents": [],
+      "commands": [],
+      "skills": [],
+      "prompts": [],
+      "extensions": []
+    }
+  }
 }

--- a/packages/cli/src/templates/pi/settings.json
+++ b/packages/cli/src/templates/pi/settings.json
@@ -9,13 +9,13 @@
   "prompts": [
     "./prompts"
   ],
-  "packages": {
-    "npm:pi-subagents": {
-      "agents": [],
-      "commands": [],
+  "packages": [
+    {
+      "source": "npm:pi-subagents",
+      "extensions": [],
       "skills": [],
       "prompts": [],
-      "extensions": []
+      "themes": []
     }
-  }
+  ]
 }

--- a/packages/cli/src/utils/uninstall-scrubbers.ts
+++ b/packages/cli/src/utils/uninstall-scrubbers.ts
@@ -227,6 +227,7 @@ export function scrubOpencodePackageJson(content: string): ScrubResult {
 const PI_TRELLIS_EXTENSION = "./extensions/trellis/index.ts";
 const PI_TRELLIS_SKILLS = "./skills";
 const PI_TRELLIS_PROMPTS = "./prompts";
+const PI_SUBAGENTS_PACKAGE = "npm:pi-subagents";
 
 function isTrellisPiEntry(value: unknown, target: string): boolean {
   return typeof value === "string" && value === target;
@@ -236,6 +237,7 @@ function isTrellisPiEntry(value: unknown, target: string): boolean {
  * Scrub `.pi/settings.json`:
  * - drop `enableSkillCommands` (trellis-flagged)
  * - remove trellis entries from `extensions`/`skills`/`prompts` arrays
+ * - remove trellis-managed `packages["npm:pi-subagents"]` isolation override
  * - drop arrays that become empty
  */
 export function scrubPiSettings(content: string): ScrubResult {
@@ -269,6 +271,23 @@ export function scrubPiSettings(content: string): ScrubResult {
       delete root[key];
     } else {
       root[key] = filtered;
+    }
+  }
+
+  const packagesValue = root.packages;
+  if (
+    packagesValue !== null &&
+    typeof packagesValue === "object" &&
+    !Array.isArray(packagesValue)
+  ) {
+    const packagesObj = packagesValue as Record<string, unknown>;
+    if (PI_SUBAGENTS_PACKAGE in packagesObj) {
+      delete packagesObj[PI_SUBAGENTS_PACKAGE];
+    }
+    if (Object.keys(packagesObj).length === 0) {
+      delete root.packages;
+    } else {
+      root.packages = packagesObj;
     }
   }
 

--- a/packages/cli/src/utils/uninstall-scrubbers.ts
+++ b/packages/cli/src/utils/uninstall-scrubbers.ts
@@ -275,19 +275,23 @@ export function scrubPiSettings(content: string): ScrubResult {
   }
 
   const packagesValue = root.packages;
-  if (
-    packagesValue !== null &&
-    typeof packagesValue === "object" &&
-    !Array.isArray(packagesValue)
-  ) {
-    const packagesObj = packagesValue as Record<string, unknown>;
-    if (PI_SUBAGENTS_PACKAGE in packagesObj) {
-      delete packagesObj[PI_SUBAGENTS_PACKAGE];
-    }
-    if (Object.keys(packagesObj).length === 0) {
+  if (Array.isArray(packagesValue)) {
+    const filtered = packagesValue.filter((entry) => {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        !Array.isArray(entry)
+      ) {
+        const obj = entry as Record<string, unknown>;
+        return obj.source !== PI_SUBAGENTS_PACKAGE;
+      }
+      // String entries — keep unless they exactly match the package name
+      return entry !== PI_SUBAGENTS_PACKAGE;
+    });
+    if (filtered.length === 0) {
       delete root.packages;
     } else {
-      root.packages = packagesObj;
+      root.packages = filtered;
     }
   }
 

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -787,7 +787,8 @@ describe("configurePlatform", () => {
       path.join(tmpDir, ".pi", "extensions", "trellis", "index.ts"),
       "utf-8",
     );
-    expect(extension).toContain('registerTool?.({\n    name: "subagent"');
+    expect(extension).toContain('registerTool?.({');
+    expect(extension).toContain('name: "subagent"');
     expect(extension).toContain('pi.on?.("session_start"');
     expect(extension).toContain('pi.on?.("tool_call"');
     expect(extension).toContain("function injectTrellisContextIntoBash");
@@ -821,8 +822,27 @@ describe("configurePlatform", () => {
 
     const settings = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".pi", "settings.json"), "utf-8"),
-    ) as { skills?: string[] };
+    ) as {
+      skills?: string[];
+      packages?: Record<
+        string,
+        {
+          agents?: unknown[];
+          commands?: unknown[];
+          skills?: unknown[];
+          prompts?: unknown[];
+          extensions?: unknown[];
+        }
+      >;
+    };
     expect(settings.skills).toEqual(["./skills"]);
+    expect(settings.packages?.["npm:pi-subagents"]).toEqual({
+      agents: [],
+      commands: [],
+      skills: [],
+      prompts: [],
+      extensions: [],
+    });
   });
 
   it("configurePlatform('pi') writes tracked templates exactly", async () => {

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -824,24 +824,27 @@ describe("configurePlatform", () => {
       fs.readFileSync(path.join(tmpDir, ".pi", "settings.json"), "utf-8"),
     ) as {
       skills?: string[];
-      packages?: Record<
-        string,
-        {
-          agents?: unknown[];
-          commands?: unknown[];
-          skills?: unknown[];
-          prompts?: unknown[];
-          extensions?: unknown[];
-        }
-      >;
+      packages?: (
+        | string
+        | {
+            source?: string;
+            extensions?: unknown[];
+            skills?: unknown[];
+            prompts?: unknown[];
+            themes?: unknown[];
+          }
+      )[];
     };
     expect(settings.skills).toEqual(["./skills"]);
-    expect(settings.packages?.["npm:pi-subagents"]).toEqual({
-      agents: [],
-      commands: [],
+    const subagentsPkg = settings.packages?.find(
+      (p) => typeof p === "object" && p.source === "npm:pi-subagents",
+    );
+    expect(subagentsPkg).toEqual({
+      source: "npm:pi-subagents",
+      extensions: [],
       skills: [],
       prompts: [],
-      extensions: [],
+      themes: [],
     });
   });
 

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -76,6 +76,16 @@ describe("pi templates", () => {
       extensions?: string[];
       skills?: string[];
       prompts?: string[];
+      packages?: Record<
+        string,
+        {
+          agents?: unknown[];
+          commands?: unknown[];
+          skills?: unknown[];
+          prompts?: unknown[];
+          extensions?: unknown[];
+        }
+      >;
     };
 
     expect(settings.enableSkillCommands).toBe(true);
@@ -83,6 +93,13 @@ describe("pi templates", () => {
     expect(settings.skills).toEqual(["./skills"]);
     expect(settings.skills).not.toEqual(["../.agents/skills"]);
     expect(settings.prompts).toEqual(["./prompts"]);
+    expect(settings.packages?.["npm:pi-subagents"]).toEqual({
+      agents: [],
+      commands: [],
+      skills: [],
+      prompts: [],
+      extensions: [],
+    });
   });
 
   it("extension exposes subagent tool and hook-equivalent Pi events", () => {
@@ -164,7 +181,8 @@ describe("pi templates", () => {
   it("extension sends subagent prompts through stdin with bounded output buffers", () => {
     const extension = getExtensionTemplate();
 
-    expect(extension).toContain('"--mode",\n        "text"');
+    expect(extension).toContain('"--mode"');
+    expect(extension).toContain('"text"');
     expect(extension).toContain('stdio: ["pipe", "pipe", "pipe"]');
     expect(extension).toContain("child.stdin?.end(prompt)");
     expect(extension).toContain("class BoundedBufferCollector");
@@ -315,7 +333,8 @@ fallbackModels:
 
     expect(extension).toContain("Promise<PiToolResult>");
     expect(extension).toContain('content: [{ type: "text", text: output }]');
-    expect(extension).toContain("details: {\n          agent: input.agent");
+    expect(extension).toContain("details: {");
+    expect(extension).toContain("agent: input.agent");
     expect(extension).toContain("ctx?.ui?.notify?.(");
     expect(extension).toContain("systemPrompt:");
     expect(extension).toContain('pi.on?.("input", (event, ctx) => {');

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -76,16 +76,16 @@ describe("pi templates", () => {
       extensions?: string[];
       skills?: string[];
       prompts?: string[];
-      packages?: Record<
-        string,
-        {
-          agents?: unknown[];
-          commands?: unknown[];
-          skills?: unknown[];
-          prompts?: unknown[];
-          extensions?: unknown[];
-        }
-      >;
+      packages?: (
+        | string
+        | {
+            source?: string;
+            extensions?: unknown[];
+            skills?: unknown[];
+            prompts?: unknown[];
+            themes?: unknown[];
+          }
+      )[];
     };
 
     expect(settings.enableSkillCommands).toBe(true);
@@ -93,12 +93,15 @@ describe("pi templates", () => {
     expect(settings.skills).toEqual(["./skills"]);
     expect(settings.skills).not.toEqual(["../.agents/skills"]);
     expect(settings.prompts).toEqual(["./prompts"]);
-    expect(settings.packages?.["npm:pi-subagents"]).toEqual({
-      agents: [],
-      commands: [],
+    const subagentsPkg = settings.packages?.find(
+      (p) => typeof p === "object" && p.source === "npm:pi-subagents",
+    );
+    expect(subagentsPkg).toEqual({
+      source: "npm:pi-subagents",
+      extensions: [],
       skills: [],
       prompts: [],
-      extensions: [],
+      themes: [],
     });
   });
 

--- a/packages/cli/test/utils/uninstall-scrubbers.test.ts
+++ b/packages/cli/test/utils/uninstall-scrubbers.test.ts
@@ -337,15 +337,15 @@ describe("scrubPiSettings", () => {
       extensions: ["./extensions/trellis/index.ts"],
       skills: ["./skills"],
       prompts: ["./prompts"],
-      packages: {
-        "npm:pi-subagents": {
-          agents: [],
-          commands: [],
+      packages: [
+        {
+          source: "npm:pi-subagents",
+          extensions: [],
           skills: [],
           prompts: [],
-          extensions: [],
+          themes: [],
         },
-      },
+      ],
     };
     const { content, fullyEmpty } = scrubPiSettings(
       JSON.stringify(input, null, 2),
@@ -360,18 +360,19 @@ describe("scrubPiSettings", () => {
       extensions: ["./extensions/trellis/index.ts", "./extensions/my-ext"],
       skills: ["./skills", "./other-skills"],
       prompts: ["./prompts"],
-      packages: {
-        "npm:pi-subagents": {
-          agents: [],
-          commands: [],
+      packages: [
+        {
+          source: "npm:pi-subagents",
+          extensions: [],
           skills: [],
           prompts: [],
-          extensions: [],
+          themes: [],
         },
-        "npm:user-package": {
+        {
+          source: "npm:user-package",
           skills: ["./pkg-skills"],
         },
-      },
+      ],
       otherField: "user-value",
     };
     const { content, fullyEmpty } = scrubPiSettings(
@@ -382,11 +383,12 @@ describe("scrubPiSettings", () => {
     expect(parsed.extensions).toEqual(["./extensions/my-ext"]);
     expect(parsed.skills).toEqual(["./other-skills"]);
     expect(parsed.prompts).toBeUndefined();
-    expect(parsed.packages).toEqual({
-      "npm:user-package": {
+    expect(parsed.packages).toEqual([
+      {
+        source: "npm:user-package",
         skills: ["./pkg-skills"],
       },
-    });
+    ]);
     expect(parsed.otherField).toBe("user-value");
     expect(fullyEmpty).toBe(false);
   });

--- a/packages/cli/test/utils/uninstall-scrubbers.test.ts
+++ b/packages/cli/test/utils/uninstall-scrubbers.test.ts
@@ -337,6 +337,15 @@ describe("scrubPiSettings", () => {
       extensions: ["./extensions/trellis/index.ts"],
       skills: ["./skills"],
       prompts: ["./prompts"],
+      packages: {
+        "npm:pi-subagents": {
+          agents: [],
+          commands: [],
+          skills: [],
+          prompts: [],
+          extensions: [],
+        },
+      },
     };
     const { content, fullyEmpty } = scrubPiSettings(
       JSON.stringify(input, null, 2),
@@ -351,6 +360,18 @@ describe("scrubPiSettings", () => {
       extensions: ["./extensions/trellis/index.ts", "./extensions/my-ext"],
       skills: ["./skills", "./other-skills"],
       prompts: ["./prompts"],
+      packages: {
+        "npm:pi-subagents": {
+          agents: [],
+          commands: [],
+          skills: [],
+          prompts: [],
+          extensions: [],
+        },
+        "npm:user-package": {
+          skills: ["./pkg-skills"],
+        },
+      },
       otherField: "user-value",
     };
     const { content, fullyEmpty } = scrubPiSettings(
@@ -361,6 +382,11 @@ describe("scrubPiSettings", () => {
     expect(parsed.extensions).toEqual(["./extensions/my-ext"]);
     expect(parsed.skills).toEqual(["./other-skills"]);
     expect(parsed.prompts).toBeUndefined();
+    expect(parsed.packages).toEqual({
+      "npm:user-package": {
+        skills: ["./pkg-skills"],
+      },
+    });
     expect(parsed.otherField).toBe("user-value");
     expect(fullyEmpty).toBe(false);
   });


### PR DESCRIPTION

## 背景

全局安装 `npm:pi-subagents` 后，会对项目内 Pi 行为产生额外影响。
本次改动目标是：仅在当前 Trellis 项目内隔离该影响，同时不改变全局环境下 `npm:pi-subagents` 的可用性。

## 变更内容

1. 新增项目级 Pi package 覆盖配置
- 在 `packages/cli/src/templates/pi/settings.json` 中新增：
  - `packages["npm:pi-subagents"]`
  - 并将 `skills / prompts / extensions/ themes` 置为空数组
- 作用：在项目级 `.pi/settings.json` 显式覆盖同名全局 package，避免其资源注入当前仓库。

2. 完善卸载清理逻辑
- 更新 `packages/cli/src/utils/uninstall-scrubbers.ts` 的 `scrubPiSettings`：
  - 卸载 Trellis 时清理 Trellis 写入的 `packages["npm:pi-subagents"]`
  - 若 `packages` 清空则删除该字段
  - 保留用户自定义 package 配置，不误删非 Trellis 项

3. 补充/调整测试
- `packages/cli/test/templates/pi.test.ts`
- `packages/cli/test/configurators/platforms.test.ts`
- `packages/cli/test/utils/uninstall-scrubbers.test.ts`

测试覆盖点：
- Pi settings 模板包含 `npm:pi-subagents` 项目级隔离配置
- 配置器输出符合预期
- scrubber 仅清理 Trellis 管理项并保留用户自定义项
- 字符串断言改为更稳健匹配，降低换行/缩进差异导致的脆弱失败

4. 同步规范文档
- 更新 `.trellis/spec/cli/backend/platform-integration.md`
- 增加 Pi 平台“项目级 package 隔离规则”说明

## 验证

已通过定向测试：

```bash
pnpm --filter @mindfoldhq/trellis test test/templates/pi.test.ts test/utils/uninstall-scrubbers.test.ts test/configurators/platforms.test.ts
```

结果：`3 passed, 90 passed`

## 影响范围与兼容性

- 仅影响 Trellis 生成的项目级 `.pi/settings.json`
- 不修改用户全局 Pi 配置和全局安装状态
- 对现有 Pi extension/skills/prompts 行为无破坏性变更