### PR TITLE
fix(hooks): avoid blocking on empty stdin

### DIFF
--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -34,6 +34,8 @@ import json
 import os
 import re
 import sys
+import queue
+import threading
 from pathlib import Path
 
 # Force UTF-8 on stdin/stdout/stderr on Windows. Default codepage there is
@@ -302,14 +304,44 @@ def build_breadcrumb(
 # Entry
 # ---------------------------------------------------------------------------
 
+def _load_hook_input() -> dict:
+    """Read hook JSON without trusting host runners to close stdin.
+
+    Kiro IDE `runCommand` and similar hook runners can leave stdin open while
+    sending no payload. A plain `json.load(sys.stdin)` then blocks forever.
+    Normal hook runners write the complete JSON payload and close stdin, so the
+    short daemon read preserves that path while failing closed to `{}` for
+    non-piping hosts.
+    """
+    result_queue: "queue.Queue[str | BaseException]" = queue.Queue(maxsize=1)
+
+    def _read() -> None:
+        try:
+            result_queue.put(sys.stdin.read())
+        except BaseException as exc:
+            result_queue.put(exc)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    try:
+        raw = result_queue.get(timeout=0.2)
+    except queue.Empty:
+        return {}
+
+    if isinstance(raw, BaseException):
+        return {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def main() -> int:
     if os.environ.get("TRELLIS_HOOKS") == "0" or os.environ.get("TRELLIS_DISABLE_HOOKS") == "1":
         return 0
 
-    try:
-        data = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError):
-        data = {}
+    data = _load_hook_input()
 
     cwd_str = data.get("cwd") or os.getcwd()
     cwd = Path(cwd_str)

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -12,7 +12,7 @@
  * 5. Platform Registry (beta.9, beta.13, beta.16)
  */
 
-import { execSync, spawnSync } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -3166,6 +3166,57 @@ describe("regression: current-task path normalization", () => {
     } finally {
       fs.rmSync(nonTrellisDir, { recursive: true, force: true });
     }
+  });
+
+  it("[#356] inject-workflow-state.py exits when host leaves stdin open with no payload", async () => {
+    setupTaskRepo();
+    writeWorkflowStateHook();
+
+    const hookPath = path.join(
+      tmpDir,
+      ".trellis",
+      "hooks",
+      "inject-workflow-state.py",
+    );
+    const child = spawn(pythonCmd, [hookPath], {
+      cwd: tmpDir,
+      env: sessionEnv({ KIRO_PROJECT_DIR: tmpDir }),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const result = await new Promise<{
+      code: number | null;
+      signal: NodeJS.Signals | null;
+      timedOut: boolean;
+    }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve({ code: null, signal: "SIGKILL", timedOut: true });
+      }, 1500);
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.once("exit", (code, signal) => {
+        clearTimeout(timer);
+        resolve({ code, signal, timedOut: false });
+      });
+    });
+
+    expect(result.timedOut, stderr).toBe(false);
+    expect(result.code).toBe(0);
+    expect(stdout).toContain("<workflow-state>");
   });
 
   // ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a bounded stdin loader for `inject-workflow-state.py` so IDE hook runners that leave stdin open do not hang
- preserve JSON stdin behavior for normal hook runners that pipe and close hook input
- add regression coverage for #356 by spawning the hook with an open, empty stdin pipe

## Root Cause
`json.load(sys.stdin)` waits for EOF. Kiro IDE `runCommand` and similar hook runners can leave stdin open while sending no payload, so the hook process blocks before it can emit workflow state.

## Tests
- `pnpm --filter @mindfoldhq/trellis-core build`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/regression.test.ts -t "#356|inject-workflow-state.py emits BeforeAgent|silent exit 0 when not a Trellis project"`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/templates/shared-hooks.test.ts`
- `python3 -m py_compile packages/cli/src/templates/shared-hooks/inject-workflow-state.py`

Fixes #356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook handling so it no longer hangs when input is left open without data.
  * Added safer fallback behavior for missing, delayed, or invalid input, allowing the process to exit cleanly.
  * Verified the hook still produces the expected workflow state output under open-stdin conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->