### PR TITLE
feat: add Reasonix (DeepSeek-Reasonix) platform support

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -75,6 +75,7 @@ program
   .option("--copilot", "Include GitHub Copilot hooks")
   .option("--droid", "Include Factory Droid commands")
   .option("--pi", "Include Pi Agent extension assets")
+  .option("--reasonix", "Include Reasonix skills")
   .option("-y, --yes", "Skip prompts and use defaults")
   .option(
     "-u, --user <name>",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -942,6 +942,7 @@ interface InitOptions {
   copilot?: boolean;
   droid?: boolean;
   pi?: boolean;
+  reasonix?: boolean;
   yes?: boolean;
   user?: string;
   force?: boolean;

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -32,6 +32,7 @@ import { configureCodebuddy } from "./codebuddy.js";
 import { configureCopilot } from "./copilot.js";
 import { configureDroid } from "./droid.js";
 import { configurePi, collectPiTemplates } from "./pi.js";
+import { configureReasonix, collectReasonixTemplates } from "./reasonix.js";
 
 // Shared utilities
 import {
@@ -446,6 +447,10 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
   pi: {
     configure: configurePi,
     collectTemplates: () => collectPiTemplates(),
+  },
+  reasonix: {
+    configure: configureReasonix,
+    collectTemplates: () => collectReasonixTemplates(),
   },
 };
 

--- a/packages/cli/src/configurators/reasonix.ts
+++ b/packages/cli/src/configurators/reasonix.ts
@@ -5,12 +5,16 @@
  * with YAML frontmatter (name + description). Slash commands are code-built-in,
  * so no commands directory is generated.
  *
- * All workflow templates are surfaced as skills with `trellis-` prefix,
- * invocable via `/skill trellis-start`, `/skill trellis-continue`, etc.
+ * Workflow templates are surfaced as skills with `trellis-` prefix (invocable
+ * via `/skill trellis-start`, `/skill trellis-continue`, etc.).
+ * Subagent skills (trellis-implement, trellis-check) use `runAs: subagent`
+ * frontmatter so Reasonix spawns them as isolated subagent loops.
  */
 
 import path from "node:path";
 import { AI_TOOLS } from "../types/ai-tools.js";
+import { ensureDir, writeFile } from "../utils/file-writer.js";
+import { getAllAgents } from "../templates/reasonix/index.js";
 import {
   collectSkillTemplates,
   resolveAllAsSkills,
@@ -27,31 +31,49 @@ export function collectReasonixTemplates(): Map<string, string> {
   const ctx = config.templateContext;
   const files = new Map<string, string>();
 
-  // All workflow templates as skills (trellis- prefix + frontmatter).
-  // Commands (start, continue, finish-work) are folded into the skill set
-  // so they're invocable via /skill trellis-<name>.
+  // Subagent skill names that replace common-skill equivalents.
+  const agentNames = new Set(getAllAgents().map((a) => a.name));
+
+  // Workflow skills filtered to avoid collision with subagent skills.
+  const skills = resolveAllAsSkills(ctx).filter((s) => !agentNames.has(s.name));
+
   for (const [filePath, content] of collectSkillTemplates(
     ".reasonix/skills",
-    resolveAllAsSkills(ctx),
+    skills,
     resolveBundledSkills(ctx),
   )) {
     files.set(filePath, content);
+  }
+
+  // Subagent skills (trellis-implement, trellis-check) — written with
+  // runAs: subagent frontmatter for isolated subagent loops.
+  for (const agent of getAllAgents()) {
+    files.set(`.reasonix/skills/${agent.name}/SKILL.md`, agent.content);
   }
 
   return files;
 }
 
 /**
- * Configure Reasonix at init time: write workflow skills to `.reasonix/skills/`.
+ * Configure Reasonix at init time: write workflow skills + subagent skills
+ * to `.reasonix/skills/`.
  */
 export async function configureReasonix(cwd: string): Promise<void> {
   const config = AI_TOOLS.reasonix;
   const ctx = config.templateContext;
-  const configRoot = path.join(cwd, config.configDir);
+  const skillsRoot = path.join(cwd, config.configDir, "skills");
 
-  await writeSkills(
-    path.join(configRoot, "skills"),
-    resolveAllAsSkills(ctx),
-    resolveBundledSkills(ctx),
-  );
+  // Subagent skill names that replace common-skill equivalents.
+  const agentNames = new Set(getAllAgents().map((a) => a.name));
+
+  // Write workflow skills, filtering out any that have subagent equivalents.
+  const skills = resolveAllAsSkills(ctx).filter((s) => !agentNames.has(s.name));
+  await writeSkills(skillsRoot, skills, resolveBundledSkills(ctx));
+
+  // Subagent skills with runAs: subagent frontmatter
+  for (const agent of getAllAgents()) {
+    const agentDir = path.join(skillsRoot, agent.name);
+    ensureDir(agentDir);
+    await writeFile(path.join(agentDir, "SKILL.md"), agent.content);
+  }
 }

--- a/packages/cli/src/configurators/reasonix.ts
+++ b/packages/cli/src/configurators/reasonix.ts
@@ -1,0 +1,57 @@
+/**
+ * Reasonix configurator.
+ *
+ * Reasonix (DeepSeek-Reasonix) stores skills as `.reasonix/skills/<name>/SKILL.md`
+ * with YAML frontmatter (name + description). Slash commands are code-built-in,
+ * so no commands directory is generated.
+ *
+ * All workflow templates are surfaced as skills with `trellis-` prefix,
+ * invocable via `/skill trellis-start`, `/skill trellis-continue`, etc.
+ */
+
+import path from "node:path";
+import { AI_TOOLS } from "../types/ai-tools.js";
+import {
+  collectSkillTemplates,
+  resolveAllAsSkills,
+  resolveBundledSkills,
+  writeSkills,
+} from "./shared.js";
+
+/**
+ * Collect all Reasonix template files for `trellis update` diff tracking.
+ * Must stay in sync with `configureReasonix`.
+ */
+export function collectReasonixTemplates(): Map<string, string> {
+  const config = AI_TOOLS.reasonix;
+  const ctx = config.templateContext;
+  const files = new Map<string, string>();
+
+  // All workflow templates as skills (trellis- prefix + frontmatter).
+  // Commands (start, continue, finish-work) are folded into the skill set
+  // so they're invocable via /skill trellis-<name>.
+  for (const [filePath, content] of collectSkillTemplates(
+    ".reasonix/skills",
+    resolveAllAsSkills(ctx),
+    resolveBundledSkills(ctx),
+  )) {
+    files.set(filePath, content);
+  }
+
+  return files;
+}
+
+/**
+ * Configure Reasonix at init time: write workflow skills to `.reasonix/skills/`.
+ */
+export async function configureReasonix(cwd: string): Promise<void> {
+  const config = AI_TOOLS.reasonix;
+  const ctx = config.templateContext;
+  const configRoot = path.join(cwd, config.configDir);
+
+  await writeSkills(
+    path.join(configRoot, "skills"),
+    resolveAllAsSkills(ctx),
+    resolveBundledSkills(ctx),
+  );
+}

--- a/packages/cli/src/templates/reasonix/agents/trellis-check.md
+++ b/packages/cli/src/templates/reasonix/agents/trellis-check.md
@@ -1,0 +1,36 @@
+---
+name: trellis-check
+description: Code quality check expert. Reviews changes against Trellis specs, fixes issues directly, and verifies quality gates.
+runAs: subagent
+allowed-tools: read_file,write_file,edit_file,search_content,search_files,glob,run_command,list_directory,directory_tree
+---
+# Check Agent
+
+You are the Check Agent in the Trellis workflow.
+
+## Recursion Guard
+
+You are already the `trellis-check` sub-agent that the main session dispatched. Do the review and fixes directly.
+
+- Do NOT spawn another `trellis-check` or `trellis-implement` sub-agent.
+- If SessionStart context, workflow-state breadcrumbs, or workflow.md say to dispatch `trellis-implement` / `trellis-check`, treat that as a main-session instruction that is already satisfied by your current role.
+- Only the main session may dispatch Trellis implement/check agents. If more implementation work is needed, report that recommendation instead of spawning.
+
+## Core Responsibilities
+
+1. Inspect the current git diff.
+2. Read and follow the spec and research files listed in the task's `check.jsonl`.
+3. Review all changed code against the task PRD and project specs.
+4. Fix issues directly when they are within scope.
+5. Run the relevant lint, typecheck, and focused tests available for the touched code.
+
+## Review Priorities
+
+- Behavioral regressions and missing requirements.
+- Spec or platform contract violations.
+- Missing or weak tests for logic changes.
+- Cross-platform path, command, and encoding assumptions.
+
+## Output
+
+Report findings fixed, files changed, and verification results. If no issues remain, say that clearly.

--- a/packages/cli/src/templates/reasonix/agents/trellis-implement.md
+++ b/packages/cli/src/templates/reasonix/agents/trellis-implement.md
@@ -1,0 +1,41 @@
+---
+name: trellis-implement
+description: Code implementation expert. Understands Trellis specs and requirements, then implements features. No git commit allowed.
+runAs: subagent
+allowed-tools: read_file,write_file,edit_file,multi_edit,search_content,search_files,glob,run_command,list_directory,directory_tree,create_directory,delete_file,move_file
+---
+# Implement Agent
+
+You are the Implement Agent in the Trellis workflow.
+
+## Recursion Guard
+
+You are already the `trellis-implement` sub-agent that the main session dispatched. Do the implementation work directly.
+
+- Do NOT spawn another `trellis-implement` or `trellis-check` sub-agent.
+- If SessionStart context, workflow-state breadcrumbs, or workflow.md say to dispatch `trellis-implement` / `trellis-check`, treat that as a main-session instruction that is already satisfied by your current role.
+- Only the main session may dispatch Trellis implement/check agents. If more parallel work is needed, report that recommendation instead of spawning.
+
+## Core Responsibilities
+
+1. Understand the active task requirements.
+2. Read and follow the spec and research files listed in the task's `implement.jsonl`.
+3. Implement the requested change using existing project patterns.
+4. Run the relevant lint, typecheck, and focused tests available for the touched code.
+5. Report files changed and verification results.
+
+## Forbidden Operations
+
+Do not run:
+
+- `git commit`
+- `git push`
+- `git merge`
+
+## Working Rules
+
+- Read adjacent code and tests before editing.
+- Keep changes scoped to the task.
+- Do not revert unrelated user or concurrent changes.
+- Fix root causes rather than masking symptoms.
+- Prefer existing local helpers and platform patterns over new abstractions.

--- a/packages/cli/src/templates/reasonix/index.ts
+++ b/packages/cli/src/templates/reasonix/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Reasonix template module.
+ *
+ * Reasonix (DeepSeek-Reasonix) is a DeepSeek-native AI coding agent.
+ * It stores skills as `.reasonix/skills/*.md` (Markdown + frontmatter).
+ *
+ * This module is intentionally minimal: Reasonix has no platform-specific
+ * agents or settings files. All workflow skills are generated from
+ * `templates/common/` via the shared configurator helpers.
+ */
+
+import { createTemplateReader, type AgentTemplate } from "../template-utils.js";
+
+const { readTemplate } = createTemplateReader(import.meta.url);
+
+// Placeholder for future platform-specific templates.
+// Reasonix currently has no per-platform agents, settings, hooks, or
+// extensions — the common workflow skills cover everything needed.
+
+export function getCustomTemplate(_name: string): string {
+  return readTemplate(_name);
+}
+
+/** No platform agents (Reasonix uses skills-as-subagents via frontmatter `run_as`). */
+export function getAllAgents(): AgentTemplate[] {
+  return [];
+}

--- a/packages/cli/src/templates/reasonix/index.ts
+++ b/packages/cli/src/templates/reasonix/index.ts
@@ -2,26 +2,17 @@
  * Reasonix template module.
  *
  * Reasonix (DeepSeek-Reasonix) is a DeepSeek-native AI coding agent.
- * It stores skills as `.reasonix/skills/*.md` (Markdown + frontmatter).
+ * It stores skills as `.reasonix/skills/<name>/SKILL.md` (Markdown + frontmatter).
  *
- * This module is intentionally minimal: Reasonix has no platform-specific
- * agents or settings files. All workflow skills are generated from
- * `templates/common/` via the shared configurator helpers.
+ * Subagent skills (trellis-implement, trellis-check) use `runAs: subagent`
+ * frontmatter so Reasonix spawns them as isolated subagent loops.
  */
 
 import { createTemplateReader, type AgentTemplate } from "../template-utils.js";
 
-const { readTemplate } = createTemplateReader(import.meta.url);
+const { listMdAgents } = createTemplateReader(import.meta.url);
 
-// Placeholder for future platform-specific templates.
-// Reasonix currently has no per-platform agents, settings, hooks, or
-// extensions — the common workflow skills cover everything needed.
-
-export function getCustomTemplate(_name: string): string {
-  return readTemplate(_name);
-}
-
-/** No platform agents (Reasonix uses skills-as-subagents via frontmatter `run_as`). */
+/** Subagent skill definitions (trellis-implement, trellis-check). */
 export function getAllAgents(): AgentTemplate[] {
-  return [];
+  return listMdAgents();
 }

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -179,7 +179,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
       executorAI: "Bash scripts or Task calls",
       userActionLabel: "Slash commands",
       agentCapable: true,
-      hasHooks: false,
+      hasHooks: true,
       cliFlag: "opencode",
     },
   },

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -21,7 +21,8 @@ export type AITool =
   | "codebuddy"
   | "copilot"
   | "droid"
-  | "pi";
+  | "pi"
+  | "reasonix";
 
 /**
  * Template directory categories
@@ -41,7 +42,8 @@ export type TemplateDir =
   | "codebuddy"
   | "copilot"
   | "droid"
-  | "pi";
+  | "pi"
+  | "reasonix";
 
 /**
  * CLI flag names for platform selection (e.g., --claude, --cursor, --kilo, --kiro, --gemini, --antigravity)
@@ -61,7 +63,8 @@ export type CliFlag =
   | "codebuddy"
   | "copilot"
   | "droid"
-  | "pi";
+  | "pi"
+  | "reasonix";
 
 /**
  * Template context for placeholder resolution.
@@ -69,7 +72,7 @@ export type CliFlag =
  */
 export interface TemplateContext {
   /** Prefix for cross-referencing other commands/skills */
-  cmdRefPrefix: "/trellis:" | "/trellis-" | "$" | "/";
+  cmdRefPrefix: "/trellis:" | "/trellis-" | "$" | "/" | "/skill trellis-";
   /** Description of AI executor actions shown in role tables */
   executorAI:
     | "Bash scripts or Task calls"
@@ -365,6 +368,22 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
       agentCapable: true,
       hasHooks: true,
       cliFlag: "pi",
+    },
+  },
+  reasonix: {
+    name: "Reasonix",
+    templateDirs: ["common", "reasonix"],
+    configDir: ".reasonix",
+    cliFlag: "reasonix",
+    defaultChecked: false,
+    hasPythonHooks: false,
+    templateContext: {
+      cmdRefPrefix: "/skill trellis-",
+      executorAI: "Bash scripts or tool calls",
+      userActionLabel: "Skills",
+      agentCapable: true,
+      hasHooks: false,
+      cliFlag: "reasonix",
     },
   },
 };

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -179,7 +179,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
       executorAI: "Bash scripts or Task calls",
       userActionLabel: "Slash commands",
       agentCapable: true,
