### PR TITLE
Feat/bayesian first principles thinking

### DIFF
--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -116,7 +116,7 @@ When adding a new platform `{platform}`, update the following:
 
 > Note: Codex/Kiro use `resolveAllAsSkills()` from `shared.ts` to generate all templates as SKILL.md files with YAML frontmatter. Skills are written via `writeSkills()`.
 >
-> **Qoder is a hybrid** — it has native Custom Commands (`.qoder/commands/{name}.md`) with required YAML frontmatter (`name` + `description`, flat layout per Qoder CLI docs), so session-boundary commands (`finish-work`, `continue`) go there via `resolveCommands()` + `wrapWithCommandFrontmatter()`, while the 5 auto-trigger workflows stay as `.qoder/skills/` via `resolveSkills()`. Use the `COMMAND_DESCRIPTIONS` registry in `shared.ts` (separate from `SKILL_DESCRIPTIONS`) for the short palette blurbs — command descriptions are one-line imperatives aimed at the user; skill descriptions are long prose aimed at the AI matcher.
+> **Qoder is a hybrid** — it has native Custom Commands (`.qoder/commands/{name}.md`) with required YAML frontmatter (`name` + `description`, flat layout per Qoder CLI docs), so session-boundary commands (`finish-work`, `continue`) go there via `resolveCommands()` + `wrapWithCommandFrontmatter()`, while the auto-triggered skills from `common/skills/` stay as `.qoder/skills/` via `resolveSkills()`. Use the `COMMAND_DESCRIPTIONS` registry in `shared.ts` (separate from `SKILL_DESCRIPTIONS`) for the short palette blurbs — command descriptions are one-line imperatives aimed at the user; skill descriptions are long prose aimed at the AI matcher.
 >
 > **Codex has a two-layer directory model:**
 >
@@ -136,7 +136,7 @@ When adding a new platform `{platform}`, update the following:
 
 `.agents/skills/` is a **shared destination**: multiple configurators (Codex, Gemini CLI 0.40+ via the workspace alias, future agentskills.io consumers) all write into the same path. Per-platform `{{CMD_REF:name}}` resolution (`$name` for Codex, `/trellis:name` for Gemini, etc.) makes the same `<skill>/SKILL.md` differ byte-for-byte depending on which configurator ran last → "last-writer-wins" content collisions and `.template-hashes.json` churn.
 
