### PR TITLE
fix(claudecode):初始化Claudecode时使用CLAUDE.md

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -848,10 +848,16 @@ async function handleReinit(
       }
     }
 
-    await createRootFiles(cwd, getRootInstructionFilesForTools(platformsToAdd));
+    const rootInstructionFilesToCreate =
+      getRootInstructionFilesForTools(platformsToAdd);
+    const rootInstructionFilesToHash = getRootInstructionFilesForTools([
+      ...[...configuredPlatforms].map((id) => AI_TOOLS[id].cliFlag),
+      ...platformsToAdd,
+    ]);
+    await createRootFiles(cwd, rootInstructionFilesToCreate);
 
     // Update template hashes
-    const hashedCount = initializeHashes(cwd);
+    const hashedCount = initializeHashes(cwd, rootInstructionFilesToHash);
     if (hashedCount > 0) {
       console.log(
         chalk.gray(`📋 Tracking ${hashedCount} template files for updates`),
@@ -1770,10 +1776,11 @@ export async function init(options: InitOptions): Promise<void> {
   }
 
   // Create root instruction files required by selected platforms.
-  await createRootFiles(cwd, getRootInstructionFilesForTools(tools));
+  const rootInstructionFiles = getRootInstructionFilesForTools(tools);
+  await createRootFiles(cwd, rootInstructionFiles);
 
   // Initialize template hashes for modification tracking
-  const hashedCount = initializeHashes(cwd);
+  const hashedCount = initializeHashes(cwd, rootInstructionFiles);
   if (hashedCount > 0) {
     console.log(
       chalk.gray(`📋 Tracking ${hashedCount} template files for updates`),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,7 +17,11 @@ import {
   getPythonCommandForPlatform,
   setResolvedPythonCommand,
 } from "../configurators/shared.js";
-import { AI_TOOLS, type CliFlag } from "../types/ai-tools.js";
+import {
+  AI_TOOLS,
+  type CliFlag,
+  type RootInstructionFile,
+} from "../types/ai-tools.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../constants/paths.js";
 import { VERSION } from "../constants/version.js";
 import { agentsMdContent } from "../templates/markdown/index.js";
@@ -843,6 +847,8 @@ async function handleReinit(
         }
       }
     }
+
+    await createRootFiles(cwd, getRootInstructionFilesForTools(platformsToAdd));
 
     // Update template hashes
     const hashedCount = initializeHashes(cwd);
@@ -1763,8 +1769,8 @@ export async function init(options: InitOptions): Promise<void> {
     logPythonAdaptationNotice(pythonCmd);
   }
 
-  // Create root files (skip if exists)
-  await createRootFiles(cwd);
+  // Create root instruction files required by selected platforms.
+  await createRootFiles(cwd, getRootInstructionFilesForTools(tools));
 
   // Initialize template hashes for modification tracking
   const hashedCount = initializeHashes(cwd);
@@ -1848,12 +1854,28 @@ function askInput(prompt: string): Promise<string> {
   });
 }
 
