### PR TITLE
docs(workflow): clarify sub-agent vs skill in in_progress breadcrumb

### DIFF
--- a/.trellis/.template-hashes.json
+++ b/.trellis/.template-hashes.json
@@ -124,7 +124,7 @@
     ".codex/hooks/session-start.py": "8c2cf3d6681cc9a766faff4774310fdbc14373419c16e1c6139e18ec49b51663",
     ".pi/prompts/trellis-continue.md": "cdb8cd157654b76014742cb8405da038d5feedce4c3228212b489c6c57a68e3d",
     ".opencode/agents/trellis-research.md": "2c5135aefe280fd4508554e58c64bd13f5f9fe58b8bb25393e68496b29bfae4e",
-    ".trellis/workflow.md": "7d875a02c892dcc6ad93bfb43499dd02ce1596fead6c4a5b625b245ff25c89c4",
+    ".trellis/workflow.md": "f4b8a6f89017f62071986d6d36cc32c4c7f01fe6f023f0fd9311eddc57d8c94f",
     ".claude/hooks/inject-workflow-state.py": "0684fb17d0d42b36d1549e9bc0a905d4c06f714e2b2008d74d9ab0d2c1c2b626",
     ".agents/skills/trellis-brainstorm/SKILL.md": "a1fa18fbd4bf528ce001c8fd013b8099f653c3379d1f7dda054e37e00552a17f",
     ".agents/skills/trellis-update-spec/SKILL.md": "003ce08a3404aeb50998029392c4d4e57b626edf526d3ebd585032bb92dcbb96",

--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -195,6 +195,7 @@ Then run `task.py start <task-dir>` to flip status to in_progress.
      commit, including Phase 3.3 spec update and Phase 3.4 commit. -->
 
 [workflow-state:in_progress]
+**Tools**: `trellis-implement` / `trellis-research` are sub-agent types only (Task/Agent tool, NOT Skill — there is no skill by these names). `trellis-update-spec` is a skill. `trellis-check` exists as both; prefer the Agent form when verifying after code changes.
 **Flow**: trellis-implement → trellis-check → trellis-update-spec → commit (Phase 3.4) → `/trellis:finish-work`.
 **Main-session default (no override)**: dispatch the `trellis-implement` / `trellis-check` sub-agents — the main agent does NOT edit code by default. Phase 3.4 commit (required, once): after trellis-update-spec, or whenever implementation is verifiably complete, the main agent **drives the commit** — state the commit plan in user-facing text, then run `git commit` — BEFORE suggesting `/trellis:finish-work`. `/finish-work` refuses to run on a dirty working tree (paths outside `.trellis/workspace/` and `.trellis/tasks/`).
 **Sub-agent self-exemption**: if you are already running as `trellis-implement`, implement directly from the loaded task context and do NOT spawn another `trellis-implement`; if you are already running as `trellis-check`, review/fix directly and do NOT spawn another `trellis-check`. The default dispatch rule applies to the main session only.

--- a/packages/cli/src/templates/trellis/workflow.md
+++ b/packages/cli/src/templates/trellis/workflow.md
@@ -195,6 +195,7 @@ Then run `task.py start <task-dir>` to flip status to in_progress.
      commit, including Phase 3.3 spec update and Phase 3.4 commit. -->
 
 [workflow-state:in_progress]
+**Tools**: `trellis-implement` / `trellis-research` are sub-agent types only (Task/Agent tool, NOT Skill — there is no skill by these names). `trellis-update-spec` is a skill. `trellis-check` exists as both; prefer the Agent form when verifying after code changes.
 **Flow**: trellis-implement → trellis-check → trellis-update-spec → commit (Phase 3.4) → `/trellis:finish-work`.
 **Main-session default (no override)**: dispatch the `trellis-implement` / `trellis-check` sub-agents — the main agent does NOT edit code by default. Phase 3.4 commit (required, once): after trellis-update-spec, or whenever implementation is verifiably complete, the main agent **drives the commit** — state the commit plan in user-facing text, then run `git commit` — BEFORE suggesting `/trellis:finish-work`. `/finish-work` refuses to run on a dirty working tree (paths outside `.trellis/workspace/` and `.trellis/tasks/`).
 **Sub-agent self-exemption**: if you are already running as `trellis-implement`, implement directly from the loaded task context and do NOT spawn another `trellis-implement`; if you are already running as `trellis-check`, review/fix directly and do NOT spawn another `trellis-check`. The default dispatch rule applies to the main session only.


### PR DESCRIPTION
## Problem / 问题

In the per-turn `[workflow-state:in_progress]` breadcrumb, the **Flow** line lists three identifiers in identical backtick formatting:

```
**Flow**: trellis-implement → trellis-check → trellis-update-spec → commit (Phase 3.4) → `/trellis:finish-work`.
```

But these three are different *kinds* of things:

| Identifier | What it actually is |
| --- | --- |
| `trellis-implement` | Sub-agent type only (lives in `.claude/agents/`, no matching skill) |
| `trellis-research` | Sub-agent type only (no matching skill) |
| `trellis-update-spec` | **Skill** only (lives in `.agents/skills/`) |
| `trellis-check` | **Both** — sub-agent and skill |

When a Claude Code (or other tool-using) main session sees the Flow line in isolation — and notices that all the *other* per-turn breadcrumbs reference skills like `trellis-brainstorm` — it tends to generalize "anything `trellis-*` in backticks = skill" and call the **Skill** tool with `trellis-implement`. That fails with `skill not found` and confuses the user.

I hit this repeatedly in my own project; the fix below is what I applied locally before realizing the same ambiguity exists upstream.

在每轮注入的 `[workflow-state:in_progress]` breadcrumb 里，**Flow** 那一行用同样的反引号格式罗列了三个名字，但它们其实是不同种类的东西（一个是 sub-agent、一个是 skill、一个两者皆有）。在主会话看不到完整 workflow.md 上下文时，模型容易把 `trellis-implement` 也当成 skill 用 Skill 工具调用，导致 "skill not found"。

## Fix

Add **one short line** at the top of the `[workflow-state:in_progress]` block to disambiguate the three identifiers:

```
**Tools**: \`trellis-implement\` / \`trellis-research\` are sub-agent types only (Task/Agent tool, NOT Skill — there is no skill by these names). \`trellis-update-spec\` is a skill. \`trellis-check\` exists as both; prefer the Agent form when verifying after code changes.
```

- Local change only — does not touch `[workflow-state:in_progress-inline]`, since that block already uses only true skills (`trellis-before-dev` / `trellis-check` / `trellis-update-spec`) and has no ambiguity.
- Per-turn token cost: ~50 tokens added to in_progress breadcrumb. Cheap relative to the main thread spinning on a failed Skill call.

## Files changed

- `packages/cli/src/templates/trellis/workflow.md` — canonical template (sync target for new projects)
- `.trellis/workflow.md` — project's own copy (kept in lockstep with the template per existing convention)
- `.trellis/.template-hashes.json` — refreshed hash for `.trellis/workflow.md`

## Verification

- `pnpm lint` — passes
- `node -e` SHA-256 of the new `.trellis/workflow.md` matches `computeHash()` in `packages/cli/src/utils/template-hash.ts` and the value committed to `.template-hashes.json`