### PR TITLE
feat(cli): refresh registry-backed spec templates

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -43,6 +43,10 @@ import {
   homedirBypassEnabled,
 } from "../utils/cwd-guard.js";
 import {
+  writeSpecRegistryConfig,
+  type SpecRegistryConfig,
+} from "../utils/registry-config.js";
+import {
   fetchTemplateIndex,
   probeRegistryIndex,
   downloadTemplateById,
@@ -56,10 +60,31 @@ import {
   type RegistryBackend,
 } from "../utils/template-fetcher.js";
 import { setupProxy, maskProxyUrl } from "../utils/proxy.js";
+import { toPosix } from "../utils/posix.js";
+import { updateHashes } from "../utils/template-hash.js";
 
 const MIN_PYTHON_MAJOR = 3;
 const MIN_PYTHON_MINOR = 9;
 const PYTHON_VERSION_RE = /Python (\d+)\.(\d+)/;
+
+function collectSpecPaths(cwd: string): Set<string> {
+  const specRoot = path.join(cwd, PATHS.SPEC);
+  const paths = new Set<string>();
+  if (!fs.existsSync(specRoot)) return paths;
+
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        paths.add(toPosix(path.relative(cwd, fullPath)));
+      }
+    }
+  };
+  walk(specRoot);
+  return paths;
+}
 
 export function isSupportedPythonVersion(versionOutput: string): boolean {
   const match = versionOutput.match(PYTHON_VERSION_RE);
@@ -1095,12 +1120,14 @@ export async function init(options: InitOptions): Promise<void> {
   const tasksDirEarly = path.join(cwd, PATHS.TASKS);
   const tasksEmptyEarly =
     !fs.existsSync(tasksDirEarly) || fs.readdirSync(tasksDirEarly).length === 0;
+  const hasTemplateRequest = !!options.template || !!options.registry;
 
   if (
     !isFirstInit &&
     !options.force &&
     !options.skipExisting &&
-    !tasksEmptyEarly
+    !tasksEmptyEarly &&
+    !hasTemplateRequest
   ) {
     const reinitDone = await handleReinit(
       cwd,
@@ -1134,9 +1161,11 @@ export async function init(options: InitOptions): Promise<void> {
 
   // Parse custom registry source early (needed by both monorepo + single-repo flows)
   let registry: RegistrySource | undefined;
+  let registrySourceForConfig: string | undefined;
   if (options.registry) {
     try {
       registry = parseRegistrySource(options.registry);
+      registrySourceForConfig = options.registry;
     } catch (error) {
       console.log(
         chalk.red(
@@ -1393,6 +1422,23 @@ export async function init(options: InitOptions): Promise<void> {
   } else if (options.template) {
     // Template specified via --template flag
     selectedTemplate = options.template;
+    if (registry) {
+      const probeResult = await probeRegistryIndex(indexUrl, registry);
+      registryBackend = probeResult.backend;
+      if (probeResult.error) {
+        console.log(chalk.red(`Error: ${probeResult.error.message}`));
+        return;
+      }
+      if (probeResult.isNotFound) {
+        console.log(
+          chalk.red(
+            "Error: Registry has no index.json. Remove --template to use direct download mode.",
+          ),
+        );
+        return;
+      }
+      fetchedTemplates = probeResult.templates;
+    }
   } else if (!options.yes) {
     // Interactive mode: show template selection
     const timeoutSec = TIMEOUTS.INDEX_FETCH_MS / 1000;
@@ -1495,6 +1541,7 @@ export async function init(options: InitOptions): Promise<void> {
           }
           try {
             registry = parseRegistrySource(customSource);
+            registrySourceForConfig = customSource;
             fetchedTemplates = []; // Reset so direct-download guard works correctly
             // Probe index.json to detect marketplace vs direct download
             const customIndexUrl = `${registry.rawBaseUrl}/index.json`;
@@ -1574,6 +1621,7 @@ export async function init(options: InitOptions): Promise<void> {
                 ),
               );
               registry = undefined; // Reset so we don't fall through to direct download
+              registrySourceForConfig = undefined;
             }
           } catch (error) {
             console.log(
@@ -1657,6 +1705,7 @@ export async function init(options: InitOptions): Promise<void> {
   // ==========================================================================
 
   let useRemoteTemplate = false;
+  let registrySpecConfigToPersist: SpecRegistryConfig | null = null;
 
   if (selectedTemplate) {
     // Marketplace mode: download specific template by ID
@@ -1682,6 +1731,12 @@ export async function init(options: InitOptions): Promise<void> {
       } else {
         console.log(chalk.green(`   ${result.message}`));
         useRemoteTemplate = true;
+        if (registry) {
+          registrySpecConfigToPersist = {
+            source: registrySourceForConfig ?? registry.gigetSource,
+            template: selectedTemplate,
+          };
+        }
       }
     } else {
       console.log(chalk.yellow(`   ${result.message}`));
@@ -1735,6 +1790,9 @@ export async function init(options: InitOptions): Promise<void> {
       } else {
         console.log(chalk.green(`   ${result.message}`));
         useRemoteTemplate = true;
+        registrySpecConfigToPersist = {
+          source: registrySourceForConfig ?? registry.gigetSource,
+        };
       }
     } else {
       console.log(chalk.yellow(`   ${result.message}`));
@@ -1802,8 +1860,22 @@ export async function init(options: InitOptions): Promise<void> {
     stopRecordingWrites();
   }
 
+  if (registrySpecConfigToPersist) {
+    writeSpecRegistryConfig(cwd, registrySpecConfigToPersist);
+  }
+
   // Initialize template hashes for modification tracking
   const hashedCount = initializeHashes(cwd, { trackedPaths: writtenPaths });
+  if (useRemoteTemplate) {
+    const specFilesToHash = new Map<string, string>();
+    for (const relativePath of collectSpecPaths(cwd)) {
+      const content = fs.readFileSync(path.join(cwd, relativePath), "utf-8");
+      specFilesToHash.set(relativePath, content);
+    }
+    if (specFilesToHash.size > 0) {
+      updateHashes(cwd, specFilesToHash);
+    }
+  }
   if (hashedCount > 0) {
     console.log(
       chalk.gray(`📋 Tracking ${hashedCount} template files for updates`),

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import chalk from "chalk";
 import inquirer from "inquirer";
@@ -53,6 +54,16 @@ import {
 } from "../configurators/index.js";
 import { replacePythonCommandLiterals } from "../configurators/shared.js";
 import { pruneOrphanManifestKeys } from "../utils/manifest-prune.js";
+import {
+  fetchRegistrySpecTemplates,
+  collectDirectoryFiles,
+  removeDirectory,
+  parseRegistrySource,
+  probeRegistryIndex,
+  downloadTemplateById,
+  type RegistrySource,
+} from "../utils/template-fetcher.js";
+import { loadSpecRegistryConfig } from "../utils/registry-config.js";
 
 export interface UpdateOptions {
   dryRun?: boolean;
@@ -607,7 +618,119 @@ function preserveExistingClaudeStatusLine(
   }
 }
 
-function collectTemplateFiles(
+function preserveExistingRegistryConfig(cwd: string, template: string): string {
+  const registry = loadSpecRegistryConfig(cwd);
+  if (!registry) return template;
+  return (
+    template.trimEnd() +
+    "\n\n" +
+    "#-------------------------------------------------------------------------------\n" +
+    "# Registry\n" +
+    "#-------------------------------------------------------------------------------\n\n" +
+    "# Source used to install .trellis/spec. trellis update refreshes this\n" +
+    "# hash-tracked spec template while preserving local edits through the\n" +
+    "# normal update conflict flow.\n" +
+    "registry:\n" +
+    "  spec:\n" +
+    `    source: ${registry.source}\n` +
+    (registry.template ? `    template: ${registry.template}\n` : "")
+  );
+}
+
+async function collectRegistrySpecTemplates(
+  cwd: string,
+): Promise<Map<string, string>> {
+  const config = loadSpecRegistryConfig(cwd);
+  if (!config) return new Map();
+
+  let registry: RegistrySource;
+  try {
+    registry = parseRegistrySource(config.source);
+  } catch (error) {
+    console.log(
+      chalk.yellow(
+        `Warning: invalid registry.spec.source in .trellis/config.yaml: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    );
+    return new Map();
+  }
+
+  const probe = await probeRegistryIndex(
+    `${registry.rawBaseUrl}/index.json`,
+    registry,
+  );
+  if (probe.templates.length > 0) {
+    if (!config.template) {
+      console.log(
+        chalk.gray(
+          "Registry spec update skipped: marketplace registries require registry.spec.template.",
+        ),
+      );
+      return new Map();
+    }
+    const template = probe.templates.find(
+      (candidate) => candidate.id === config.template,
+    );
+    if (!template) {
+      console.log(
+        chalk.yellow(
+          `Warning: registry spec update skipped: template "${config.template}" was not found in registry index.`,
+        ),
+      );
+      return new Map();
+    }
+    const tempRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "trellis-registry-template-"),
+    );
+    try {
+      const result = await downloadTemplateById(
+        tempRoot,
+        config.template,
+        "overwrite",
+        template,
+        registry,
+        undefined,
+        probe.backend,
+      );
+      if (!result.success) {
+        console.log(
+          chalk.yellow(
+            `Warning: registry spec update skipped: ${result.message}`,
+          ),
+        );
+        return new Map();
+      }
+      return collectDirectoryFiles(path.join(tempRoot, PATHS.SPEC), PATHS.SPEC);
+    } finally {
+      await removeDirectory(tempRoot);
+    }
+  }
+  if (!probe.isNotFound) {
+    console.log(
+      chalk.yellow(
+        `Warning: registry spec update skipped: ${
+          probe.error?.message ?? "could not reach registry"
+        }`,
+      ),
+    );
+    return new Map();
+  }
+
+  const result = await fetchRegistrySpecTemplates(registry, probe.backend);
+  if (!result.success) {
+    console.log(
+      chalk.yellow(
+        `Warning: registry spec update skipped: ${result.message ?? "download failed"}`,
+      ),
+    );
+    return new Map();
+  }
+  return result.files;
+}
+
+async function collectTemplateFiles(
   cwd: string,
   extraPlatforms?: Set<AITool>,
   /**
@@ -619,7 +742,7 @@ function collectTemplateFiles(
    * "Modified by you" conflict prompt — they can skip per-file there.
    */
   bypassUpdateSkip = false,
-): Map<string, string> {
+): Promise<Map<string, string>> {
   const files = new Map<string, string>();
   const platforms = getConfiguredPlatforms(cwd);
   if (extraPlatforms) {
@@ -634,7 +757,10 @@ function collectTemplateFiles(
   }
 
   // Configuration
-  files.set(`${DIR_NAMES.WORKFLOW}/config.yaml`, configYamlTemplate);
+  files.set(
+    `${DIR_NAMES.WORKFLOW}/config.yaml`,
+    preserveExistingRegistryConfig(cwd, configYamlTemplate),
+  );
   files.set(`${DIR_NAMES.WORKFLOW}/.gitignore`, gitignoreTemplate);
   // workflow.md is included here because it is runtime-parsed by
   // get_context.py and shared hooks. Keep it on the normal template update
@@ -659,6 +785,10 @@ function collectTemplateFiles(
   }
 
   preserveExistingClaudeStatusLine(cwd, files);
+
+  for (const [filePath, content] of await collectRegistrySpecTemplates(cwd)) {
+    files.set(filePath, content);
+  }
 
   // Apply update.skip from config.yaml (unless bypassed for breaking release)
   if (!bypassUpdateSkip) {
@@ -1827,7 +1957,7 @@ export async function update(options: UpdateOptions): Promise<void> {
     })();
 
   // Collect templates (used for both migration classification and change analysis)
-  const templates = collectTemplateFiles(
+  const templates = await collectTemplateFiles(
     cwd,
     codexUpgradeNeeded ? new Set<AITool>(["codex"]) : undefined,
     breakingBypass,

--- a/packages/cli/src/utils/registry-config.ts
+++ b/packages/cli/src/utils/registry-config.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { DIR_NAMES } from "../constants/paths.js";
+import { toPosix } from "./posix.js";
+
+export interface SpecRegistryConfig {
+  source: string;
+  template?: string;
+}
+
+function configPath(cwd: string): string {
+  return path.join(cwd, DIR_NAMES.WORKFLOW, "config.yaml");
+}
+
+function stripYamlScalar(value: string): string {
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function specRegistryLines(config: SpecRegistryConfig): string[] {
+  const normalizedSource = toPosix(config.source);
+  return [
+    "  spec:",
+    `    source: ${normalizedSource}`,
+    ...(config.template ? [`    template: ${config.template}`] : []),
+  ];
+}
+
+export function loadSpecRegistryConfig(cwd: string): SpecRegistryConfig | null {
+  const filePath = configPath(cwd);
+  if (!fs.existsSync(filePath)) return null;
+
+  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+  let inRegistry = false;
+  let inSpec = false;
+  let source: string | null = null;
+  let template: string | undefined;
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+
+    if (/^registry:\s*$/.test(trimmed)) {
+      inRegistry = true;
+      inSpec = false;
+      continue;
+    }
+
+    if (inRegistry && /^\s{2}spec:\s*$/.test(trimmed)) {
+      inSpec = true;
+      continue;
+    }
+
+    if (inRegistry && trimmed !== "" && !trimmed.startsWith(" ")) {
+      if (source) return { source, ...(template ? { template } : {}) };
+      inRegistry = false;
+      inSpec = false;
+      continue;
+    }
+
+    if (inSpec) {
+      const sourceMatch = trimmed.match(/^\s{4}source:\s+(.+)$/);
+      if (sourceMatch) {
+        source = stripYamlScalar(sourceMatch[1]);
+        continue;
+      }
+      const templateMatch = trimmed.match(/^\s{4}template:\s+(.+)$/);
+      if (templateMatch) {
+        template = stripYamlScalar(templateMatch[1]);
+        continue;
+      }
+      if (trimmed !== "" && !trimmed.startsWith("    ")) {
+        if (source) return { source, ...(template ? { template } : {}) };
+        inSpec = false;
+      }
+    }
+  }
+
+  if (source) return { source, ...(template ? { template } : {}) };
+  return null;
+}
+
+export function writeSpecRegistryConfig(
+  cwd: string,
+  config: SpecRegistryConfig,
+): void {
+  const filePath = configPath(cwd);
+  if (!fs.existsSync(filePath)) return;
+
+  const normalizedSource = toPosix(config.source);
+  const specLines = specRegistryLines(config);
+  const content = fs.readFileSync(filePath, "utf-8");
+  if (/^registry:\s*$/m.test(content)) {
+    const lines = content.split("\n");
+    const output: string[] = [];
+    let inRegistry = false;
+    let inSpec = false;
+    let sawSpec = false;
+    let wroteSource = false;
+    let wroteTemplate = false;
+    for (const line of lines) {
+      const trimmed = line.trimEnd();
+      if (/^registry:\s*$/.test(trimmed)) {
+        inRegistry = true;
+        inSpec = false;
+        sawSpec = false;
+        wroteSource = false;
+        output.push(line);
+        continue;
+      }
+      if (inRegistry && trimmed !== "" && !trimmed.startsWith(" ")) {
+        if (inSpec) {
+          if (!wroteSource) output.push(`    source: ${normalizedSource}`);
+          if (config.template && !wroteTemplate) {
+            output.push(`    template: ${config.template}`);
+          }
+        } else if (!sawSpec) {
+          output.push(...specLines);
+        }
+        inRegistry = false;
+        inSpec = false;
+      }
+      if (inRegistry && /^\s{2}spec:\s*$/.test(trimmed)) {
+        inSpec = true;
+        sawSpec = true;
+        wroteSource = false;
+        wroteTemplate = false;
+        output.push(line);
+        continue;
+      }
+      if (inSpec && /^\s{4}source:\s+/.test(trimmed)) {
+        output.push(`    source: ${normalizedSource}`);
+        wroteSource = true;
+        continue;
+      }
+      if (inSpec && /^\s{4}template:\s+/.test(trimmed)) {
+        if (config.template) {
+          output.push(`    template: ${config.template}`);
+          wroteTemplate = true;
+        }
+        continue;
+      }
+      if (inSpec && trimmed !== "" && !trimmed.startsWith("    ")) {
+        if (!wroteSource) output.push(`    source: ${normalizedSource}`);
+        if (config.template && !wroteTemplate) {
+          output.push(`    template: ${config.template}`);
+          wroteTemplate = true;
+        }
+        inSpec = false;
+      }
+      if (inRegistry && trimmed !== "" && !trimmed.startsWith(" ")) {
+        inRegistry = false;
+      }
+      output.push(line);
+    }
+    if (inRegistry) {
+      if (inSpec) {
+        if (!wroteSource) output.push(`    source: ${normalizedSource}`);
+        if (config.template && !wroteTemplate) {
+          output.push(`    template: ${config.template}`);
+        }
+      } else if (!sawSpec) {
+        output.push(...specLines);
+      }
+    }
+    fs.writeFileSync(filePath, output.join("\n"), "utf-8");
+    return;
+  }
+
+  const section = [
+    "",
+    "#-------------------------------------------------------------------------------",
+    "# Registry",
+    "#-------------------------------------------------------------------------------",
+    "",
+    "# Source used to install .trellis/spec. trellis update refreshes this",
+    "# hash-tracked spec template while preserving local edits through the",
+    "# normal update conflict flow.",
+    "registry:",
+    ...specLines,
+    "",
+  ].join("\n");
+
+  fs.writeFileSync(filePath, content.trimEnd() + "\n" + section, "utf-8");
+}

--- a/packages/cli/src/utils/template-fetcher.ts
+++ b/packages/cli/src/utils/template-fetcher.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { downloadTemplate } from "giget";
+import { toPosix } from "./posix.js";
 
 // =============================================================================
 // Constants
@@ -595,6 +596,15 @@ interface GitCheckout {
   cleanup: () => Promise<void>;
 }
 
+export async function removeDirectory(dir: string): Promise<void> {
+  await fs.promises.rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+}
+
 async function runGit(args: string[]): Promise<GitCommandOutput> {
   const { execFile } = await import("node:child_process");
   return new Promise<GitCommandOutput>((resolve, reject) => {
@@ -723,6 +733,7 @@ async function cloneRegistryRef(
         registry.gitUrl,
         dir,
       ]);
+      await runGit(["-C", dir, "config", "core.autocrlf", "false"]);
     } catch (error) {
       throw classifyGitError(error, "clone", registry);
     }
@@ -745,11 +756,11 @@ async function cloneRegistryRef(
     return {
       dir,
       cleanup: async () => {
-        await fs.promises.rm(dir, { recursive: true, force: true });
+        await removeDirectory(dir);
       },
     };
   } catch (error) {
-    await fs.promises.rm(dir, { recursive: true, force: true });
+    await removeDirectory(dir);
     throw error;
   }
 }
@@ -1283,5 +1294,64 @@ export async function downloadRegistryDirect(
       success: false,
       message: `Download failed: ${errorMessage}`,
     };
+  }
+}
+
+export function collectDirectoryFiles(
+  root: string,
+  relativeRoot: string,
+): Map<string, string> {
+  const files = new Map<string, string>();
+  if (!fs.existsSync(root)) return files;
+
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        const relativePath = toPosix(
+          path.join(relativeRoot, path.relative(root, fullPath)),
+        );
+        files.set(relativePath, fs.readFileSync(fullPath, "utf-8"));
+      }
+    }
+  };
+
+  walk(root);
+  return files;
+}
+
+/**
+ * Download a direct registry spec into a temporary directory and return its
+ * files as update-template entries under `.trellis/spec/**`.
+ */
+export async function fetchRegistrySpecTemplates(
+  registry: RegistrySource,
+  registryBackend?: RegistryBackend,
+): Promise<{ success: boolean; message?: string; files: Map<string, string> }> {
+  const tempRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "trellis-registry-spec-"),
+  );
+  try {
+    const result = await downloadRegistryDirect(
+      tempRoot,
+      registry,
+      "overwrite",
+      undefined,
+      registryBackend,
+    );
+    if (!result.success) {
+      return { success: false, message: result.message, files: new Map() };
+    }
+    return {
+      success: true,
+      files: collectDirectoryFiles(
+        path.join(tempRoot, ".trellis", "spec"),
+        ".trellis/spec",
+      ),
+    };
+  } finally {
+    await removeDirectory(tempRoot);
   }
 }

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -24,6 +24,26 @@ vi.mock("node:child_process", () => ({
   execSync: vi.fn().mockReturnValue(""),
 }));
 
+const registryDownload = vi.hoisted(() => ({
+  files: new Map<string, string>(),
+}));
+
+vi.mock("giget", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  return {
+    downloadTemplate: vi.fn(
+      async (_source: string, options: { dir: string }) => {
+        for (const [relativePath, content] of registryDownload.files) {
+          const targetPath = path.join(options.dir, relativePath);
+          fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+          fs.writeFileSync(targetPath, content, "utf-8");
+        }
+      },
+    ),
+  };
+});
+
 // === Imports ===
 
 import { init } from "../../src/commands/init.js";
@@ -44,6 +64,7 @@ describe("init() integration", () => {
     vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
     vi.spyOn(console, "log").mockImplementation(noop);
     vi.spyOn(console, "error").mockImplementation(noop);
+    registryDownload.files.clear();
     vi.mocked(execSync).mockClear();
     vi.mocked(execSync).mockImplementation(((cmd: string) => {
       const expectedPythonCmd =
@@ -912,6 +933,141 @@ describe("init() integration", () => {
 
     expect(logOutput).toContain("Error: Could not reach registry index");
     expect(fs.existsSync(path.join(tmpDir, DIR_NAMES.WORKFLOW))).toBe(false);
+  });
+
+  it("#21 -y --registry records direct spec registry source and tracks downloaded spec files", async () => {
+    registryDownload.files.set("index.md", "# remote spec\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 404,
+        ok: false,
+      }),
+    );
+
+    await init({
+      yes: true,
+      registry: `gitlab:local/registry/spec`,
+      overwrite: true,
+    });
+
+    const config = fs.readFileSync(
+      path.join(tmpDir, DIR_NAMES.WORKFLOW, "config.yaml"),
+      "utf-8",
+    );
+    expect(config).toContain("registry:");
+    expect(config).toContain("spec:");
+    expect(config).toContain("source: gitlab:local/registry/spec");
+
+    const hashFile = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, DIR_NAMES.WORKFLOW, ".template-hashes.json"),
+        "utf-8",
+      ),
+    ) as { hashes?: Record<string, string> };
+    expect(hashFile.hashes?.[".trellis/spec/index.md"]).toBe(
+      computeHash("# remote spec\n"),
+    );
+  });
+
+  it("#22 -y --registry --template records marketplace template source and tracks downloaded spec files", async () => {
+    registryDownload.files.set("index.md", "# golang spec\n");
+    const index = JSON.stringify({
+      version: 1,
+      templates: [
+        {
+          id: "golang-spec",
+          type: "spec",
+          name: "Golang",
+          path: "backend",
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(index),
+      }),
+    );
+
+    await init({
+      yes: true,
+      registry: "gitlab:local/registry/marketplace",
+      template: "golang-spec",
+      overwrite: true,
+    });
+
+    const config = fs.readFileSync(
+      path.join(tmpDir, DIR_NAMES.WORKFLOW, "config.yaml"),
+      "utf-8",
+    );
+    expect(config).toContain("registry:");
+    expect(config).toContain("spec:");
+    expect(config).toContain("source: gitlab:local/registry/marketplace");
+    expect(config).toContain("template: golang-spec");
+
+    const hashFile = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, DIR_NAMES.WORKFLOW, ".template-hashes.json"),
+        "utf-8",
+      ),
+    ) as { hashes?: Record<string, string> };
+    expect(hashFile.hashes?.[".trellis/spec/index.md"]).toBe(
+      computeHash("# golang spec\n"),
+    );
+  });
+
+  it("#23 existing project --registry --template still refreshes spec and records source", async () => {
+    await init({ yes: true, user: "alice" });
+
+    registryDownload.files.set("index.md", "# refreshed golang spec\n");
+    const index = JSON.stringify({
+      version: 1,
+      templates: [
+        {
+          id: "golang-spec",
+          type: "spec",
+          name: "Golang",
+          path: "backend",
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(index),
+      }),
+    );
+
+    await init({
+      yes: true,
+      user: "alice",
+      registry: "gitlab:local/registry/marketplace",
+      template: "golang-spec",
+      overwrite: true,
+    });
+
+    const config = fs.readFileSync(
+      path.join(tmpDir, DIR_NAMES.WORKFLOW, "config.yaml"),
+      "utf-8",
+    );
+    expect(config).toContain("source: gitlab:local/registry/marketplace");
+    expect(config).toContain("template: golang-spec");
+    expect(
+      fs.readFileSync(path.join(tmpDir, PATHS.SPEC, "index.md"), "utf-8"),
+    ).toBe("# refreshed golang spec\n");
+
+    const hashFile = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, DIR_NAMES.WORKFLOW, ".template-hashes.json"),
+        "utf-8",
+      ),
+    ) as { hashes?: Record<string, string> };
+    expect(hashFile.hashes?.[".trellis/spec/index.md"]).toBe(
+      computeHash("# refreshed golang spec\n"),
+    );
   });
 
   it("#19 polyrepo: writes git: true for sibling .git packages", async () => {

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -28,6 +28,26 @@ vi.mock("node:child_process", () => ({
   }),
 }));
 
+const registryDownload = vi.hoisted(() => ({
+  files: new Map<string, string>(),
+}));
+
+vi.mock("giget", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  return {
+    downloadTemplate: vi.fn(
+      async (_source: string, options: { dir: string }) => {
+        for (const [relativePath, content] of registryDownload.files) {
+          const targetPath = path.join(options.dir, relativePath);
+          fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+          fs.writeFileSync(targetPath, content, "utf-8");
+        }
+      },
+    ),
+  };
+});
+
 // === Imports ===
 
 import { init } from "../../src/commands/init.js";
@@ -140,6 +160,7 @@ describe("update() integration", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-update-int-"));
     vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    registryDownload.files.clear();
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const noop = () => {};
     vi.spyOn(console, "log").mockImplementation(noop);
@@ -622,6 +643,131 @@ describe("update() integration", () => {
 
     // spec/ directory should NOT be recreated by update
     expect(fs.existsSync(specDir)).toBe(false);
+  });
+
+  it("#14b registry-backed pristine spec is refreshed by update", async () => {
+    await setupProject();
+
+    const specFile = `${PATHS.SPEC}/index.md`;
+    writeProjectFile(specFile, "# remote spec v1\n");
+    writeProjectFile(
+      `${DIR_NAMES.WORKFLOW}/config.yaml`,
+      `${readProjectFile(`${DIR_NAMES.WORKFLOW}/config.yaml`)}\nregistry:\n  spec:\n    source: gitlab:local/registry/spec\n`,
+    );
+    const hashes = readHashesV2(hashFilePath());
+    hashes[specFile] = computeHash("# remote spec v1\n");
+    writeHashesV2(hashFilePath(), hashes);
+
+    registryDownload.files.set("index.md", "# remote spec v2\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("registry.npmjs.org")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ version: VERSION }),
+          });
+        }
+        return Promise.resolve({ status: 404, ok: false });
+      }),
+    );
+
+    await update({ force: true });
+
+    expect(readProjectFile(specFile)).toBe("# remote spec v2\n");
+    expect(readHashesV2(hashFilePath())[specFile]).toBe(
+      computeHash("# remote spec v2\n"),
+    );
+    expect(readProjectFile(`${DIR_NAMES.WORKFLOW}/config.yaml`)).toContain(
+      "source: gitlab:local/registry/spec",
+    );
+  });
+
+  it("#14c registry-backed user-modified spec is preserved under skipAll", async () => {
+    await setupProject();
+
+    const specFile = `${PATHS.SPEC}/index.md`;
+    writeProjectFile(specFile, "# local edits\n");
+    writeProjectFile(
+      `${DIR_NAMES.WORKFLOW}/config.yaml`,
+      `${readProjectFile(`${DIR_NAMES.WORKFLOW}/config.yaml`)}\nregistry:\n  spec:\n    source: gitlab:local/registry/spec\n`,
+    );
+    const hashes = readHashesV2(hashFilePath());
+    hashes[specFile] = computeHash("# remote spec v1\n");
+    writeHashesV2(hashFilePath(), hashes);
+
+    registryDownload.files.set("index.md", "# remote spec v2\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("registry.npmjs.org")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ version: VERSION }),
+          });
+        }
+        return Promise.resolve({ status: 404, ok: false });
+      }),
+    );
+
+    await update({ skipAll: true });
+
+    expect(readProjectFile(specFile)).toBe("# local edits\n");
+    expect(readHashesV2(hashFilePath())[specFile]).toBe(
+      computeHash("# remote spec v1\n"),
+    );
+  });
+
+  it("#14d registry-backed marketplace template spec is refreshed by update", async () => {
+    await setupProject();
+
+    const specFile = `${PATHS.SPEC}/index.md`;
+    writeProjectFile(specFile, "# golang spec v1\n");
+    writeProjectFile(
+      `${DIR_NAMES.WORKFLOW}/config.yaml`,
+      `${readProjectFile(`${DIR_NAMES.WORKFLOW}/config.yaml`)}\nregistry:\n  spec:\n    source: gitlab:local/registry/marketplace\n    template: golang-spec\n`,
+    );
+    const hashes = readHashesV2(hashFilePath());
+    hashes[specFile] = computeHash("# golang spec v1\n");
+    writeHashesV2(hashFilePath(), hashes);
+
+    registryDownload.files.set("index.md", "# golang spec v2\n");
+    const index = JSON.stringify({
+      version: 1,
+      templates: [
+        {
+          id: "golang-spec",
+          type: "spec",
+          name: "Golang",
+          path: "backend",
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("registry.npmjs.org")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ version: VERSION }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(index),
+        });
+      }),
+    );
+
+    await update({ force: true });
+
+    expect(readProjectFile(specFile)).toBe("# golang spec v2\n");
+    expect(readHashesV2(hashFilePath())[specFile]).toBe(
+      computeHash("# golang spec v2\n"),
+    );
   });
 
   it("#15 truly new file (no stored hash) is still added", async () => {

--- a/packages/cli/test/utils/registry-config.test.ts
+++ b/packages/cli/test/utils/registry-config.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadSpecRegistryConfig,
+  writeSpecRegistryConfig,
+} from "../../src/utils/registry-config.js";
+
+describe("registry-config", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-reg-config-"));
+    fs.mkdirSync(path.join(tmpDir, ".trellis"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when config.yaml is missing", () => {
+    expect(loadSpecRegistryConfig(tmpDir)).toBeNull();
+  });
+
+  it("writes and reads registry spec source", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "# Trellis Configuration\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, { source: "gitlab:org/repo/spec" });
+
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "gitlab:org/repo/spec",
+    });
+  });
+
+  it("writes and reads registry marketplace template source", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "# Trellis Configuration\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, {
+      source: "gitlab:org/repo/marketplace",
+      template: "golang-spec",
+    });
+
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "gitlab:org/repo/marketplace",
+      template: "golang-spec",
+    });
+  });
+
+  it("preserves self-hosted SSH registry source strings", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "# Trellis Configuration\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, {
+      source: "git@git.ppdaicorp.com:xionghongwei/trellis-spec.git",
+      template: "golang-spec",
+    });
+
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "git@git.ppdaicorp.com:xionghongwei/trellis-spec.git",
+      template: "golang-spec",
+    });
+  });
+
+  it("reads quoted registry spec source", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "registry:\n  spec:\n    source: 'gh:org/repo/spec#main'\n    template: \"backend\"\n",
+      "utf-8",
+    );
+
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "gh:org/repo/spec#main",
+      template: "backend",
+    });
+  });
+
+  it("does not duplicate an existing registry section", () => {
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    fs.writeFileSync(
+      configPath,
+      "registry:\n  spec:\n    source: gh:org/repo/spec\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, { source: "gh:other/repo/spec" });
+
+    const config = fs.readFileSync(configPath, "utf-8");
+    expect(config.match(/^registry:/gm)).toHaveLength(1);
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "gh:other/repo/spec",
+    });
+  });
+
+  it("updates an existing registry section", () => {
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    fs.writeFileSync(
+      configPath,
+      "registry:\n  spec:\n    source: gitlab:old/spec\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, {
+      source: "git@git.ppdaicorp.com:xionghongwei/trellis-spec.git",
+      template: "golang-spec",
+    });
+
+    const config = fs.readFileSync(configPath, "utf-8");
+    expect(config.match(/^registry:/gm)).toHaveLength(1);
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "git@git.ppdaicorp.com:xionghongwei/trellis-spec.git",
+      template: "golang-spec",
+    });
+  });
+
+  it("adds spec config under an existing registry section", () => {
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    fs.writeFileSync(
+      configPath,
+      "registry:\n  marketplace:\n    source: gh:org/marketplace\n\ncommands:\n  skip: []\n",
+      "utf-8",
+    );
+
+    writeSpecRegistryConfig(tmpDir, {
+      source: "gh:org/specs/golang",
+      template: "golang-spec",
+    });
+
+    const config = fs.readFileSync(configPath, "utf-8");
+    expect(config.match(/^registry:/gm)).toHaveLength(1);
+    expect(config).toContain("  marketplace:\n    source: gh:org/marketplace");
+    expect(loadSpecRegistryConfig(tmpDir)).toEqual({
+      source: "gh:org/specs/golang",
+      template: "golang-spec",
+    });
+  });
+});

--- a/packages/cli/test/utils/template-fetcher.test.ts
+++ b/packages/cli/test/utils/template-fetcher.test.ts
@@ -531,6 +531,10 @@ async function withGitRegistry<T>(
 
   try {
     execFileSync("git", ["init"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "core.autocrlf", "false"], {
+      cwd: repoDir,
+      stdio: "pipe",
+    });
     execFileSync("git", ["checkout", "-b", "main"], {
       cwd: repoDir,
       stdio: "pipe",
@@ -566,7 +570,12 @@ async function withGitRegistry<T>(
 
     return await callback({ tmpDir, repoDir, registry });
   } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    await fs.promises.rm(tmpDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Persist registry spec source/template in `.trellis/config.yaml` during init
- Refresh registry-backed `.trellis/spec` files through the existing `trellis update` hash/conflict flow
- Support both direct spec registries and marketplace-style registries, including SSH/self-hosted Git sources

Closes #315

## Verification
- `pnpm --filter @mindfoldhq/trellis test test/utils/registry-config.test.ts test/commands/init.integration.test.ts test/commands/update.integration.test.ts test/utils/template-fetcher.test.ts`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis build`