### PR TITLE
feat: add Trae IDE platform support

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -85,6 +85,7 @@ program
   .option("--pi", "Include Pi Agent extension assets")
   .option("--reasonix", "Include Reasonix skills")
   .option("--zcode", "Include ZCode commands")
+  .option("--trae", "Include Trae IDE commands")
   .option(
     "--with-statusline",
     "Install the Trellis statusLine for Claude Code (off by default)",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1020,6 +1020,7 @@ interface InitOptions {
   pi?: boolean;
   reasonix?: boolean;
   zcode?: boolean;
+  trae?: boolean;
   yes?: boolean;
   user?: string;
   force?: boolean;

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -79,6 +79,7 @@ function buildStructuredFileSpecs(): Map<string, StructuredFileSpec> {
         ".codebuddy/settings.json",
         ".qoder/settings.json",
         ".codex/hooks.json",
+        ".trae/hooks.json",
       ] as const
     ).map(
       (p): StructuredFileSpec => ({

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -34,6 +34,7 @@ import { configureDroid } from "./droid.js";
 import { configurePi, collectPiTemplates } from "./pi.js";
 import { configureReasonix, collectReasonixTemplates } from "./reasonix.js";
 import { configureZcode, collectZcodeTemplates } from "./zcode.js";
+import { configureTrae } from "./trae.js";
 
 // Shared utilities
 import {
@@ -73,6 +74,10 @@ import {
   getAllAgents as getQoderAgents,
   getSettingsTemplate as getQoderSettings,
 } from "../templates/qoder/index.js";
+import {
+  getAllAgents as getTraeAgents,
+  getSettingsTemplate as getTraeSettings,
+} from "../templates/trae/index.js";
 import {
   getAllAgents as getCodebuddyAgents,
   getSettingsTemplate as getCodebuddySettings,
@@ -455,6 +460,32 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
   zcode: {
     configure: configureZcode,
     collectTemplates: () => collectZcodeTemplates(),
+  },
+  trae: {
+    configure: configureTrae,
+    collectTemplates: () => {
+      const files = collectBothTemplates(
+        AI_TOOLS.trae.templateContext,
+        (n) => `.trae/commands/trellis-${n}.md`,
+        ".trae/skills",
+        (filePath, content) => {
+          const name = path.basename(filePath, ".md");
+          return wrapWithCommandFrontmatter(name, content);
+        },
+      );
+      for (const agent of applyPullBasedPreludeMarkdown(getTraeAgents())) {
+        files.set(`.trae/agents/${agent.name}.md`, agent.content);
+      }
+      for (const [k, v] of collectSharedHooks(".trae/hooks", "trae")) {
+        files.set(k, v);
+      }
+      const settings = getTraeSettings();
+      files.set(
+        `.trae/${settings.targetPath}`,
+        resolvePlaceholders(settings.content),
+      );
+      return files;
+    },
   },
 };
 

--- a/packages/cli/src/configurators/trae.ts
+++ b/packages/cli/src/configurators/trae.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+import { AI_TOOLS } from "../types/ai-tools.js";
+import { ensureDir, writeFile } from "../utils/file-writer.js";
+import {
+  resolvePlaceholders,
+  resolveCommands,
+  resolveSkills,
+  resolveBundledSkills,
+  wrapWithCommandFrontmatter,
+  writeSkills,
+  writeAgents,
+  writeSharedHooks,
+  applyPullBasedPreludeMarkdown,
+} from "./shared.js";
+import { getAllAgents, getSettingsTemplate } from "../templates/trae/index.js";
+
+/**
+ * Configure Trae IDE (pull-based class-2 platform).
+ *
+ * Trae is a class-2 platform: hooks fire on SessionStart +
+ * UserPromptSubmit in the main session, but cannot inject sub-agent
+ * prompts. Sub-agents use a pull-based prelude to load context themselves.
+ *
+ * Directory structure created:
+ *   .trae/
+ *   ├── commands/      # Slash commands (trellis-*.md with frontmatter)
+ *   ├── skills/        # Skill definitions
+ *   ├── agents/        # Sub-agent definitions with pull-based prelude
+ *   ├── hooks/         # Shared Python hook scripts
+ *   └── hooks.json     # Hook event registration
+ */
+export async function configureTrae(cwd: string): Promise<void> {
+  const config = AI_TOOLS.trae;
+  const ctx = config.templateContext;
+  const configRoot = path.join(cwd, config.configDir);
+
+  // 1. Commands — slash commands with frontmatter
+  const commandsDir = path.join(configRoot, "commands");
+  ensureDir(commandsDir);
+  for (const cmd of resolveCommands(ctx)) {
+    const name = `trellis-${cmd.name}`;
+    await writeFile(
+      path.join(commandsDir, `${name}.md`),
+      wrapWithCommandFrontmatter(name, cmd.content),
+    );
+  }
+
+  // 2. Skills
+  await writeSkills(
+    path.join(configRoot, "skills"),
+    resolveSkills(ctx),
+    resolveBundledSkills(ctx),
+  );
+
+  // 3. Agents — with pull-based prelude (class-2 pattern)
+  await writeAgents(
+    path.join(configRoot, "agents"),
+    applyPullBasedPreludeMarkdown(getAllAgents()),
+  );
+
+  // 4. Shared hooks — Python scripts
+  await writeSharedHooks(path.join(configRoot, "hooks"), "trae");
+
+  // 5. Hook configuration — register hook events
+  const settings = getSettingsTemplate();
+  await writeFile(
+    path.join(configRoot, settings.targetPath),
+    resolvePlaceholders(settings.content),
+  );
+}

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-hooks.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-hooks.md
@@ -4,7 +4,7 @@ Hooks are the automation layer that connects a platform to Trellis. When the use
 
 ## Read These Files First
 
-1. Target platform settings/config, such as `.claude/settings.json`, `.codex/hooks.json`, `.cursor/hooks.json`
+1. Target platform settings/config, such as `.claude/settings.json`, `.codex/hooks.json`, `.cursor/hooks.json`, `.trae/hooks.json`
 2. Target platform hooks directory
 3. `.trellis/scripts/common/active_task.py`
 4. `.trellis/scripts/common/session_context.py`

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/generated-files.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/generated-files.md
@@ -40,7 +40,7 @@ Different platforms generate different directories. Common categories:
 | Category | Example paths | Purpose |
 | --- | --- | --- |
 | hooks | `.claude/hooks/`, `.codex/hooks/`, `.cursor/hooks/` | Inject session context, workflow-state, and sub-agent context. |
-| settings | `.claude/settings.json`, `.codex/hooks.json`, `.qoder/settings.json` | Tell the platform when to run hooks or plugins. |
+| settings | `.claude/settings.json`, `.codex/hooks.json`, `.qoder/settings.json`, `.trae/hooks.json` | Tell the platform when to run hooks or plugins. |
 | agents | `.claude/agents/`, `.codex/agents/`, `.kiro/agents/`, `.zcode/cli/agents/` | Define agents such as `trellis-research`, `trellis-implement`, and `trellis-check`. |
 | skills | `.claude/skills/`, `.agents/skills/`, `.qoder/skills/` | Skills that auto-trigger or can be read by AI. |
 | commands/prompts/workflows | `.cursor/commands/`, `.github/prompts/`, `.devin/workflows/`, `.zcode/commands/` | Explicit user-invoked command or workflow entry points. |

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/hooks-and-settings.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/hooks-and-settings.md
@@ -27,6 +27,7 @@ Common files:
 | GitHub Copilot | `.github/copilot/hooks.json` |
 | Factory Droid | `.factory/settings.json` |
 | Pi Agent | `.pi/settings.json`, `.pi/extensions/trellis/` |
+| Trae IDE | `.trae/hooks.json` |
 
 Reasonix and ZCode are pull-based platforms that do not use hooks or settings files; their agent files contain prelude instructions to read context after startup.
 

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/overview.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/overview.md
@@ -5,7 +5,7 @@ Trellis connects the same local architecture to different AI tools. `.trellis/` 
 When a local AI modifies Trellis, it should distinguish two file categories first:
 
 - **Shared files**: `.trellis/workflow.md`, `.trellis/tasks/`, `.trellis/spec/`, `.trellis/scripts/`.
-- **Platform files**: `.claude/`, `.codex/`, `.cursor/`, `.opencode/`, `.kiro/`, `.gemini/`, `.qoder/`, `.codebuddy/`, `.github/`, `.factory/`, `.pi/`, `.kilocode/`, `.agent/`, `.devin/`, `.reasonix/`, `.zcode/`, and similar directories.
+- **Platform files**: `.claude/`, `.codex/`, `.cursor/`, `.opencode/`, `.kiro/`, `.gemini/`, `.qoder/`, `.codebuddy/`, `.github/`, `.factory/`, `.pi/`, `.trae/`, `.kilocode/`, `.agent/`, `.devin/`, `.reasonix/`, `.zcode/`, and similar directories.
 
 Platform files do not store business state. They let the corresponding AI tool read Trellis state, call Trellis scripts, and load Trellis skills/agents/hooks.
 
@@ -13,7 +13,7 @@ Platform files do not store business state. They let the corresponding AI tool r
 
 | Category | Common paths | Purpose |
 | --- | --- | --- |
-| settings/config | `.claude/settings.json`, `.codex/hooks.json`, `.qoder/settings.json` | Register hooks, plugins, extensions, or platform behavior. |
+| settings/config | `.claude/settings.json`, `.codex/hooks.json`, `.qoder/settings.json`, `.trae/hooks.json` | Register hooks, plugins, extensions, or platform behavior. |
 | hooks/plugins/extensions | `.claude/hooks/`, `.opencode/plugins/`, `.pi/extensions/` | Inject context at session start, user input, agent startup, shell execution, and similar events. |
 | agents | `.claude/agents/`, `.codex/agents/`, `.kiro/agents/` | Define `trellis-research`, `trellis-implement`, and `trellis-check`. |
 | skills | `.claude/skills/`, `.agents/skills/`, `.qoder/skills/` | Capability descriptions that auto-trigger or can be read on demand. |

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
@@ -41,6 +41,7 @@ These platforms usually have `trellis-research`, `trellis-implement`, and `trell
 - GitHub Copilot
 - Factory Droid
 - Pi Agent
+- Trae IDE
 - Reasonix (delivered as skills with `runAs: subagent` under `.reasonix/skills/`, not as a separate `agents/` directory)
 - ZCode
 

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
@@ -20,6 +20,7 @@ This page lists common Trellis file locations in a user project by platform. Whe
 | GitHub Copilot | `--copilot` | `.github/` | `.github/skills/` | `.github/agents/` | `.github/copilot/hooks/` + prompts |
 | Factory Droid | `--droid` | `.factory/` | `.factory/skills/` | `.factory/droids/` | `.factory/hooks/` + settings |
 | Pi Agent | `--pi` | `.pi/` | `.pi/skills/` | `.pi/agents/` | `.pi/extensions/trellis/` (native `trellis_subagent` tool) + `.pi/settings.json` |
+| Trae IDE | `--trae` | `.trae/` | `.trae/skills/` | `.trae/agents/` | `.trae/hooks/` + `.trae/hooks.json` |
 | Reasonix | `--reasonix` | `.reasonix/` | `.reasonix/skills/` | None — sub-agents are skills with `runAs: subagent` frontmatter | None |
 | ZCode | `--zcode` | `.zcode/` | `.agents/skills/` | `.zcode/cli/agents/` | pull-based prelude (no hooks) |
 

--- a/packages/cli/src/templates/shared-hooks/index.ts
+++ b/packages/cli/src/templates/shared-hooks/index.ts
@@ -39,7 +39,8 @@ export type SharedHookPlatform =
   | "copilot"
   | "codebuddy"
   | "droid"
-  | "kiro";
+  | "kiro"
+  | "trae";
 
 /**
  * Which shared hooks each platform actually invokes. Single source of truth
@@ -104,6 +105,7 @@ export const SHARED_HOOKS_BY_PLATFORM: Record<
     "inject-workflow-state.py",
     "inject-subagent-context.py",
   ],
+  trae: ["session-start.py", "inject-workflow-state.py"],
 };
 
 /**

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -102,6 +102,7 @@ def _detect_platform(input_data: dict) -> str | None:
         "QODER_PROJECT_DIR": "qoder",
         "KIRO_PROJECT_DIR": "kiro",
         "COPILOT_PROJECT_DIR": "copilot",
+        "TRAE_PROJECT_DIR": "trae",
     }
     for env_name, platform in env_map.items():
         if os.environ.get(env_name):
@@ -123,6 +124,8 @@ def _detect_platform(input_data: dict) -> str | None:
         return "droid"
     if ".kiro" in script_parts:
         return "kiro"
+    if ".trae" in script_parts:
+        return "trae"
     return None
 
 

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -137,6 +137,7 @@ def should_skip_injection() -> bool:
         "GEMINI_NON_INTERACTIVE",
         "KIRO_NON_INTERACTIVE",
         "COPILOT_NON_INTERACTIVE",
+        "TRAE_NON_INTERACTIVE",
     ]
     return any(os.environ.get(var) == "1" for var in non_interactive_vars)
 
@@ -195,6 +196,7 @@ def _detect_platform(input_data: dict) -> str | None:
         "QODER_PROJECT_DIR": "qoder",
         "KIRO_PROJECT_DIR": "kiro",
         "COPILOT_PROJECT_DIR": "copilot",
+        "TRAE_PROJECT_DIR": "trae",
     }
     for env_name, platform in env_map.items():
         if os.environ.get(env_name):
@@ -216,6 +218,8 @@ def _detect_platform(input_data: dict) -> str | None:
         return "droid"
     if ".kiro" in script_parts:
         return "kiro"
+    if ".trae" in script_parts:
+        return "trae"
     return None
 
 
@@ -739,6 +743,7 @@ def main():
         "GEMINI_PROJECT_DIR",
         "KIRO_PROJECT_DIR",
         "COPILOT_PROJECT_DIR",
+        "TRAE_PROJECT_DIR",
     ]
     project_dir = None
     for var in project_dir_env_vars:

--- a/packages/cli/src/templates/trae/agents/trellis-check.md
+++ b/packages/cli/src/templates/trae/agents/trellis-check.md
@@ -1,0 +1,108 @@
+---
+name: trellis-check
+description: |
+  Code quality check expert. Reviews code changes against specs and self-fixes issues.
+tools: Read, Write, Edit, Bash, Glob, Grep
+---
+# Check Agent
+
+You are the Check Agent in the Trellis workflow.
+
+## Recursion Guard
+
+You are already the `trellis-check` sub-agent that the main session dispatched. Do the review and fixes directly.
+
+- Do NOT spawn another `trellis-check` or `trellis-implement` sub-agent.
+- If SessionStart context, workflow-state breadcrumbs, or workflow.md say to dispatch `trellis-implement` / `trellis-check`, treat that as a main-session instruction that is already satisfied by your current role.
+- Only the main session may dispatch Trellis implement/check agents. If more implementation work is needed, report that recommendation instead of spawning.
+
+## Context
+
+Before checking, read:
+- `.trellis/spec/` - Development guidelines
+- Task `prd.md` - Requirements document
+- Task `design.md` - Technical design (if exists)
+- Task `implement.md` - Execution plan (if exists)
+- Pre-commit checklist for quality standards
+
+## Core Responsibilities
+
+1. **Get code changes** - Use git diff to get uncommitted code
+2. **Review task artifacts** - Check changes against prd.md, design.md if present, and implement.md if present
+3. **Check against specs** - Verify code follows guidelines
+4. **Self-fix** - Fix issues yourself, not just report them
+5. **Run verification** - typecheck and lint
+
+## Important
+
+**Fix issues yourself**, don't just report them.
+
+You have write and edit tools, you can modify code directly.
+
+---
+
+## Workflow
+
+### Step 1: Get Changes
+
+```bash
+git diff --name-only  # List changed files
+git diff              # View specific changes
+```
+
+### Step 2: Check Against Specs and Task Artifacts
+
+Read the task's prd.md, design.md if present, and implement.md if present, then read relevant specs in `.trellis/spec/` to check code:
+
+- Does it satisfy the task requirements
+- Does it follow the technical design and implementation plan when present
+- Does it follow directory structure conventions
+- Does it follow naming conventions
+- Does it follow code patterns
+- Are there missing types
+- Are there potential bugs
+
+### Step 3: Self-Fix
+
+After finding issues:
+
+1. Fix the issue directly (use edit tool)
+2. Record what was fixed
+3. Continue checking other issues
+
+### Step 4: Run Verification
+
+Run project's lint and typecheck commands to verify changes.
+
+If failed, fix issues and re-run.
+
+---
+
+## Report Format
+
+```markdown
+## Self-Check Complete
+
+### Files Checked
+
+- src/components/Feature.tsx
+- src/hooks/useFeature.ts
+
+### Issues Found and Fixed
+
+1. `<file>:<line>` - <what was fixed>
+2. `<file>:<line>` - <what was fixed>
+
+### Issues Not Fixed
+
+(If there are issues that cannot be self-fixed, list them here with reasons)
+
+### Verification Results
+
+- TypeCheck: Passed
+- Lint: Passed
+
+### Summary
+
+Checked X files, found Y issues, all fixed.
+```

--- a/packages/cli/src/templates/trae/agents/trellis-implement.md
+++ b/packages/cli/src/templates/trae/agents/trellis-implement.md
@@ -1,0 +1,103 @@
+---
+name: trellis-implement
+description: |
+  Code implementation expert. Understands specs and requirements, then implements features. No git commit allowed.
+tools: Read, Write, Edit, Bash, Glob, Grep
+---
+# Implement Agent
+
+You are the Implement Agent in the Trellis workflow.
+
+## Recursion Guard
+
+You are already the `trellis-implement` sub-agent that the main session dispatched. Do the implementation work directly.
+
+- Do NOT spawn another `trellis-implement` or `trellis-check` sub-agent.
+- If SessionStart context, workflow-state breadcrumbs, or workflow.md say to dispatch `trellis-implement` / `trellis-check`, treat that as a main-session instruction that is already satisfied by your current role.
+- Only the main session may dispatch Trellis implement/check agents. If more parallel work is needed, report that recommendation instead of spawning.
+
+## Context
+
+Before implementing, read:
+- `.trellis/workflow.md` - Project workflow
+- `.trellis/spec/` - Development guidelines
+- Task `prd.md` - Requirements document
+- Task `design.md` - Technical design (if exists)
+- Task `implement.md` - Execution plan (if exists)
+
+## Core Responsibilities
+
+1. **Understand specs** - Read relevant spec files in `.trellis/spec/`
+2. **Understand task artifacts** - Read prd.md, design.md if present, and implement.md if present
+3. **Implement features** - Write code following specs and task artifacts
+4. **Self-check** - Ensure code quality
+5. **Report results** - Report completion status
+
+## Forbidden Operations
+
+**Do NOT execute these git commands:**
+
+- `git commit`
+- `git push`
+- `git merge`
+
+---
+
+## Workflow
+
+### 1. Understand Specs
+
+Read relevant specs based on task type:
+
+- Spec layers: `.trellis/spec/<package>/<layer>/`
+- Shared guides: `.trellis/spec/guides/`
+
+### 2. Understand Requirements
+
+Read the task's prd.md, design.md if present, and implement.md if present:
+
+- What are the core requirements
+- Key points of technical design
+- Implementation order, validation commands, and rollback points
+
+### 3. Implement Features
+
+- Write code following specs and task artifacts
+- Follow existing code patterns
+- Only do what's required, no over-engineering
+
+### 4. Verify
+
+Run project's lint and typecheck commands to verify changes.
+
+---
+
+## Report Format
+
+```markdown
+## Implementation Complete
+
+### Files Modified
+
+- `src/components/Feature.tsx` - New component
+- `src/hooks/useFeature.ts` - New hook
+
+### Implementation Summary
+
+1. Created Feature component...
+2. Added useFeature hook...
+
+### Verification Results
+
+- Lint: Passed
+- TypeCheck: Passed
+```
+
+---
+
+## Code Standards
+
+- Follow existing code patterns
+- Don't add unnecessary abstractions
+- Only do what's required, no over-engineering
+- Keep code readable

--- a/packages/cli/src/templates/trae/agents/trellis-research.md
+++ b/packages/cli/src/templates/trae/agents/trellis-research.md
@@ -1,0 +1,137 @@
+---
+name: trellis-research
+description: |
+  Code and tech search expert. Finds files, patterns, and tech solutions, and PERSISTS every finding to the current task's research/ directory. No code modifications outside that directory.
+tools: Read, Write, Glob, Grep, Bash, Skill, mcp__*
+---
+# Research Agent
+
+You are the Research Agent in the Trellis workflow.
+
+## Core Principle
+
+**You do one thing: find, explain, and PERSIST information.**
+
+Conversations get compacted; files don't. Every research output MUST end up as a file under `{TASK_DIR}/research/`. Returning findings only through the chat reply is a failure — the caller cannot read them next session.
+
+---
+
+## Core Responsibilities
+
+1. **Internal Search** — locate files/components, understand code logic, discover patterns (Glob, Grep, Read)
+2. **External Search** — library docs, API references, best practices (web search)
+3. **Persist** — write each research topic to `{TASK_DIR}/research/<topic>.md`
+4. **Report** — return file paths + one-line summaries to the main agent (not full content)
+
+---
+
+## Workflow
+
+### Step 1: Resolve Current Task
+
+Run `python3 ./.trellis/scripts/task.py current --source` → active task path. If no active task is set, ask the user where to write output; do NOT guess.
+
+Ensure `{TASK_DIR}/research/` exists:
+
+```bash
+mkdir -p <TASK_DIR>/research
+```
+
+### Step 2: Understand Search Request
+
+Classify: internal / external / mixed. Determine scope (global / specific directory) and expected shape (file list / pattern notes / tech comparison).
+
+### Step 3: Execute Search
+
+Run independent searches in parallel (Glob + Grep + web) for efficiency.
+
+### Step 4: Persist Each Topic
+
+For each distinct research topic, Write a markdown file at `{TASK_DIR}/research/<topic-slug>.md`. Use the File Format below.
+
+### Step 5: Report to Main Agent
+
+Reply with ONLY:
+
+- List of files written (paths relative to repo root)
+- One-line summary per file
+- Any critical caveats that the main agent needs to know right now
+
+Do NOT paste full research content into the reply. The files are the contract.
+
+---
+
+## Scope Limits (Strict)
+
+### Write ALLOWED
+
+- `{TASK_DIR}/research/*.md` — your own output
+- Creating `{TASK_DIR}/research/` if it doesn't exist (via `mkdir -p`)
+
+### Write FORBIDDEN
+
+- Code files (`src/`, `lib/`, …)
+- Spec files (`.trellis/spec/`) — main agent should use `update-spec` skill instead
+- `.trellis/scripts/`, `.trellis/workflow.md`, platform config (`.claude/`, `.cursor/`, etc.)
+- Other task directories
+- Any git operation (commit / push / branch / merge)
+
+If the user asks you to edit code, decline and suggest spawning `implement` instead.
+
+---
+
+## File Format
+
+Each `{TASK_DIR}/research/<topic>.md` should follow:
+
+```markdown
+# Research: <topic>
+
+- **Query**: <original query>
+- **Scope**: <internal / external / mixed>
+- **Date**: <YYYY-MM-DD>
+
+## Findings
+
+### Files Found
+
+| File Path | Description |
+|---|---|
+| `src/services/xxx.ts` | Main implementation |
+| `src/types/xxx.ts` | Type definitions |
+
+### Code Patterns
+
+<describe patterns, cite file:line>
+
+### External References
+
+- [Library X docs](url) — <why relevant, version constraints>
+
+### Related Specs
+
+- `.trellis/spec/xxx.md` — <description>
+
+## Caveats / Not Found
+
+<anything incomplete or uncertain>
+```
+
+---
+
+## Guidelines
+
+### DO
+
+- Provide specific file paths and line numbers
+- Quote actual code snippets
+- Persist every topic to its own file
+- Return file paths in your reply, not the full content
+- Mark "not found" explicitly when searches come up empty
+
+### DON'T
+
+- Don't write code or modify files outside `{TASK_DIR}/research/`
+- Don't guess uncertain info
+- Don't paste full research text into the reply (files are the deliverable)
+- Don't propose improvements or critique implementation (that's not your role)

--- a/packages/cli/src/templates/trae/agents/trellis-research.md
+++ b/packages/cli/src/templates/trae/agents/trellis-research.md
@@ -72,7 +72,7 @@ Do NOT paste full research content into the reply. The files are the contract.
 
 - Code files (`src/`, `lib/`, …)
 - Spec files (`.trellis/spec/`) — main agent should use `update-spec` skill instead
-- `.trellis/scripts/`, `.trellis/workflow.md`, platform config (`.claude/`, `.cursor/`, etc.)
+- `.trellis/scripts/`, `.trellis/workflow.md`, platform config (`.claude/`, `.cursor/`, `.trae/`, etc.)
 - Other task directories
 - Any git operation (commit / push / branch / merge)
 

--- a/packages/cli/src/templates/trae/hooks.json
+++ b/packages/cli/src/templates/trae/hooks.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{PYTHON_CMD}} .trae/hooks/session-start.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{PYTHON_CMD}} .trae/hooks/inject-workflow-state.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/cli/src/templates/trae/index.ts
+++ b/packages/cli/src/templates/trae/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Trae IDE templates
+ *
+ * These are GENERIC templates for user projects.
+ *
+ * Directory structure:
+ *   trae/
+ *   ├── agents/         # Multi-agent pipeline agents (Markdown)
+ *   └── hooks.json     # Hook configuration
+ */
+
+import {
+  createTemplateReader,
+  type AgentTemplate,
+  type HookTemplate,
+} from "../template-utils.js";
+
+export type { AgentTemplate, HookTemplate };
+
+const { listMdAgents, getSettings } = createTemplateReader(import.meta.url);
+
+export const getAllAgents = (): AgentTemplate[] => listMdAgents();
+export const getSettingsTemplate = (): HookTemplate =>
+  getSettings("hooks.json");

--- a/packages/cli/src/templates/trellis/scripts/common/active_task.py
+++ b/packages/cli/src/templates/trellis/scripts/common/active_task.py
@@ -43,6 +43,7 @@ _KNOWN_PLATFORMS = {
     "kiro",
     "copilot",
     "pi",
+    "trae",
 }
 
 _ENV_SESSION_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -57,6 +58,7 @@ _ENV_SESSION_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("kiro", ("KIRO_SESSION_ID",)),
     ("copilot", ("COPILOT_SESSION_ID", "COPILOT_SESSIONID")),
     ("pi", ("PI_SESSION_ID", "PI_SESSIONID")),
+    ("trae", ("TRAE_SESSION_ID",)),
 )
 _ENV_CONVERSATION_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("cursor", ("CURSOR_CONVERSATION_ID", "CURSOR_CONVERSATIONID")),

--- a/packages/cli/src/templates/trellis/scripts/common/cli_adapter.py
+++ b/packages/cli/src/templates/trellis/scripts/common/cli_adapter.py
@@ -693,17 +693,19 @@ def detect_platform(project_root: Path) -> Platform:
     2. .opencode directory exists → opencode
     3. .iflow directory exists → iflow
     4. .cursor directory exists (without .claude) → cursor
-    5. .codex exists and no other platform dirs → codex
-    6. .kilocode directory exists → kilo
-    7. .kiro/skills exists and no other platform dirs → kiro
-    8. .gemini directory exists → gemini
+    5. .gemini directory exists → gemini
+    6. .codex exists and no other platform dirs → codex
+    7. .kilocode directory exists → kilo
+    8. .kiro/skills exists and no other platform dirs → kiro
     9. .agent/workflows exists and no other platform dirs → antigravity
     10. .devin/workflows (or legacy .windsurf/workflows) exists and no other platform dirs → devin
     11. .codebuddy directory exists → codebuddy
     12. .qoder directory exists → qoder
-    13. .pi directory exists → pi
-    14. .trae directory exists → trae
-    15. Default → claude
+    13. .github/copilot directory exists → copilot
+    14. .factory directory exists → droid
+    15. .pi directory exists → pi
+    16. .trae directory exists → trae
+    17. Default → claude
 
     Args:
         project_root: Project root directory

--- a/packages/cli/src/templates/trellis/scripts/common/cli_adapter.py
+++ b/packages/cli/src/templates/trellis/scripts/common/cli_adapter.py
@@ -19,6 +19,7 @@ Supported platforms:
 - copilot: GitHub Copilot (VS Code)
 - droid: Factory Droid (commands-based)
 - pi: Pi Agent (extension-backed)
+- trae: Trae IDE (IDE-only, hooks-based)
 
 Usage:
     from common.cli_adapter import CLIAdapter
@@ -53,6 +54,7 @@ Platform = Literal[
     "copilot",
     "droid",
     "pi",
+    "trae",
 ]
 
 
@@ -97,7 +99,7 @@ class CLIAdapter:
         """Get platform-specific config directory name.
 
         Returns:
-            Directory name ('.claude', '.opencode', '.cursor', '.iflow', '.codex', '.kilocode', '.kiro', '.gemini', '.agent', '.devin', '.qoder', '.codebuddy', '.github/copilot', '.factory', or '.pi')
+            Directory name ('.claude', '.opencode', '.cursor', '.iflow', '.codex', '.kilocode', '.kiro', '.gemini', '.agent', '.devin', '.qoder', '.codebuddy', '.github/copilot', '.factory', '.pi', or '.trae')
         """
         if self.platform == "opencode":
             return ".opencode"
@@ -127,6 +129,8 @@ class CLIAdapter:
             return ".factory"
         elif self.platform == "pi":
             return ".pi"
+        elif self.platform == "trae":
+            return ".trae"
         else:
             return ".claude"
 
@@ -137,7 +141,7 @@ class CLIAdapter:
             project_root: Project root directory
 
         Returns:
-            Path to config directory (.claude, .opencode, .cursor, .iflow, .codex, .kilocode, .kiro, .gemini, .agent, .devin, .qoder, .codebuddy, .github/copilot, .factory, or .pi)
+            Path to config directory (.claude, .opencode, .cursor, .iflow, .codex, .kilocode, .kiro, .gemini, .agent, .devin, .qoder, .codebuddy, .github/copilot, .factory, .pi, or .trae)
         """
         return project_root / self.config_dir_name
 
@@ -305,6 +309,8 @@ class CLIAdapter:
             return {}
         elif self.platform == "pi":
             return {}
+        elif self.platform == "trae":
+            return {}
         else:
             return {"CLAUDE_NON_INTERACTIVE": "1"}
 
@@ -390,6 +396,10 @@ class CLIAdapter:
             )
         elif self.platform == "pi":
             cmd = ["pi", "-p", prompt]
+        elif self.platform == "trae":
+            raise ValueError(
+                "Trae is IDE-only; CLI agent run is not supported."
+            )
 
         else:  # claude
             cmd = ["claude", "-p"]
@@ -456,6 +466,10 @@ class CLIAdapter:
             )
         elif self.platform == "pi":
             return ["pi", "-c", session_id]
+        elif self.platform == "trae":
+            raise ValueError(
+                "Trae is IDE-only; CLI resume is not supported."
+            )
         else:
             return ["claude", "--resume", session_id]
 
@@ -530,6 +544,8 @@ class CLIAdapter:
             return "droid"
         elif self.platform == "pi":
             return "pi"
+        elif self.platform == "trae":
+            return "trae"
         else:
             return "claude"
 
@@ -594,7 +610,7 @@ def get_cli_adapter(platform: str = "claude") -> CLIAdapter:
     """Get CLI adapter for the specified platform.
 
     Args:
-        platform: Platform name ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', or 'pi')
+        platform: Platform name ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', 'pi', or 'trae')
 
     Returns:
         CLIAdapter instance
@@ -625,9 +641,10 @@ def get_cli_adapter(platform: str = "claude") -> CLIAdapter:
         "copilot",
         "droid",
         "pi",
+        "trae",
     ):
         raise ValueError(
-            f"Unsupported platform: {platform} (must be 'claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', or 'pi')"
+            f"Unsupported platform: {platform} (must be 'claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', 'pi', or 'trae')"
         )
 
     return CLIAdapter(platform=platform)  # type: ignore
@@ -650,6 +667,7 @@ _ALL_PLATFORM_CONFIG_DIRS = (
     ".github/copilot",
     ".factory",
     ".pi",
+    ".trae",
 )
 """Platform-specific config directory names used by detect_platform exclusion
 checks. `.agents/skills/` is NOT listed here: it is a shared cross-platform
@@ -684,13 +702,14 @@ def detect_platform(project_root: Path) -> Platform:
     11. .codebuddy directory exists → codebuddy
     12. .qoder directory exists → qoder
     13. .pi directory exists → pi
-    14. Default → claude
+    14. .trae directory exists → trae
+    15. Default → claude
 
     Args:
         project_root: Project root directory
 
     Returns:
-        Detected platform ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', 'pi', or default 'claude')
+        Detected platform ('claude', 'opencode', 'cursor', 'iflow', 'codex', 'kilo', 'kiro', 'gemini', 'antigravity', 'devin', 'qoder', 'codebuddy', 'copilot', 'droid', 'pi', 'trae', or default 'claude')
     """
     import os
 
@@ -715,6 +734,7 @@ def detect_platform(project_root: Path) -> Platform:
         "copilot",
         "droid",
         "pi",
+        "trae",
     ):
         return env_platform  # type: ignore
 
@@ -790,6 +810,10 @@ def detect_platform(project_root: Path) -> Platform:
     # Check for .pi directory (Pi Agent-specific)
     if (project_root / ".pi").is_dir():
         return "pi"
+
+    # Check for .trae directory (Trae IDE-specific)
+    if (project_root / ".trae").is_dir():
+        return "trae"
 
     # Fallback: checkout only has the Codex shared-skills layer
     # (.agents/skills/trellis-* dirs) and no explicit platform config dir.

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -128,6 +128,7 @@ _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
     ".factory",   # Factory Droid
     ".github/copilot",
     ".pi",        # Pi Agent
+    ".trae",      # Trae IDE
 )
 
 _SEED_EXAMPLE = (

--- a/packages/cli/src/templates/trellis/workflow.md
+++ b/packages/cli/src/templates/trellis/workflow.md
@@ -220,7 +220,7 @@ Inline mode: skip jsonl curation; Phase 2 reads artifacts/specs via `trellis-bef
      therefore must cover every required step from implementation through
      commit, including Phase 3.3 spec update and Phase 3.4 commit. -->
 
-Sub-agent dispatch protocol applies to all platforms and all sub-agents, including class-2 Codex/Copilot/Gemini/Qoder and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions.
+Sub-agent dispatch protocol applies to all platforms and all sub-agents, including class-2 Codex/Copilot/Gemini/Qoder/Trae and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions.
 
 [workflow-state:in_progress]
 Tools: `trellis-implement` / `trellis-research` are sub-agent types only (Task/Agent tool, NOT Skill; there is no skill by these names). `trellis-update-spec` is a skill. `trellis-check` exists as both; prefer the Agent form when verifying after code changes.
@@ -272,13 +272,13 @@ Code committed. Run `/trellis:finish-work`; if dirty, return to Phase 3.4 first.
 
 When a user request matches one of these intents inside an active task, route first, then load the detailed phase step if needed.
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 - Planning or unclear requirements -> `trellis-brainstorm`.
 - `in_progress` implementation/check -> dispatch `trellis-implement` / `trellis-check`.
 - Repeated debugging -> `trellis-break-loop`; spec updates -> `trellis-update-spec`.
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
@@ -353,7 +353,7 @@ Return to this step whenever requirements change and revise the relevant artifac
 
 Research can happen at any time during requirement exploration. It isn't limited to local code — you can use any available tool (MCP servers, skills, web search, etc.) to look up external information, including third-party library docs, industry practices, API references, etc.
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 Spawn the research sub-agent:
 
@@ -361,7 +361,7 @@ Spawn the research sub-agent:
 - **Task description**: Research <specific question>
 - **Key requirement**: Research output MUST be persisted to `{TASK_DIR}/research/`
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
@@ -380,7 +380,7 @@ Brainstorm and research can interleave freely — pause to research a technical 
 
 #### 1.3 Configure context `[required · once]`
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 Curate `implement.jsonl` and `check.jsonl` so the Phase 2 sub-agents get the right spec/research context. These files were seeded on `task create` with a single self-describing `_example` line; your job here is to fill in real entries.
 
@@ -423,7 +423,7 @@ Delete the seed `_example` line once real entries exist (optional — it's skipp
 
 Skip when: `implement.jsonl` and `check.jsonl` have agent-curated entries (the seed row alone doesn't count).
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
@@ -456,11 +456,11 @@ If `task.py start` errors with a session-identity message (no context key from h
 | `design.md` exists (complex tasks) | ✅ |
 | `implement.md` exists (complex tasks) | ✅ |
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 | `implement.jsonl` / `check.jsonl` curated when extra spec or research context is needed | recommended |
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 ---
 
@@ -470,7 +470,7 @@ Goal: turn reviewed planning artifacts into code that passes quality checks.
 
 #### 2.1 Implement `[required · repeatable]`
 
-[Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Trae]
 
 Spawn the implement sub-agent:
 
@@ -482,7 +482,7 @@ The platform hook/plugin auto-handles:
 - Reads `implement.jsonl` and injects referenced spec/research files into the agent prompt
 - Injects `prd.md`, `design.md` if present, and `implement.md` if present
 
-[/Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Trae]
 
 [codex-sub-agent, ZCode, Reasonix]
 
@@ -524,7 +524,7 @@ The platform prelude auto-handles the context load requirement:
 
 #### 2.2 Quality check `[required · repeatable]`
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 Spawn the check sub-agent:
 
@@ -538,7 +538,7 @@ The check agent's job:
 - Auto-fix issues it finds
 - Run lint and typecheck to verify
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -23,7 +23,8 @@ export type AITool =
   | "droid"
   | "pi"
   | "reasonix"
-  | "zcode";
+  | "zcode"
+  | "trae";
 
 /**
  * Template directory categories
@@ -45,7 +46,8 @@ export type TemplateDir =
   | "droid"
   | "pi"
   | "reasonix"
-  | "zcode";
+  | "zcode"
+  | "trae";
 
 /**
  * CLI flag names for platform selection (e.g., --claude, --cursor, --kilo, --kiro, --gemini, --antigravity)
@@ -67,7 +69,8 @@ export type CliFlag =
   | "droid"
   | "pi"
   | "reasonix"
-  | "zcode";
+  | "zcode"
+  | "trae";
 
 /**
  * Template context for placeholder resolution.
@@ -83,7 +86,12 @@ export interface TemplateContext {
     | "Bash scripts or Agent calls"
     | "Bash scripts or file reads";
   /** Label for user-invocable actions */
-  userActionLabel: "Slash commands" | "Skills" | "Workflows" | "Prompts";
+  userActionLabel:
+    | "Slash commands"
+    | "Skills"
+    | "Workflows"
+    | "Prompts"
+    | "Commands";
   /** Platform supports spawning sub-agents with isolated context */
   agentCapable: boolean;
   /** Platform has hook system (SessionStart, PreToolUse) */
@@ -406,6 +414,22 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
       agentCapable: true,
       hasHooks: false,
       cliFlag: "zcode",
+    },
+  },
+  trae: {
+    name: "Trae",
+    templateDirs: ["common", "trae"],
+    configDir: ".trae",
+    cliFlag: "trae",
+    defaultChecked: false,
+    hasPythonHooks: true,
+    templateContext: {
+      cmdRefPrefix: "/trellis-",
+      executorAI: "Bash scripts or tool calls",
+      userActionLabel: "Commands",
+      agentCapable: true,
+      hasHooks: true,
+      cliFlag: "trae",
     },
   },
 };

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -1253,6 +1253,7 @@ describe("update() integration", () => {
     const updated = fs.readFileSync(workflowPath, "utf-8");
     expect(updated).toBe(replacePythonCommandLiterals(workflowMdTemplate));
     expect(updated).toContain("[codex-sub-agent, ZCode, Reasonix]");
+    expect(updated).toContain("[/Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Trae]");
     expect(updated).toContain("[codex-inline, Kilo, Antigravity, Devin]");
     expect(updated).not.toContain("[Codex]");
     expect(updated).not.toContain("[Kilo, Antigravity, Windsurf]");

--- a/packages/cli/test/registry-invariants.test.ts
+++ b/packages/cli/test/registry-invariants.test.ts
@@ -133,6 +133,11 @@ describe("UserPromptSubmit hook wiring", () => {
       path: "codex/hooks.json",
       event: "UserPromptSubmit",
     },
+    {
+      platform: "trae",
+      path: "trae/hooks.json",
+      event: "UserPromptSubmit",
+    },
   ] as const;
 
   for (const { platform, path, event } of PLATFORM_HOOK_CONFIGS) {

--- a/packages/cli/test/templates/shared-hooks.test.ts
+++ b/packages/cli/test/templates/shared-hooks.test.ts
@@ -57,7 +57,7 @@ describe("shared-hooks capability table", () => {
   it("inject-subagent-context.py is restricted to class-1 push-based platforms", () => {
     // Class-2 (pull-based) platforms load context via agent-definition prelude,
     // not a hook-mutated prompt.
-    const class2 = new Set(["codex", "copilot", "gemini", "qoder"]);
+    const class2 = new Set(["codex", "copilot", "gemini", "qoder", "trae"]);
     for (const [platform, hooks] of Object.entries(
       SHARED_HOOKS_BY_PLATFORM,
     )) {

--- a/packages/cli/test/templates/trae.test.ts
+++ b/packages/cli/test/templates/trae.test.ts
@@ -129,7 +129,7 @@ describe("trae hooks.json registers SessionStart + UserPromptSubmit", () => {
     // Trae docs: matcher is only for PreToolUse/PostToolUse/Notification.
     // SessionStart fires once per new session (source: "startup" only).
     // Having matchers on SessionStart would cause 3x execution or be ignored.
-    const sessionStartGroups = (parsed.hooks as Record<string, Array<Record<string, unknown>>>)["SessionStart"];
+    const sessionStartGroups = (parsed.hooks as Record<string, Record<string, unknown>[]>)["SessionStart"];
     expect(sessionStartGroups).toHaveLength(1);
     expect(sessionStartGroups[0]).not.toHaveProperty("matcher");
   });
@@ -153,7 +153,7 @@ describe("trae hooks.json registers SessionStart + UserPromptSubmit", () => {
   it("UserPromptSubmit hook group has no matcher", () => {
     const raw = fs.readFileSync(hooksPath, "utf-8");
     const parsed = JSON.parse(raw) as { hooks?: Record<string, unknown> };
-    const userPromptGroups = (parsed.hooks as Record<string, Array<Record<string, unknown>>>)["UserPromptSubmit"];
+    const userPromptGroups = (parsed.hooks as Record<string, Record<string, unknown>[]>)["UserPromptSubmit"];
     expect(userPromptGroups).toHaveLength(1);
     expect(userPromptGroups[0]).not.toHaveProperty("matcher");
   });
@@ -222,6 +222,7 @@ describe("trae pull-based prelude injection (class-2)", () => {
     const agents = applyPullBasedPreludeMarkdown(getAllAgents());
     const research = agents.find((a) => a.name === "trellis-research");
     expect(research).toBeDefined();
-    expect(research!.content).not.toContain("Load Trellis Context First");
+    if (!research) return; // guard for type-safety
+    expect(research.content).not.toContain("Load Trellis Context First");
   });
 });

--- a/packages/cli/test/templates/trae.test.ts
+++ b/packages/cli/test/templates/trae.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getAllAgents, getSettingsTemplate } from "../../src/templates/trae/index.js";
+import {
+  resolveAllAsSkills,
+  resolveSkills,
+  resolveBundledSkills,
+  applyPullBasedPreludeMarkdown,
+} from "../../src/configurators/shared.js";
+import { AI_TOOLS } from "../../src/types/ai-tools.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+const EXPECTED_AGENT_NAMES = [
+  "trellis-check",
+  "trellis-implement",
+  "trellis-research",
+];
+
+// Shared skills are sourced from common/ via resolveAllAsSkills (written to
+// .trae/skills/ — Trae has its own private config dir, no .agents/skills alias).
+describe("trae shared skills (from common source)", () => {
+  it("resolves all common templates for trae context", () => {
+    const skills = resolveAllAsSkills(AI_TOOLS.trae.templateContext);
+    expect(skills.length).toBeGreaterThan(0);
+    for (const skill of skills) {
+      expect(skill.content).toContain("description:");
+      expect(skill.content).toContain(`name: ${skill.name}`);
+    }
+  });
+
+  it("does not include platform-specific syntax in resolved output", () => {
+    const skills = resolveAllAsSkills(AI_TOOLS.trae.templateContext);
+    for (const skill of skills) {
+      // Trae uses /trellis- prefix, not /trellis:
+      expect(skill.content).not.toContain("/trellis:");
+      expect(skill.content).not.toContain(".claude/");
+      expect(skill.content).not.toContain(".cursor/");
+    }
+  });
+
+  it("resolves bundled skills for trae context", () => {
+    const bundled = resolveBundledSkills(AI_TOOLS.trae.templateContext);
+    expect(bundled.length).toBeGreaterThan(0);
+  });
+
+  it("resolves auto-triggered skills (resolveSkills) for trae context", () => {
+    const skills = resolveSkills(AI_TOOLS.trae.templateContext);
+    expect(skills.length).toBeGreaterThan(0);
+    for (const skill of skills) {
+      expect(skill.content).toContain("description:");
+      expect(skill.content).toContain(`name: ${skill.name}`);
+    }
+  });
+});
+
+describe("trae getAllAgents", () => {
+  it("returns the expected custom agent set", () => {
+    const agents = getAllAgents();
+    const names = agents.map((agent) => agent.name);
+    expect(names).toEqual(EXPECTED_AGENT_NAMES);
+  });
+
+  it("each agent is a Markdown file with YAML frontmatter", () => {
+    for (const agent of getAllAgents()) {
+      expect(agent.content.length).toBeGreaterThan(0);
+      expect(agent.content).toMatch(/^---\n/);
+      expect(agent.content).toContain("name: ");
+      expect(agent.content).toContain("description:");
+    }
+  });
+});
+
+// =============================================================================
+// Trae sub-agent recursion guard (mirrors codex issue #234)
+// =============================================================================
+//
+// trellis-implement / trellis-check agent markdown MUST contain a hard recursion
+// guard so the dispatched sub-agent does not spawn another
+// trellis-implement / trellis-check sub-agent.
+describe("trae sub-agent recursion guard", () => {
+  for (const name of ["trellis-implement", "trellis-check"] as const) {
+    it(`${name}.md forbids spawning trellis-implement / trellis-check`, () => {
+      const mdPath = path.join(
+        repoRoot,
+        "packages/cli/src/templates/trae/agents",
+        `${name}.md`,
+      );
+      const content = fs.readFileSync(mdPath, "utf-8");
+      // Hard prohibition keyword
+      expect(content).toMatch(/Do NOT spawn/i);
+      // Mentions both sibling agent kinds explicitly
+      expect(content).toContain("trellis-implement");
+      expect(content).toContain("trellis-check");
+      // Mentions the leakage source so the reader knows why
+      expect(content).toMatch(
+        /SessionStart|dispatch.*main session|breadcrumb/i,
+      );
+    });
+  }
+});
+
+describe("trae has no config.toml (no Codex CLI trust mechanism)", () => {
+  it("does not ship a config.toml template", () => {
+    const configPath = path.join(
+      repoRoot,
+      "packages/cli/src/templates/trae/config.toml",
+    );
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+});
+
+describe("trae hooks.json registers SessionStart + UserPromptSubmit", () => {
+  const hooksPath = path.join(
+    repoRoot,
+    "packages/cli/src/templates/trae/hooks.json",
+  );
+
+  it("includes version field and wires session-start.py under SessionStart", () => {
+    const raw = fs.readFileSync(hooksPath, "utf-8");
+    const parsed = JSON.parse(raw) as { version?: number; hooks?: Record<string, unknown> };
+    expect(parsed.version).toBe(1);
+    expect(parsed.hooks).toBeDefined();
+    expect(Object.keys(parsed.hooks ?? {})).toContain("SessionStart");
+    expect(raw).toContain(".trae/hooks/session-start.py");
+    // Trae docs: matcher is only for PreToolUse/PostToolUse/Notification.
+    // SessionStart fires once per new session (source: "startup" only).
+    // Having matchers on SessionStart would cause 3x execution or be ignored.
+    const sessionStartGroups = (parsed.hooks as Record<string, Array<Record<string, unknown>>>)["SessionStart"];
+    expect(sessionStartGroups).toHaveLength(1);
+    expect(sessionStartGroups[0]).not.toHaveProperty("matcher");
+  });
+
+  it("wires inject-workflow-state.py under UserPromptSubmit", () => {
+    const raw = fs.readFileSync(hooksPath, "utf-8");
+    const parsed = JSON.parse(raw) as { hooks?: Record<string, unknown> };
+    expect(parsed.hooks).toBeDefined();
+    expect(Object.keys(parsed.hooks ?? {})).toContain("UserPromptSubmit");
+    expect(raw).toContain(".trae/hooks/inject-workflow-state.py");
+  });
+
+  it("does not register any other hook events", () => {
+    const raw = fs.readFileSync(hooksPath, "utf-8");
+    const parsed = JSON.parse(raw) as { hooks?: Record<string, unknown> };
+    expect(Object.keys(parsed.hooks ?? {}).sort()).toEqual(
+      ["SessionStart", "UserPromptSubmit"].sort(),
+    );
+  });
+
+  it("UserPromptSubmit hook group has no matcher", () => {
+    const raw = fs.readFileSync(hooksPath, "utf-8");
+    const parsed = JSON.parse(raw) as { hooks?: Record<string, unknown> };
+    const userPromptGroups = (parsed.hooks as Record<string, Array<Record<string, unknown>>>)["UserPromptSubmit"];
+    expect(userPromptGroups).toHaveLength(1);
+    expect(userPromptGroups[0]).not.toHaveProperty("matcher");
+  });
+});
+
+describe("trae getSettingsTemplate", () => {
+  it("returns hooks.json as the target path with version field", () => {
+    const settings = getSettingsTemplate();
+    expect(settings.targetPath).toBe("hooks.json");
+    expect(settings.content).toContain("\"version\": 1");
+    expect(settings.content).toContain("SessionStart");
+    expect(settings.content).toContain("UserPromptSubmit");
+  });
+});
+
+// inject-workflow-state.py is shared across platforms; its _detect_platform()
+// must map a hook installed under .trae/ to the "trae" platform so the
+// breadcrumb is emitted with the right context (mirrors the .codex branch).
+describe("trae platform detection in shared inject-workflow-state.py", () => {
+  it("_detect_platform returns 'trae' for a .trae script path", () => {
+    const hookPath = path.join(
+      repoRoot,
+      "packages/cli/src/templates/shared-hooks/inject-workflow-state.py",
+    );
+    const content = fs.readFileSync(hookPath, "utf-8");
+    expect(content).toMatch(/if "\.trae" in script_parts:\s*\n\s*return "trae"/);
+  });
+});
+
+// session-start.py is also a shared hook for Trae; it must detect .trae paths
+// and TRAE_PROJECT_DIR env so the SessionStart context is emitted correctly.
+describe("trae platform detection in shared session-start.py", () => {
+  it("detects .trae directory and TRAE_PROJECT_DIR env", () => {
+    const hookPath = path.join(
+      repoRoot,
+      "packages/cli/src/templates/shared-hooks/session-start.py",
+    );
+    const content = fs.readFileSync(hookPath, "utf-8");
+    expect(content).toMatch(/if "\.trae" in script_parts:\s*\n\s*return "trae"/);
+    expect(content).toContain("TRAE_PROJECT_DIR");
+  });
+});
+
+// =============================================================================
+// Pull-based prelude (class-2 platform)
+// =============================================================================
+//
+// Trae is a class-2 (pull-based) platform: hooks cannot mutate sub-agent
+// prompts. The implement/check agents must have a pull-based prelude injected
+// so they load Trellis context themselves.
+describe("trae pull-based prelude injection (class-2)", () => {
+  it("applyPullBasedPreludeMarkdown injects context-loading instructions", () => {
+    const agents = applyPullBasedPreludeMarkdown(getAllAgents());
+    for (const agent of agents) {
+      if (
+        agent.name === "trellis-implement" ||
+        agent.name === "trellis-check"
+      ) {
+        expect(agent.content).toContain("Load Trellis Context First");
+        expect(agent.content).toContain("task.py current --source");
+      }
+    }
+  });
+
+  it("research agent does not get the prelude (no task context needed)", () => {
+    const agents = applyPullBasedPreludeMarkdown(getAllAgents());
+    const research = agents.find((a) => a.name === "trellis-research");
+    expect(research).toBeDefined();
+    expect(research!.content).not.toContain("Load Trellis Context First");
+  });
+});


### PR DESCRIPTION
新增对Trae的支持。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--trae` option to CLI initialization, with automatic platform detection for existing `.trae/` projects.
  * Added Trae IDE templates (agents, hooks, and settings) and registered Trae shared hook wiring.
* **Bug Fixes**
  * Improved uninstall cleanup for Trae hook settings (`.trae/hooks.json`) so it’s scrubbed like other managed hook manifests.
  * Updated session/task context resolution to recognize Trae environment variables and `.trae/`.
* **Documentation**
  * Updated platform maps and file reference docs to include Trae directory and flag details.
* **Tests**
  * Added/updated tests covering Trae template generation, hook wiring, and platform detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->