-**Rule**: Anything written under `.agents/skills/` MUST be rendered via `resolvePlaceholdersNeutral()` (in `configurators/shared.ts`), which substitutes `` `name` (Trellis command) `` for `{{CMD_REF:name}}` instead of a platform prefix. All other placeholders (`{{CLI_FLAG}}`, `{{EXECUTOR_AI}}`, `{{USER_ACTION_LABEL}}`, conditionals, `{{PYTHON_CMD}}`) still resolve from the platform context — those don't appear in the 5 shared workflow skills (`brainstorm`, `before-dev`, `check`, `break-loop`, `update-spec`), so the rendered output stays identical across writers.
+**Rule**: Anything written under `.agents/skills/` MUST be rendered via `resolvePlaceholdersNeutral()` (in `configurators/shared.ts`), which substitutes `` `name` (Trellis command) `` for `{{CMD_REF:name}}` instead of a platform prefix. All other placeholders (`{{CLI_FLAG}}`, `{{EXECUTOR_AI}}`, `{{USER_ACTION_LABEL}}`, conditionals, `{{PYTHON_CMD}}`) still resolve from the platform context — those don't appear in the auto-triggered skill templates from `common/skills/`, so the rendered output stays identical across writers.
 
 Per-platform skill directories (`.claude/skills/`, `.cursor/skills/`, `.qoder/skills/`, etc.) keep using `resolvePlaceholders()` — `{{CMD_REF}}` resolves to the platform-correct slash form there, because no other configurator writes those paths.
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -568,8 +568,7 @@ function needsCodexUpgrade(cwd: string): boolean {
   // command-as-skill files `trellis-continue/SKILL.md` and
   // `trellis-finish-work/SKILL.md` under `.agents/skills/`. Other platforms
   // that share `.agents/skills/` (e.g. Gemini CLI 0.40+ via the workspace
-  // alias — issue #224) only write the 5 workflow skills (brainstorm,
-  // before-dev, check, break-loop, update-spec) and never these two
+  // alias — issue #224) only write shared common skills and never these two
   // command files, so their presence in the hash file is a reliable signal
   // that the project was originally configured with Codex before `.codex/`
   // existed as a separate config dir.

--- a/packages/cli/src/configurators/antigravity.ts
+++ b/packages/cli/src/configurators/antigravity.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Configure Antigravity:
  * - workflows/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  */
 export async function configureAntigravity(cwd: string): Promise<void> {
   const ctx = AI_TOOLS.antigravity.templateContext;

--- a/packages/cli/src/configurators/claude.ts
+++ b/packages/cli/src/configurators/claude.ts
@@ -96,7 +96,7 @@ async function copyDirFiltered(
  * - agents/, settings.json from platform-specific templates
  * - hooks/ from shared-hooks/ (unified with other platforms)
  * - commands/trellis/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  * - with `withStatusline`: opt-in statusline.py hook + `statusLine` settings
  *   entry (off by default; `trellis init --with-statusline`)
  */

--- a/packages/cli/src/configurators/codebuddy.ts
+++ b/packages/cli/src/configurators/codebuddy.ts
@@ -18,7 +18,7 @@ import {
 /**
  * Configure CodeBuddy:
  * - commands/trellis/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  * - agents/{name}.md — sub-agent definitions
  * - hooks/*.py — shared hook scripts
  * - settings.json — hook configuration

--- a/packages/cli/src/configurators/codex.ts
+++ b/packages/cli/src/configurators/codex.ts
@@ -27,8 +27,8 @@ import {
  */
 export async function configureCodex(cwd: string): Promise<void> {
   // Shared skills from common source → .agents/skills/
-  // Uses the neutral placeholder resolver so the 5 shared workflow skills
-  // (brainstorm, before-dev, check, break-loop, update-spec) render to the
+  // Uses the neutral placeholder resolver so the auto-triggered skill templates
+  // from `common/skills/` render to the
   // same bytes regardless of which platform writes them — required because
   // Gemini CLI 0.40+ also targets `.agents/skills/` (last-writer-wins is
   // safe when both writers produce identical output).

--- a/packages/cli/src/configurators/copilot.ts
+++ b/packages/cli/src/configurators/copilot.ts
@@ -17,7 +17,7 @@ import {
 /**
  * Configure GitHub Copilot:
  * - prompts/ — start + finish-work as prompt files
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  * - agents/{name}.agent.md — sub-agent definitions (note .agent.md suffix)
  * - copilot/hooks/ — platform-specific + shared hook scripts
  * - hooks config — hooks.json

--- a/packages/cli/src/configurators/cursor.ts
+++ b/packages/cli/src/configurators/cursor.ts
@@ -15,7 +15,7 @@ import { getAllAgents, getHooksConfig } from "../templates/cursor/index.js";
 /**
  * Configure Cursor:
  * - commands/ — start + finish-work as slash commands (trellis- prefix, flat)
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  * - agents/{name}.md — sub-agent definitions
  * - hooks/*.py — shared hook scripts
  * - hooks.json — hook configuration (separate file, not settings.json)

--- a/packages/cli/src/configurators/devin.ts
+++ b/packages/cli/src/configurators/devin.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Configure Devin (formerly Windsurf):
  * - workflows/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  */
 export async function configureDevin(cwd: string): Promise<void> {
   const ctx = AI_TOOLS.devin.templateContext;

--- a/packages/cli/src/configurators/droid.ts
+++ b/packages/cli/src/configurators/droid.ts
@@ -15,7 +15,7 @@ import { getAllDroids, getSettingsTemplate } from "../templates/droid/index.js";
 /**
  * Configure Factory Droid:
  * - commands/trellis/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  * - droids/{name}.md — sub-agent definitions (Droid calls them "droids")
  * - hooks/*.py — shared hook scripts
  * - settings.json — hook configuration

--- a/packages/cli/src/configurators/gemini.ts
+++ b/packages/cli/src/configurators/gemini.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Configure Gemini CLI (pull-based class-2 platform):
  * - commands/trellis/ — start + finish-work as TOML slash commands
- * - .agents/skills/trellis-{name}/SKILL.md — 5 auto-triggered shared skills
+ * - .agents/skills/trellis-{name}/SKILL.md — auto-triggered shared skills
  *   written to the cross-platform `.agents/skills/` workspace alias (Gemini
  *   CLI 0.40+ reads it natively; previously `.gemini/skills/` was used,
  *   which collided with Codex's identical write target and caused

--- a/packages/cli/src/configurators/kilo.ts
+++ b/packages/cli/src/configurators/kilo.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Configure Kilo CLI:
  * - workflows/ — start + finish-work as slash commands
- * - skills/trellis-{name}/SKILL.md — other 5 as auto-triggered skills
+ * - skills/trellis-{name}/SKILL.md — auto-triggered skills from `common/skills/`
  */
 export async function configureKilo(cwd: string): Promise<void> {
   const ctx = AI_TOOLS.kilo.templateContext;

--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -176,15 +176,15 @@ export function resolvePlaceholders(
  * Identical to {@link resolvePlaceholders} except that {@link CMD_REF} is
  * rendered in a platform-neutral form (`` `name` (Trellis command) ``)
  * instead of substituting a platform-specific prefix. This is the only
- * placeholder that varies between platforms in the 5 shared workflow skills
- * (`brainstorm`, `before-dev`, `check`, `break-loop`, `update-spec`), so
+ * placeholder that varies between platforms in the auto-triggered skill templates
+ * from `common/skills/`, so
  * neutralizing it makes the rendered SKILL.md files byte-identical regardless
  * of which Trellis configurator wrote them — eliminating the
  * "last-writer-wins" collision when both Codex and Gemini target
  * `.agents/skills/`.
  *
  * `{{CLI_FLAG}}`, `{{EXECUTOR_AI}}`, `{{USER_ACTION_LABEL}}`, conditionals,
- * and `{{PYTHON_CMD}}` are still resolved from the platform context. The 5
+ * and `{{PYTHON_CMD}}` are still resolved from the platform context. The
  * shared skills do not use those placeholders, so they remain platform-
  * neutral. Codex-only skill files (e.g. `trellis-continue/SKILL.md`,
  * `trellis-finish-work/SKILL.md` written via `resolveAllAsSkillsNeutral`) DO
@@ -210,8 +210,8 @@ export function resolvePlaceholdersNeutral(
   result = result.replace(RE_USER_ACTION_LABEL, context.userActionLabel);
   result = result.replace(RE_CLI_FLAG, context.cliFlag);
 
-  // Conditional blocks (resolved per platform — none of the 5 shared skills
-  // use conditionals, but Codex-only command-as-skill files might in future).
+  // Conditional blocks (resolved per platform — none of the auto-triggered
+  // shared skills use conditionals, but Codex-only command-as-skill files might in future).
   const flagValues: Record<(typeof CONDITIONAL_FLAGS)[number], boolean> = {
     AGENT_CAPABLE: context.agentCapable,
     HAS_HOOKS: context.hasHooks,
@@ -379,7 +379,7 @@ export function resolveCommands(ctx: TemplateContext): ResolvedTemplate[] {
 }
 
 /**
- * Resolve only the 5 skill templates with trellis- prefix + SKILL.md frontmatter.
+ * Resolve the auto-triggered skill templates from `common/skills/` with trellis- prefix + SKILL.md frontmatter.
  * Used by "both" platforms for the auto-triggered skills.
  */
 export function resolveSkills(ctx: TemplateContext): ResolvedTemplate[] {
@@ -411,7 +411,7 @@ export function resolveSkillsNeutral(ctx: TemplateContext): ResolvedTemplate[] {
 
 /**
  * Same as {@link resolveAllAsSkills} but uses
- * {@link resolvePlaceholdersNeutral} for the 5 shared skills. The 2 command
+ * {@link resolvePlaceholdersNeutral} for the shared common skills. The 2 command
  * templates (continue, finish-work) folded into the skill set still resolve
  * `{{CLI_FLAG}}` / `{{PYTHON_CMD}}` per platform — only Codex writes those
  * files into `.agents/skills/`, so byte-identity isn't required there.

--- a/packages/cli/src/templates/common/skills/brainstorm.md
+++ b/packages/cli/src/templates/common/skills/brainstorm.md
@@ -64,6 +64,49 @@ Each question must include:
 
 Do not ask process questions such as whether to search, inspect files, or continue brainstorming. Do the evidence work directly. Ask the user only when the remaining issue is a product decision, preference, scope boundary, or risk tolerance choice.
 
+## Thinking Framework: First Principles Analysis
+
+When requirements are vague, solutions feel over-engineered, or you're about to add complexity "because everyone does" — decompose to fundamental truths before reasoning upward.
+
+### Step 1: Restate the Problem
+
+Strip away implementation details to one sentence.
+
+> Bad: "We need to add Redis caching to the user profile endpoint"
+> Good: "User profile data takes too long to load"
+
+### Step 2: List Fundamental Truths
+
+What is absolutely true (not opinion or convention)?
+
+| Category | Examples |
+|----------|----------|
+| **Physical constraints** | Network latency ≥ 0, disk I/O has limits |
+| **Business rules** | "Users must see their own data" |
+| **Technical invariants** | "Data must be consistent" |
+| **User needs** | "The user wants X within Y seconds" |
+
+### Step 3: Challenge Assumptions
+
+For each component of the current plan:
+
+- **Fact or convention?** "We always use REST" — why?
+- **What if we removed this?** If nothing breaks, it's unnecessary.
+- **Solving the actual problem or a symptom?** Trace the causal chain.
+- **Who benefits from this complexity?** If "nobody", simplify.
+
+### Step 4: Build Up from Truths
+
+1. Start with the minimum viable mechanism satisfying all truths
+2. Add complexity only when a specific truth demands it
+3. Each addition must answer: "Which truth requires this?"
+
+### Step 5: Validate
+
+- Does the solution solve the original problem?
+- What assumptions need verification?
+- What's the simplest experiment to test this?
+
 ## Artifact Rules
 
 `prd.md` records requirements and acceptance:

--- a/packages/cli/src/templates/common/skills/break-loop.md
+++ b/packages/cli/src/templates/common/skills/break-loop.md
@@ -106,6 +106,65 @@ Three levels of insight:
 
 30 minutes of analysis saves 30 hours of future debugging.
 
+
+## Thinking Framework: Bayesian Reasoning
+
+When multiple root causes are plausible and evidence is incomplete, update your beliefs proportionally to new evidence rather than clinging to initial assumptions.
+
+### Step 1: Establish Priors
+
+Before investigating, state what you believe and why:
+
+| Hypothesis | Prior | Reasoning |
+|------------|-------|-----------|
+| H1: [cause A] | 40% | Most common for this pattern |
+| H2: [cause B] | 30% | Plausible given environment |
+| H3: [other] | 30% | Catch-all |
+
+Priors must sum to 100%. If you can't assign probabilities, investigate first.
+
+### Step 2: Observe Evidence
+
+Document what you found — be specific about reliability:
+
+- What exactly did you observe?
+- How reliable? (test output > log message > user report > hunch)
+- Could multiple hypotheses explain this?
+
+### Step 3: Update Beliefs
+
+For each hypothesis, ask: **How likely is this evidence if this hypothesis were true?**
+
+Direction of update matters more than calculation:
+- Evidence strongly predicted by H1 → H1 probability increases
+- Evidence contradicts H2 → H2 probability decreases
+- Evidence equally likely under all → no update
+
+### Step 4: Seek Discriminating Evidence
+
+Don't gather more of the same. Find evidence that **differs strongly** between top hypotheses.
+
+> If H1 and H3 are close: "What would I see if H1 is true but not if H3 is true?" Then check for that.
+
+### Step 5: State Confidence
+
+| Confidence | Action |
+|------------|--------|
+| 90%+ | Proceed with fix, monitor |
+| 70-90% | Proceed, add fallback check |
+| 50-70% | Test hypothesis before committing |
+| <50% | Need more evidence, don't guess |
+
+Never express binary certainty when evidence is incomplete. Use "most likely", "plausible but unlikely", "worth investigating".
+
+### Common Fallacies
+
+| Fallacy | Example | Correction |
+|---------|---------|------------|
+| **Base rate neglect** | "Test failed → code is broken" | How often do tests fail for other reasons? |
+| **Confirmation bias** | "Must be a race condition, let me find race evidence" | Actively seek evidence AGAINST your top hypothesis |
+| **Anchoring** | "Last time it was caching, probably caching again" | Establish priors from current context, not yesterday's bug |
+
 ---
 
 ## After Analysis: Immediate Actions

--- a/packages/cli/test/configurators/shared.test.ts
+++ b/packages/cli/test/configurators/shared.test.ts
@@ -555,15 +555,15 @@ describe("resolveSkillsNeutral / resolveAllAsSkillsNeutral", () => {
     }
   });
 
-  it("resolveAllAsSkillsNeutral keeps the 5 shared skills byte-identical to resolveSkillsNeutral", () => {
+  it("resolveAllAsSkillsNeutral keeps shared common skills byte-identical to resolveSkillsNeutral", () => {
     const all = resolveAllAsSkillsNeutral(AI_TOOLS.codex.templateContext);
-    const fiveOnly = resolveSkillsNeutral(AI_TOOLS.codex.templateContext);
-    const sharedNames = new Set(fiveOnly.map((s) => s.name));
+    const commonSkills = resolveSkillsNeutral(AI_TOOLS.codex.templateContext);
+    const sharedNames = new Set(commonSkills.map((s) => s.name));
     const allShared = all.filter((s) => sharedNames.has(s.name));
-    expect(allShared.length).toBe(fiveOnly.length);
-    for (const five of fiveOnly) {
-      const match = allShared.find((s) => s.name === five.name);
-      expect(match?.content).toBe(five.content);
+    expect(allShared.length).toBe(commonSkills.length);
+    for (const skill of commonSkills) {
+      const match = allShared.find((s) => s.name === skill.name);
+      expect(match?.content).toBe(skill.content);
     }
   });
 });

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -5655,7 +5655,7 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
         `Codex and Gemini disagree on ${filePath} — last-writer-wins would corrupt the shared skill`,
       ).toBe(codexContent);
     }
-    // At least the 5 shared workflow skills + bundled trellis-meta files must
+    // At least the shared common skills + bundled trellis-meta files must
     // overlap. If this drops to 0 the assertion above is silently passing.
     expect(overlapCount).toBeGreaterThan(0);
   });
@@ -5707,8 +5707,8 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
   });
 
   it("[#224] needsCodexUpgrade looks for Codex-only command-as-skill markers, not bare `.agents/skills/` prefix", () => {
-    // Regression: with Gemini also writing to `.agents/skills/` (5 shared
-    // workflow skills only), the legacy-Codex detector previously triggered
+    // Regression: with Gemini also writing to `.agents/skills/` (shared common
+    // skills only), the legacy-Codex detector previously triggered
     // a false-positive `.codex/` install on every fresh `init --gemini` +
     // `update` cycle. The fix narrows detection to Codex-only files
     // (`trellis-continue/SKILL.md`, `trellis-finish-work/SKILL.md`) which


### PR DESCRIPTION
新增 bayesian-reasoning 和 first-principles 两个思维框架，作为 Thinking Framework 小节分别内嵌到现有工作流技能中：
- first-principles → brainstorm.md — 需求发现时挑战假设、从约束推导最小方案
- bayesian-reasoning → break-loop.md — bug 诊断时多假设权衡、按证据更新信念
- 同步清理了源码和 spec 中过时的"5个技能"硬编码注释，改为 count-free 措辞。

 验证：107 配置器测试通过 / tsc + eslint 通过 / 全量 1035 测试通过（15 失败均为既有的 python3 环境缺失）