### PR TITLE
docs(readme): revert slogan to 'team scale' positioning (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-<strong>The harness that makes coding agents production-ready</strong><br/>
-<sub>Start a feature in Gemini, continue in Claude Code, ship it with Codex — or hand it off to a teammate at any step. Context, specs, and standards are shared across every agent and every teammate, so anyone's best spec lifts the whole team.</sub>
+<strong>Make AI coding reliable at team scale.</strong><br/>
+<sub>A team AI coding harness for progressive specs, custom workflows, task context, and memory across Claude Code, Cursor, OpenCode, Codex, Kiro, Kilo, Gemini CLI, Antigravity, Windsurf, Qoder, CodeBuddy, GitHub Copilot, Droid, and Pi Agent.</sub>
 </p>
 
 <p align="center">

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-<strong>让 AI Agent 真正具备生产力的 Coding Harness</strong><br/>
-<sub>用 Gemini 写前端，Claude Code 写后端，Codex 代码审查，或者交给团队接力开发 —— Trellis 将上下文、规范与标准在所有平台和团队内部之间共享，无需 handoff 就可以接着之前的进度继续开发，而且任何人的最佳实践都能提升整个团队的能力。</sub>
+<strong>给 AI 立规矩的开源框架</strong><br/>
+<sub>支持 Claude Code、Cursor、OpenCode、Codex、Kiro、Kilo、Gemini CLI、Antigravity、Windsurf、Qoder、CodeBuddy、GitHub Copilot、Droid 和 Pi Agent。</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Roll the README slogan back to the 4-28 wording ([8d53c048](https://github.com/mindfold-ai/Trellis/commit/8d53c048) "docs: bring README refresh to beta") for both `README.md` and `README_CN.md`. The current 5-12 "agent handoff" narrative gets replaced with the earlier team-scale positioning.

| Side | Before (origin/main) | After (this PR) |
|---|---|---|
| EN main | The harness that makes coding agents production-ready | **Make AI coding reliable at team scale.** |
| ZH main | 让 AI Agent 真正具备生产力的 Coding Harness | **给 AI 立规矩的开源框架** |
| Subtitle | Gemini → Claude → Codex handoff narrative | A team AI coding harness for progressive specs, custom workflows, task context, and memory + platform list |

## Platform list

The subtitle platform list is refreshed against the **current docs site** ([advanced/multi-platform](https://docs.trytrellis.app/advanced/multi-platform)) rather than copying 4-28 verbatim — so it reflects the current 14 platforms instead of the older list.

Changes vs the 4-28 version:
- iFlow removed (no longer in docs site list)
- "Factory Droid" → "Droid" (docs site name)
- Order follows the docs headline tuple

Final list (14): Claude Code, Cursor, OpenCode, Codex, Kiro, Kilo, Gemini CLI, Antigravity, Windsurf, Qoder, CodeBuddy, GitHub Copilot, Droid, and Pi Agent.

## Scope

- Only the `<strong>` + `<sub>` slogan block changes — 4 lines total across both files.
- No changes to badges, demo GIF, links, body, FAQ, scenarios, or community sections.

## Test plan

- [ ] Visual check on GitHub render for both `README.md` and `README_CN.md`
- [ ] Confirm middle-of-page demo GIF + badges still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)