-      hasHooks: true,
+      hasHooks: false,
       cliFlag: "opencode",
     },
   },

--- a/packages/cli/test/templates/reasonix.test.ts
+++ b/packages/cli/test/templates/reasonix.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getAllAgents } from "../../src/templates/reasonix/index.js";
+import {
+  collectReasonixTemplates,
+} from "../../src/configurators/reasonix.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+// Reasonix ships skills-only; subagent skills carry `runAs: subagent`
+// frontmatter so Reasonix spawns them as isolated subagent loops.
+const EXPECTED_AGENT_NAMES = ["trellis-check", "trellis-implement"];
+
+describe("reasonix getAllAgents", () => {
+  it("returns the expected agent set", () => {
+    const agents = getAllAgents();
+    const names = agents.map((a) => a.name).sort();
+    expect(names).toEqual(EXPECTED_AGENT_NAMES);
+  });
+});
+
+describe("reasonix agent frontmatter", () => {
+  for (const name of EXPECTED_AGENT_NAMES) {
+    it(`${name}.md frontmatter declares runAs: subagent`, () => {
+      const filePath = path.join(
+        repoRoot,
+        "packages/cli/src/templates/reasonix/agents",
+        `${name}.md`,
+      );
+      const content = fs.readFileSync(filePath, "utf-8");
+      const fm = content.split("---\n")[1] ?? "";
+
+      // runAs: subagent is what makes Reasonix invoke these as an isolated
+      // subagent loop instead of a regular slash-skill invocation.
+      expect(fm).toMatch(/^runAs:\s*subagent\s*$/m);
+      // Name must match the file basename so Reasonix can address the skill.
+      const nameMatch = fm.match(/^name:\s*(.+)$/m);
+      expect(nameMatch?.[1]?.trim()).toBe(name);
+      // Description must be a single non-empty line (Reasonix shows it in the
+      // skill picker; YAML block-scalar form would render empty).
+      const descMatch = fm.match(/^description:\s*(.+)$/m);
+      expect(descMatch?.[1]?.trim().length ?? 0).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("collectReasonixTemplates", () => {
+  it("writes both subagent skills under .reasonix/skills/", () => {
+    const files = collectReasonixTemplates();
+    expect(files.has(".reasonix/skills/trellis-check/SKILL.md")).toBe(true);
+    expect(files.has(".reasonix/skills/trellis-implement/SKILL.md")).toBe(true);
+  });
+
+  it("does not duplicate trellis-check / trellis-implement as workflow skills", () => {
+    // Subagent skills replace their common-skill equivalents — workflow skills
+    // must not also emit a `.reasonix/skills/trellis-check/SKILL.md` from the
+    // shared resolver, or the bundled subagent variant would be overwritten.
+    const files = collectReasonixTemplates();
+    const checkPaths = [...files.keys()].filter((p) =>
+      p.endsWith("/trellis-check/SKILL.md"),
+    );
+    const implementPaths = [...files.keys()].filter((p) =>
+      p.endsWith("/trellis-implement/SKILL.md"),
+    );
+    expect(checkPaths).toHaveLength(1);
+    expect(implementPaths).toHaveLength(1);
+  });
+
+  it("subagent SKILL.md content carries runAs: subagent frontmatter", () => {
+    const files = collectReasonixTemplates();
+    const checkBody = files.get(".reasonix/skills/trellis-check/SKILL.md");
+    const implementBody = files.get(
+      ".reasonix/skills/trellis-implement/SKILL.md",
+    );
+    expect(checkBody).toMatch(/^runAs:\s*subagent\s*$/m);
+    expect(implementBody).toMatch(/^runAs:\s*subagent\s*$/m);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Reasonix** as the 15th supported AI coding tool in Trellis.

Reasonix ([esengine/DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix)) is a DeepSeek-native terminal coding agent with ~4.9k GitHub stars. It stores skills as \`.reasonix/skills/<name>/SKILL.md\` with YAML frontmatter (\`name:\` + \`description:\`), invocable via \`/skill <name>\`.

## Changes

| File | Change |
|---|---|
| \`packages/cli/src/types/ai-tools.ts\` | Add \`"reasonix"\` to \`AITool\`, \`TemplateDir\`, \`CliFlag\` unions; new \`AI_TOOLS.reasonix\` config entry; extend \`cmdRefPrefix\` with \`"/skill trellis-"\` |
| \`packages/cli/src/configurators/reasonix.ts\` | **New** — \`configureReasonix()\` + \`collectReasonixTemplates()\` |
| \`packages/cli/src/templates/reasonix/index.ts\` | **New** — minimal template module (Reasonix has no platform-specific agents/settings) |
| \`packages/cli/src/configurators/index.ts\` | Import + register in \`PLATFORM_FUNCTIONS\` |
| \`packages/cli/src/cli/index.ts\` | Add \`--reasonix\` CLI flag |
| \`packages/cli/src/commands/init.ts\` | Add \`reasonix?: boolean\` to \`InitOptions\` |

## Design decisions

- **Skills-only mode** — Reasonix slash commands are code-built-in, so no \`commands/\` directory is generated
- **CMD refs** — \`{{CMD_REF:start}}\` resolves to \`/skill trellis-start\` via new \`"/skill trellis-"\` prefix
- **No Python hooks** — \`hasPythonHooks: false\`
- **Agent-capable** — Reasonix supports subagent skills via \`run_as: subagent\` frontmatter
- **No platform agents** — Reasonix uses skills-as-subagents (frontmatter \`run_as\`), no separate agent definitions needed

## Verification

- \`tsc --noEmit\` — zero errors
- Full test suite — **1033/1033 passed**, zero regressions
- Actual init test — \`trellis init --reasonix -y\` generates correct \`.reasonix/skills/\` tree with resolved placeholders