-async function createRootFiles(cwd: string): Promise<void> {
-  const agentsPath = path.join(cwd, FILE_NAMES.AGENTS);
+function getRootInstructionFilesForTools(
+  tools: string[],
+): RootInstructionFile[] {
+  const files = new Set<RootInstructionFile>();
+  for (const tool of tools) {
+    const platformId = resolveCliFlag(tool);
+    if (platformId) {
+      files.add(AI_TOOLS[platformId].rootInstructionFile);
+    }
+  }
+  return [...files];
+}
 
-  // Write AGENTS.md from template
-  const agentsWritten = await writeFile(agentsPath, agentsMdContent);
-  if (agentsWritten) {
-    console.log(chalk.blue("📄 Created AGENTS.md"));
+async function createRootFiles(
+  cwd: string,
+  rootInstructionFiles: RootInstructionFile[],
+): Promise<void> {
+  for (const fileName of rootInstructionFiles) {
+    const filePath = path.join(cwd, fileName);
+    const written = await writeFile(filePath, agentsMdContent);
+    if (written) {
+      console.log(chalk.blue(`📄 Created ${fileName}`));
+    }
   }
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -4,7 +4,11 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../constants/paths.js";
-import type { AITool } from "../types/ai-tools.js";
+import {
+  AI_TOOLS,
+  type AITool,
+  type RootInstructionFile,
+} from "../types/ai-tools.js";
 import { VERSION, PACKAGE_NAME } from "../constants/version.js";
 import {
   getMigrationsForVersion,
@@ -141,8 +145,8 @@ function replaceTrellisManagedBlock(
   );
 }
 
-function buildAgentsMdTemplate(cwd: string): string {
-  const fullPath = path.join(cwd, FILE_NAMES.AGENTS);
+function buildRootInstructionTemplate(cwd: string, fileName: string): string {
+  const fullPath = path.join(cwd, fileName);
   if (!fs.existsSync(fullPath)) {
     return agentsMdContent;
   }
@@ -182,6 +186,16 @@ function isKnownUntrackedTemplate(
   }
 
   return LEGACY_UNTRACKED_AGENTS_MD_BLOCK_HASHES.has(computeHash(managedBlock));
+}
+
+function getRootInstructionFilesForPlatforms(
+  platforms: Set<AITool>,
+): RootInstructionFile[] {
+  const files = new Set<RootInstructionFile>();
+  for (const platform of platforms) {
+    files.add(AI_TOOLS[platform].rootInstructionFile);
+  }
+  return [...files];
 }
 
 /**
@@ -626,6 +640,7 @@ function collectTemplateFiles(
       platforms.add(p);
     }
   }
+  const rootInstructionFiles = getRootInstructionFilesForPlatforms(platforms);
 
   // Python scripts (single source of truth: getAllScripts())
   for (const [scriptPath, content] of getAllScripts()) {
@@ -645,7 +660,9 @@ function collectTemplateFiles(
   files.set(`${DIR_NAMES.WORKFLOW}/workflow.md`, workflowMdTemplate);
   // workspace/index.md stays excluded — it's runtime-appended by add_session.py
   // (journal index) and has no script-parsed structure.
-  files.set(FILE_NAMES.AGENTS, buildAgentsMdTemplate(cwd));
+  for (const fileName of rootInstructionFiles) {
+    files.set(fileName, buildRootInstructionTemplate(cwd, fileName));
+  }
 
   // Platform-specific templates (only for configured platforms)
   for (const platformId of platforms) {
@@ -760,14 +777,18 @@ function analyzeChanges(
   return result;
 }
 
-function collectMissingAgentsMdHash(
+function collectMissingRootInstructionHashes(
   changes: ChangeAnalysis,
   hashes: TemplateHashes,
 ): Map<string, string> {
   const files = new Map<string, string>();
 
   for (const file of changes.unchangedFiles) {
-    if (file.relativePath === FILE_NAMES.AGENTS && !hashes[file.relativePath]) {
+    if (
+      (file.relativePath === FILE_NAMES.AGENTS ||
+        file.relativePath === FILE_NAMES.CLAUDE) &&
+      !hashes[file.relativePath]
+    ) {
       files.set(file.relativePath, file.newContent);
     }
   }
@@ -935,7 +956,7 @@ function backupFile(
 const BACKUP_DIRS = ALL_MANAGED_DIRS;
 
 /** Root-level managed files to include in update backups. */
-const BACKUP_FILES = [FILE_NAMES.AGENTS] as const;
+const BACKUP_FILES = [FILE_NAMES.AGENTS, FILE_NAMES.CLAUDE] as const;
 
 /**
  * Patterns to exclude from backup (user data that shouldn't be backed up)
@@ -1944,7 +1965,10 @@ export async function update(options: UpdateOptions): Promise<void> {
 
   // Analyze changes (pass hashes for modification detection)
   const changes = analyzeChanges(cwd, hashes, templates);
-  const missingAgentsMdHash = collectMissingAgentsMdHash(changes, hashes);
+  const missingRootInstructionHashes = collectMissingRootInstructionHashes(
+    changes,
+    hashes,
+  );
 
   // Print summary
   printChangeSummary(changes);
@@ -1983,8 +2007,8 @@ export async function update(options: UpdateOptions): Promise<void> {
     !hasPendingMigrations &&
     !hasSafeDeletes
   ) {
-    if (!options.dryRun && missingAgentsMdHash.size > 0) {
-      updateHashes(cwd, missingAgentsMdHash);
+    if (!options.dryRun && missingRootInstructionHashes.size > 0) {
+      updateHashes(cwd, missingRootInstructionHashes);
     }
 
     if (isSameVersion) {
@@ -2257,7 +2281,7 @@ export async function update(options: UpdateOptions): Promise<void> {
   updateVersionFile(cwd);
 
   // Update template hashes for new, auto-updated, and overwritten files
-  const filesToHash = new Map<string, string>(missingAgentsMdHash);
+  const filesToHash = new Map<string, string>(missingRootInstructionHashes);
   for (const file of changes.newFiles) {
     filesToHash.set(file.relativePath, file.newContent);
   }

--- a/packages/cli/src/constants/paths.ts
+++ b/packages/cli/src/constants/paths.ts
@@ -25,6 +25,8 @@ export const DIR_NAMES = {
 export const FILE_NAMES = {
   /** Root agent instructions file */
   AGENTS: "AGENTS.md",
+  /** Claude Code root instructions file */
+  CLAUDE: "CLAUDE.md",
   /** Developer identity file */
   DEVELOPER: ".developer",
   /** Current task pointer */

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -63,6 +63,8 @@ export type CliFlag =
   | "droid"
   | "pi";
 
+export type RootInstructionFile = "AGENTS.md" | "CLAUDE.md";
+
 /**
  * Template context for placeholder resolution.
  * Controls how common templates are rendered per platform.
@@ -102,6 +104,8 @@ export interface AIToolConfig {
   templateDirs: TemplateDir[];
   /** Config directory name in the project root (e.g., ".claude") */
   configDir: string;
+  /** Root instructions file managed for this platform */
+  rootInstructionFile: RootInstructionFile;
   /**
    * Whether the platform supports the shared `.agents/skills/` layer
    * (agentskills.io open standard). When true, `.agents/skills` is added
@@ -136,6 +140,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Claude Code",
     templateDirs: ["common", "claude"],
     configDir: ".claude",
+    rootInstructionFile: "CLAUDE.md",
     cliFlag: "claude",
     defaultChecked: true,
     hasPythonHooks: true,
@@ -152,6 +157,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Cursor",
     templateDirs: ["common", "cursor"],
     configDir: ".cursor",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "cursor",
     defaultChecked: true,
     hasPythonHooks: true,
@@ -168,6 +174,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "OpenCode",
     templateDirs: ["common", "opencode"],
     configDir: ".opencode",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "opencode",
     defaultChecked: false,
     hasPythonHooks: false,
@@ -184,6 +191,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Codex (also writes .agents/skills/ — read by Cursor, Gemini CLI, GitHub Copilot, Amp, Kimi Code)",
     templateDirs: ["common", "codex"],
     configDir: ".codex",
+    rootInstructionFile: "AGENTS.md",
     supportsAgentSkills: true,
     cliFlag: "codex",
     defaultChecked: false,
@@ -201,6 +209,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Kilo CLI",
     templateDirs: ["common", "kilo"],
     configDir: ".kilocode",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "kilo",
     defaultChecked: false,
     hasPythonHooks: false,
@@ -217,6 +226,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Kiro Code",
     templateDirs: ["common", "kiro"],
     configDir: ".kiro/skills",
+    rootInstructionFile: "AGENTS.md",
     extraManagedPaths: [".kiro/agents", ".kiro/hooks"],
     cliFlag: "kiro",
     defaultChecked: false,
@@ -234,6 +244,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Gemini CLI",
     templateDirs: ["common", "gemini"],
     configDir: ".gemini",
+    rootInstructionFile: "AGENTS.md",
     supportsAgentSkills: true,
     cliFlag: "gemini",
     defaultChecked: false,
@@ -251,6 +262,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Antigravity",
     templateDirs: ["common", "antigravity"],
     configDir: ".agent/workflows",
+    rootInstructionFile: "AGENTS.md",
     extraManagedPaths: [".agent/skills"],
     cliFlag: "antigravity",
     defaultChecked: false,
@@ -268,6 +280,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Windsurf",
     templateDirs: ["common", "windsurf"],
     configDir: ".windsurf/workflows",
+    rootInstructionFile: "AGENTS.md",
     extraManagedPaths: [".windsurf/skills"],
     cliFlag: "windsurf",
     defaultChecked: false,
@@ -285,6 +298,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Qoder",
     templateDirs: ["common", "qoder"],
     configDir: ".qoder",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "qoder",
     defaultChecked: false,
     hasPythonHooks: true,
@@ -301,6 +315,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "CodeBuddy",
     templateDirs: ["common", "codebuddy"],
     configDir: ".codebuddy",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "codebuddy",
     defaultChecked: false,
     hasPythonHooks: true,
@@ -317,6 +332,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "GitHub Copilot",
     templateDirs: ["common", "copilot"],
     configDir: ".github/copilot",
+    rootInstructionFile: "AGENTS.md",
     extraManagedPaths: [
       ".github/agents",
       ".github/hooks",
@@ -339,6 +355,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Factory Droid",
     templateDirs: ["common", "droid"],
     configDir: ".factory",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "droid",
     defaultChecked: false,
     hasPythonHooks: true,
@@ -355,6 +372,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     name: "Pi Agent",
     templateDirs: ["common", "pi"],
     configDir: ".pi",
+    rootInstructionFile: "AGENTS.md",
     cliFlag: "pi",
     defaultChecked: false,
     hasPythonHooks: false,
@@ -396,4 +414,8 @@ export function getManagedPaths(tool: AITool): string[] {
  */
 export function getTemplateDirs(tool: AITool): TemplateDir[] {
   return AI_TOOLS[tool].templateDirs;
+}
+
+export function getRootInstructionFile(tool: AITool): RootInstructionFile {
+  return AI_TOOLS[tool].rootInstructionFile;
 }

--- a/packages/cli/src/utils/template-hash.ts
+++ b/packages/cli/src/utils/template-hash.ts
@@ -264,7 +264,7 @@ export function getModificationStatus(
 const TEMPLATE_DIRS = ALL_MANAGED_DIRS;
 
 /** Root-level template files written by init and managed by update. */
-const TEMPLATE_FILES = [FILE_NAMES.AGENTS] as const;
+const TEMPLATE_FILES = [FILE_NAMES.AGENTS, FILE_NAMES.CLAUDE] as const;
 
 /**
  * Patterns to exclude from hash tracking

--- a/packages/cli/src/utils/template-hash.ts
+++ b/packages/cli/src/utils/template-hash.ts
@@ -263,8 +263,8 @@ export function getModificationStatus(
  */
 const TEMPLATE_DIRS = ALL_MANAGED_DIRS;
 
-/** Root-level template files written by init and managed by update. */
-const TEMPLATE_FILES = [FILE_NAMES.AGENTS, FILE_NAMES.CLAUDE] as const;
+/** Root-level template files that may be managed by init/update. */
+const TEMPLATE_FILES = new Set<string>([FILE_NAMES.AGENTS, FILE_NAMES.CLAUDE]);
 
 /**
  * Patterns to exclude from hash tracking
@@ -340,10 +340,16 @@ function collectFiles(
  * @param cwd - Working directory
  * @returns Number of files hashed
  */
-export function initializeHashes(cwd: string): number {
+export function initializeHashes(
+  cwd: string,
+  rootTemplateFiles: readonly string[] = [],
+): number {
   const hashes: TemplateHashes = {};
 
-  for (const relativePath of TEMPLATE_FILES) {
+  for (const relativePath of new Set(rootTemplateFiles)) {
+    if (!TEMPLATE_FILES.has(relativePath)) {
+      continue;
+    }
     if (shouldExcludeFromHash(relativePath)) {
       continue;
     }

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -30,7 +30,7 @@ import { init } from "../../src/commands/init.js";
 import { VERSION } from "../../src/constants/version.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../../src/constants/paths.js";
 import { collectPlatformTemplates } from "../../src/configurators/index.js";
-import { computeHash } from "../../src/utils/template-hash.js";
+import { computeHash, loadHashes } from "../../src/utils/template-hash.js";
 import { execSync } from "node:child_process";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -153,6 +153,26 @@ describe("init() integration", () => {
     ).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(false);
+  });
+
+  it("#2b Claude-only init does not hash-track a pre-existing AGENTS.md", async () => {
+    const userAgentsContent = "# Existing agent notes\n";
+    fs.writeFileSync(path.join(tmpDir, FILE_NAMES.AGENTS), userAgentsContent);
+
+    await init({ yes: true, claude: true });
+
+    expect(fs.readFileSync(path.join(tmpDir, FILE_NAMES.AGENTS), "utf-8")).toBe(
+      userAgentsContent,
+    );
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(true);
+
+    const hashes = loadHashes(tmpDir);
+    expect(hashes[FILE_NAMES.AGENTS]).toBeUndefined();
+    expect(hashes[FILE_NAMES.CLAUDE]).toBe(
+      computeHash(
+        fs.readFileSync(path.join(tmpDir, FILE_NAMES.CLAUDE), "utf-8"),
+      ),
+    );
   });
 
   it("#3 multi platform creates all selected platform directories", async () => {

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -90,6 +90,7 @@ describe("init() integration", () => {
 
     // Root files
     expect(fs.existsSync(path.join(tmpDir, "AGENTS.md"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "CLAUDE.md"))).toBe(true);
 
     // Built-in multi-file skill is installed for default platforms.
     expect(
@@ -150,6 +151,8 @@ describe("init() integration", () => {
         path.join(tmpDir, ".claude", "skills", "trellis-meta", "SKILL.md"),
       ),
     ).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(false);
   });
 
   it("#3 multi platform creates all selected platform directories", async () => {
@@ -170,12 +173,16 @@ describe("init() integration", () => {
     );
     expect(fs.existsSync(path.join(tmpDir, ".github", "copilot"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".pi"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(true);
   });
 
   it("#3b codex platform creates skills plus .codex assets", async () => {
     await init({ yes: true, codex: true });
 
     expect(fs.existsSync(path.join(tmpDir, ".agents", "skills"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(false);
     // Codex SessionStart hook was removed (de-recursion fix); the
     // <trellis-bootstrap> notice in inject-workflow-state.py invokes
     // `$trellis-start` to load workflow context, so the skill is emitted.
@@ -257,7 +264,19 @@ describe("init() integration", () => {
     );
   });
 
-  it("#3c kiro platform creates .kiro/skills", async () => {
+  it("#3c re-init adding Claude Code creates CLAUDE.md", async () => {
+    await init({ yes: true, codex: true, force: true });
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(false);
+
+    await init({ yes: true, claude: true });
+
+    expect(fs.existsSync(path.join(tmpDir, ".claude"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.AGENTS))).toBe(true);
+  });
+
+  it("#3d kiro platform creates .kiro/skills", async () => {
     await init({ yes: true, kiro: true });
 
     expect(fs.existsSync(path.join(tmpDir, ".kiro", "skills"))).toBe(true);
@@ -656,7 +675,12 @@ describe("init() integration", () => {
       path.join(tmpDir, FILE_NAMES.AGENTS),
       "utf-8",
     );
+    const claudeContent = fs.readFileSync(
+      path.join(tmpDir, FILE_NAMES.CLAUDE),
+      "utf-8",
+    );
     expect(hashes[FILE_NAMES.AGENTS]).toBe(computeHash(agentsContent));
+    expect(hashes[FILE_NAMES.CLAUDE]).toBe(computeHash(claudeContent));
     expect(Object.keys(hashes).length).toBeGreaterThan(0);
   });
 

--- a/packages/cli/test/commands/uninstall.integration.test.ts
+++ b/packages/cli/test/commands/uninstall.integration.test.ts
@@ -28,7 +28,7 @@ vi.mock("node:child_process", () => ({
 
 import { init } from "../../src/commands/init.js";
 import { uninstall } from "../../src/commands/uninstall.js";
-import { DIR_NAMES } from "../../src/constants/paths.js";
+import { DIR_NAMES, FILE_NAMES } from "../../src/constants/paths.js";
 import { loadHashes } from "../../src/utils/template-hash.js";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -65,11 +65,11 @@ describe("uninstall() integration", () => {
 
   it("#2 errors when manifest is missing but .trellis/ exists", async () => {
     fs.mkdirSync(path.join(tmpDir, DIR_NAMES.WORKFLOW));
-    const exitSpy = vi
-      .spyOn(process, "exit")
-      .mockImplementation(((code?: number) => {
-        throw new Error(`process.exit(${code ?? 0})`);
-      }) as never);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
 
     await expect(uninstall({ yes: true })).rejects.toThrow("process.exit(1)");
     expect(exitSpy).toHaveBeenCalledWith(1);
@@ -126,6 +126,23 @@ describe("uninstall() integration", () => {
         expect(text).not.toContain(otherPath);
       }
     }
+  });
+
+  it("#3b Claude-only uninstall preserves a pre-existing untracked AGENTS.md", async () => {
+    const userAgentsContent = "# Existing agent notes\n";
+    fs.writeFileSync(path.join(tmpDir, FILE_NAMES.AGENTS), userAgentsContent);
+
+    await init({ yes: true, claude: true });
+    const hashesBefore = loadHashes(tmpDir);
+    expect(hashesBefore[FILE_NAMES.AGENTS]).toBeUndefined();
+    expect(hashesBefore[FILE_NAMES.CLAUDE]).toBeDefined();
+
+    await uninstall({ yes: true });
+
+    expect(fs.readFileSync(path.join(tmpDir, FILE_NAMES.AGENTS), "utf-8")).toBe(
+      userAgentsContent,
+    );
+    expect(fs.existsSync(path.join(tmpDir, FILE_NAMES.CLAUDE))).toBe(false);
   });
 
   it("#4 dry-run does not modify anything", async () => {
@@ -308,7 +325,9 @@ describe("uninstall() integration", () => {
     // We need this file in the manifest for it to be processed. If init
     // didn't track it, add it manually so the scrubber path runs.
     const hashes = loadHashes(tmpDir);
-    if (!Object.prototype.hasOwnProperty.call(hashes, ".claude/settings.json")) {
+    if (
+      !Object.prototype.hasOwnProperty.call(hashes, ".claude/settings.json")
+    ) {
       hashes[".claude/settings.json"] = "synthetic-hash";
       const hashFile = path.join(
         tmpDir,
@@ -325,10 +344,9 @@ describe("uninstall() integration", () => {
 
     // .trellis/ is gone, but settings.json should remain (had user fields).
     if (fs.existsSync(settingsPath)) {
-      const after = JSON.parse(fs.readFileSync(settingsPath, "utf-8")) as Record<
-        string,
-        unknown
-      >;
+      const after = JSON.parse(
+        fs.readFileSync(settingsPath, "utf-8"),
+      ) as Record<string, unknown>;
       expect(after.model).toBe("claude-sonnet-4");
       expect(after.permissions).toEqual({ allow: ["Bash(git:*)"] });
 

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -374,6 +374,35 @@ describe("update() integration", () => {
     expect(result.endsWith(templateContent.trimEnd() + "\n")).toBe(true);
   });
 
+  it("#4e auto-updates Claude Code CLAUDE.md and preserves outside content", async () => {
+    await init({ yes: true, claude: true, force: true });
+
+    const targetRelative = FILE_NAMES.CLAUDE;
+    const targetFull = path.join(tmpDir, targetRelative);
+    const templateContent = fs.readFileSync(targetFull, "utf-8");
+    const oldContent = removeSubagentsSection(templateContent);
+    const existingContent = `# Claude local notes\n\n${oldContent}\n\n## Project Notes\n\nKeep this.`;
+    const expectedContent = `# Claude local notes\n\n${templateContent}\n\n## Project Notes\n\nKeep this.`;
+
+    fs.writeFileSync(targetFull, existingContent);
+
+    const hashFile = path.join(
+      tmpDir,
+      DIR_NAMES.WORKFLOW,
+      ".template-hashes.json",
+    );
+    const hashes = readHashesV2(hashFile);
+    hashes[targetRelative] = computeHash(existingContent);
+    writeHashesV2(hashFile, hashes);
+
+    await update({});
+
+    expect(fs.readFileSync(targetFull, "utf-8")).toBe(expectedContent);
+    expect(readHashesV2(hashFile)[targetRelative]).toBe(
+      computeHash(expectedContent),
+    );
+  });
+
   it("#5 force overwrites user-modified files", async () => {
     await setupProject();
 

--- a/packages/cli/test/types/ai-tools.test.ts
+++ b/packages/cli/test/types/ai-tools.test.ts
@@ -19,6 +19,16 @@ describe("AI_TOOLS registry", () => {
       expect(config.configDir.startsWith(".")).toBe(true);
       expect(config.cliFlag.length).toBeGreaterThan(0);
       expect(config.templateDirs).toContain("common");
+      expect(["AGENTS.md", "CLAUDE.md"]).toContain(
+        config.rootInstructionFile,
+      );
+    }
+  });
+
+  it("uses CLAUDE.md only for Claude Code root instructions", () => {
+    for (const id of ALL_TOOL_IDS) {
+      const expected = id === "claude-code" ? "CLAUDE.md" : "AGENTS.md";
+      expect(AI_TOOLS[id].rootInstructionFile).toBe(expected);
     }
   });
 });

--- a/packages/cli/test/utils/template-hash.test.ts
+++ b/packages/cli/test/utils/template-hash.test.ts
@@ -328,7 +328,9 @@ describe("matchesOriginalTemplate", () => {
   });
 
   it("returns false when file does not exist", () => {
-    expect(matchesOriginalTemplate(tmpDir, "missing.txt", "content")).toBe(false);
+    expect(matchesOriginalTemplate(tmpDir, "missing.txt", "content")).toBe(
+      false,
+    );
   });
 
   it("returns true when file matches original content exactly", () => {
@@ -406,10 +408,16 @@ describe("initializeHashes", () => {
   it("hashes files in managed directories", () => {
     // Create .trellis with a script and .claude with a command
     fs.mkdirSync(path.join(tmpDir, ".trellis", "scripts"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, ".trellis", "scripts", "task.py"), "print('hello')");
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "scripts", "task.py"),
+      "print('hello')",
+    );
 
     fs.mkdirSync(path.join(tmpDir, ".claude", "commands"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, ".claude", "commands", "start.md"), "# Start");
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "commands", "start.md"),
+      "# Start",
+    );
 
     const count = initializeHashes(tmpDir);
     expect(count).toBeGreaterThanOrEqual(2);
@@ -419,22 +427,27 @@ describe("initializeHashes", () => {
     expect(hashes).toHaveProperty(".claude/commands/start.md");
   });
 
-  it("hashes existing root instruction files", () => {
+  it("hashes only selected root instruction files", () => {
     fs.mkdirSync(path.join(tmpDir, ".trellis"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agents\n");
     fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "# Claude\n");
 
-    const count = initializeHashes(tmpDir);
+    const count = initializeHashes(tmpDir, [FILE_NAMES.CLAUDE]);
     const hashes = loadHashes(tmpDir);
 
-    expect(hashes[FILE_NAMES.AGENTS]).toBe(computeHash("# Agents\n"));
+    expect(hashes[FILE_NAMES.AGENTS]).toBeUndefined();
     expect(hashes[FILE_NAMES.CLAUDE]).toBe(computeHash("# Claude\n"));
-    expect(count).toBe(2);
+    expect(count).toBe(1);
   });
 
   it("excludes workspace and tasks directories", () => {
-    fs.mkdirSync(path.join(tmpDir, ".trellis", "workspace"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, ".trellis", "workspace", "data.md"), "user data");
+    fs.mkdirSync(path.join(tmpDir, ".trellis", "workspace"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "data.md"),
+      "user data",
+    );
     fs.mkdirSync(path.join(tmpDir, ".trellis", "tasks"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, ".trellis", "tasks", "task.json"), "{}");
 
@@ -448,12 +461,27 @@ describe("initializeHashes", () => {
   });
 
   it("excludes spec/ directory files from hashing", () => {
-    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "guides"), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "frontend"), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "backend"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, ".trellis", "spec", "guides", "index.md"), "# Guides");
-    fs.writeFileSync(path.join(tmpDir, ".trellis", "spec", "frontend", "index.md"), "# Frontend");
-    fs.writeFileSync(path.join(tmpDir, ".trellis", "spec", "backend", "index.md"), "# Backend");
+    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "guides"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "frontend"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(tmpDir, ".trellis", "spec", "backend"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "spec", "guides", "index.md"),
+      "# Guides",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "spec", "frontend", "index.md"),
+      "# Frontend",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "spec", "backend", "index.md"),
+      "# Backend",
+    );
 
     const count = initializeHashes(tmpDir);
     const hashes = loadHashes(tmpDir);
@@ -501,9 +529,7 @@ describe("initializeHashes", () => {
     const count = initializeHashes(tmpDir);
     const hashes = loadHashes(tmpDir);
 
-    expect(hashes).toHaveProperty(
-      ".pi/skills/trellis-update-spec/SKILL.md",
-    );
+    expect(hashes).toHaveProperty(".pi/skills/trellis-update-spec/SKILL.md");
     expect(count).toBe(1);
   });
 });

--- a/packages/cli/test/utils/template-hash.test.ts
+++ b/packages/cli/test/utils/template-hash.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { FILE_NAMES } from "../../src/constants/paths.js";
 import {
   computeHash,
   loadHashes,
@@ -416,6 +417,19 @@ describe("initializeHashes", () => {
     const hashes = loadHashes(tmpDir);
     expect(hashes).toHaveProperty(".trellis/scripts/task.py");
     expect(hashes).toHaveProperty(".claude/commands/start.md");
+  });
+
+  it("hashes existing root instruction files", () => {
+    fs.mkdirSync(path.join(tmpDir, ".trellis"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agents\n");
+    fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "# Claude\n");
+
+    const count = initializeHashes(tmpDir);
+    const hashes = loadHashes(tmpDir);
+
+    expect(hashes[FILE_NAMES.AGENTS]).toBe(computeHash("# Agents\n"));
+    expect(hashes[FILE_NAMES.CLAUDE]).toBe(computeHash("# Claude\n"));
+    expect(count).toBe(2);
   });
 
   it("excludes workspace and tasks directories", () => {


### PR DESCRIPTION
When using trellies init command and select claude code, initialize CLAUDE.md instead of AGETNS.md.
使用trellies init 命令初始化并选择Claudecode时创建CLAUDE.md而不是AGETNS.md