### PR TITLE
[codex] Require lossless PRD convergence in brainstorm

### DIFF
--- a/.agents/skills/trellis-brainstorm/SKILL.md
+++ b/.agents/skills/trellis-brainstorm/SKILL.md
@@ -53,6 +53,7 @@ Use a concise title from the user's request. Use a slug without a date prefix. `
 5. Include your recommended answer with the question.
 6. After each user answer, update `prd.md` before continuing.
 7. For complex tasks, create or update `design.md` and `implement.md` before implementation starts.
+8. Before final review or `task.py start`, run the PRD convergence pass below.
 
 Do not invent a project-specific product/spec hierarchy. If the repository already has product, domain, or spec docs, use them. If it does not, proceed with the evidence that exists.
 
@@ -142,11 +143,27 @@ Lightweight tasks may have only `prd.md`. Complex tasks must have `prd.md`, `des
 
 `implement.md` is not a replacement for `implement.jsonl`. On sub-agent-dispatch workflows, `implement.jsonl` and `check.jsonl` must each contain at least one real spec/research entry before `task.py start`; the seed `_example` row does not count. Inline workflows skip this JSONL gate because Phase 2 loads context through `trellis-before-dev`.
 
+## PRD Convergence Pass
+
+Before declaring planning ready or running `task.py start`, rewrite `prd.md` once against the final structure described in the artifact rules above. This is not optional cleanup; it is the final planning gate.
+
+The pass must be lossless:
+
+- Collapse repeated facts into one authoritative section.
+- Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions` into Goal, Background, Requirements, Technical Notes, or Acceptance Criteria.
+- Remove resolved open questions instead of leaving empty or already-answered sections.
+- Merge parallel bug and requirement lists when they describe the same work; keep each defect's severity, evidence, and file:line anchors on the owning requirement.
+- Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.
+- Keep only genuinely blocking open questions.
+
+After the pass, read `prd.md` top to bottom and verify that no fact is repeated across sections unless the repetition adds new information.
+
 ## Quality Bar
 
 Before declaring planning ready:
 
 - `prd.md` contains testable acceptance criteria.
+- `prd.md` has passed the PRD convergence pass: no unresolved temporary brainstorm sections, no duplicate facts across sections, and no lost anchors, decisions, or acceptance mappings.
 - Repository-answerable questions have already been answered through inspection.
 - Remaining open questions are genuinely about user intent or scope.
 - Complex tasks have `design.md` and `implement.md`.

--- a/.claude/skills/trellis-brainstorm/SKILL.md
+++ b/.claude/skills/trellis-brainstorm/SKILL.md
@@ -53,6 +53,7 @@ Use a concise title from the user's request. Use a slug without a date prefix. `
 5. Include your recommended answer with the question.
 6. After each user answer, update `prd.md` before continuing.
 7. For complex tasks, create or update `design.md` and `implement.md` before implementation starts.
+8. Before final review or `task.py start`, run the PRD convergence pass below.
 
 Do not invent a project-specific product/spec hierarchy. If the repository already has product, domain, or spec docs, use them. If it does not, proceed with the evidence that exists.
 
@@ -142,11 +143,27 @@ Lightweight tasks may have only `prd.md`. Complex tasks must have `prd.md`, `des
 
 `implement.md` is not a replacement for `implement.jsonl`. Use JSONL files only for manifest-style spec and research references when the task needs them.
 
+## PRD Convergence Pass
+
+Before declaring planning ready or running `task.py start`, rewrite `prd.md` once against the final structure described in the artifact rules above. This is not optional cleanup; it is the final planning gate.
+
+The pass must be lossless:
+
+- Collapse repeated facts into one authoritative section.
+- Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions` into Goal, Background, Requirements, Technical Notes, or Acceptance Criteria.
+- Remove resolved open questions instead of leaving empty or already-answered sections.
+- Merge parallel bug and requirement lists when they describe the same work; keep each defect's severity, evidence, and file:line anchors on the owning requirement.
+- Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.
+- Keep only genuinely blocking open questions.
+
+After the pass, read `prd.md` top to bottom and verify that no fact is repeated across sections unless the repetition adds new information.
+
 ## Quality Bar
 
 Before declaring planning ready:
 
 - `prd.md` contains testable acceptance criteria.
+- `prd.md` has passed the PRD convergence pass: no unresolved temporary brainstorm sections, no duplicate facts across sections, and no lost anchors, decisions, or acceptance mappings.
 - Repository-answerable questions have already been answered through inspection.
 - Remaining open questions are genuinely about user intent or scope.
 - Complex tasks have `design.md` and `implement.md`.

--- a/.trellis/tasks/06-18-brainstorm-prd-dedup/prd.md
+++ b/.trellis/tasks/06-18-brainstorm-prd-dedup/prd.md
@@ -27,12 +27,14 @@
 - 可能涉及 workflow.md 的 Phase 1 → Phase 2 过渡描述（Step 8 与 task.py start 之间）
 - 多平台同步（同 sync-on-change Trigger 1 类）
 
-## 验收（待细化）
+## 验收
 
-- [ ] brainstorm 走完后，终态 prd.md 无跨章节重复、无遗留临时章节
-- [ ] 收敛无损：file:line 锚点 / 决策 / AC↔需求映射全保留
-- [ ] 关联 #320，实现后在 issue 回复并 close
+- [x] `trellis-brainstorm` 的 common/codex/copilot 模板都要求在最终 review 或 `task.py start` 前执行 PRD convergence pass。
+- [x] 收敛步骤明确要求合并 `What I already know` / `Assumptions` / resolved `Open Questions`，并去除跨章节重复事实。
+- [x] 收敛步骤明确要求无损保留 file:line 锚点、决策、约束、需求 ID、验收映射。
+- [x] 回归测试覆盖三份安装模板，防止只改一份模板导致平台漂移。
+- [ ] 关联 #320，实现后在 issue 回复并 close。
 
 ## 状态
 
-planning（记账，后续排期）。关联 issue #320（已标 enhancement）。
+in_progress。关联 issue #320（已标 enhancement）。

--- a/.trellis/tasks/06-18-brainstorm-prd-dedup/task.json
+++ b/.trellis/tasks/06-18-brainstorm-prd-dedup/task.json
@@ -3,7 +3,7 @@
   "name": "brainstorm-prd-dedup",
   "title": "brainstorm PRD 收敛去重环节（#320）",
   "description": "",
-  "status": "planning",
+  "status": "in_progress",
   "dev_type": null,
   "scope": null,
   "package": null,

--- a/packages/cli/src/templates/codex/skills/brainstorm/SKILL.md
+++ b/packages/cli/src/templates/codex/skills/brainstorm/SKILL.md
@@ -53,6 +53,7 @@ Use a concise title from the user's request. Use a slug without a date prefix. `
 5. Include your recommended answer with the question.
 6. After each user answer, update `prd.md` before continuing.
 7. For complex tasks, create or update `design.md` and `implement.md` before implementation starts.
+8. Before final review or `task.py start`, run the PRD convergence pass below.
 
 Do not invent a project-specific product/spec hierarchy. If the repository already has product, domain, or spec docs, use them. If it does not, proceed with the evidence that exists.
 
@@ -99,11 +100,27 @@ Lightweight tasks may have only `prd.md`. Complex tasks must have `prd.md`, `des
 
 `implement.md` is not a replacement for `implement.jsonl`. On sub-agent-dispatch workflows, `implement.jsonl` and `check.jsonl` must each contain at least one real spec/research entry before `task.py start`; the seed `_example` row does not count. Inline workflows skip this JSONL gate because Phase 2 loads context through `trellis-before-dev`.
 
+## PRD Convergence Pass
+
+Before declaring planning ready or running `task.py start`, rewrite `prd.md` once against the final structure described in the artifact rules above. This is not optional cleanup; it is the final planning gate.
+
+The pass must be lossless:
+
+- Collapse repeated facts into one authoritative section.
+- Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions` into Goal, Background, Requirements, Technical Notes, or Acceptance Criteria.
+- Remove resolved open questions instead of leaving empty or already-answered sections.
+- Merge parallel bug and requirement lists when they describe the same work; keep each defect's severity, evidence, and file:line anchors on the owning requirement.
+- Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.
+- Keep only genuinely blocking open questions.
+
+After the pass, read `prd.md` top to bottom and verify that no fact is repeated across sections unless the repetition adds new information.
+
 ## Quality Bar
 
 Before declaring planning ready:
 
 - `prd.md` contains testable acceptance criteria.
+- `prd.md` has passed the PRD convergence pass: no unresolved temporary brainstorm sections, no duplicate facts across sections, and no lost anchors, decisions, or acceptance mappings.
 - Repository-answerable questions have already been answered through inspection.
 - Remaining open questions are genuinely about user intent or scope.
 - Complex tasks have `design.md` and `implement.md`.

--- a/packages/cli/src/templates/common/skills/brainstorm.md
+++ b/packages/cli/src/templates/common/skills/brainstorm.md
@@ -48,6 +48,7 @@ Use a concise title from the user's request. Use a slug without a date prefix. `
 5. Include your recommended answer with the question.
 6. After each user answer, update `prd.md` before continuing.
 7. For complex tasks, create or update `design.md` and `implement.md` before implementation starts.
+8. Before final review or `task.py start`, run the PRD convergence pass below.
 
 Do not invent a project-specific product/spec hierarchy. If the repository already has product, domain, or spec docs, use them. If it does not, proceed with the evidence that exists.
 
@@ -137,11 +138,27 @@ Lightweight tasks may have only `prd.md`. Complex tasks must have `prd.md`, `des
 
 `implement.md` is not a replacement for `implement.jsonl`. On sub-agent-dispatch workflows, `implement.jsonl` and `check.jsonl` must each contain at least one real spec/research entry before `task.py start`; the seed `_example` row does not count. Inline workflows skip this JSONL gate because Phase 2 loads context through `trellis-before-dev`.
 
+## PRD Convergence Pass
+
+Before declaring planning ready or running `task.py start`, rewrite `prd.md` once against the final structure described in the artifact rules above. This is not optional cleanup; it is the final planning gate.
+
+The pass must be lossless:
+
+- Collapse repeated facts into one authoritative section.
+- Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions` into Goal, Background, Requirements, Technical Notes, or Acceptance Criteria.
+- Remove resolved open questions instead of leaving empty or already-answered sections.
+- Merge parallel bug and requirement lists when they describe the same work; keep each defect's severity, evidence, and file:line anchors on the owning requirement.
+- Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.
+- Keep only genuinely blocking open questions.
+
+After the pass, read `prd.md` top to bottom and verify that no fact is repeated across sections unless the repetition adds new information.
+
 ## Quality Bar
 
 Before declaring planning ready:
 
 - `prd.md` contains testable acceptance criteria.
+- `prd.md` has passed the PRD convergence pass: no unresolved temporary brainstorm sections, no duplicate facts across sections, and no lost anchors, decisions, or acceptance mappings.
 - Repository-answerable questions have already been answered through inspection.
 - Remaining open questions are genuinely about user intent or scope.
 - Complex tasks have `design.md` and `implement.md`.

--- a/packages/cli/src/templates/copilot/prompts/brainstorm.prompt.md
+++ b/packages/cli/src/templates/copilot/prompts/brainstorm.prompt.md
@@ -52,6 +52,7 @@ Use a concise title from the user's request. Use a slug without a date prefix. `
 5. Include your recommended answer with the question.
 6. After each user answer, update `prd.md` before continuing.
 7. For complex tasks, create or update `design.md` and `implement.md` before implementation starts.
+8. Before final review or `task.py start`, run the PRD convergence pass below.
 
 Do not invent a project-specific product/spec hierarchy. If the repository already has product, domain, or spec docs, use them. If it does not, proceed with the evidence that exists.
 
@@ -98,11 +99,27 @@ Lightweight tasks may have only `prd.md`. Complex tasks must have `prd.md`, `des
 
 `implement.md` is not a replacement for `implement.jsonl`. On sub-agent-dispatch workflows, `implement.jsonl` and `check.jsonl` must each contain at least one real spec/research entry before `task.py start`; the seed `_example` row does not count. Inline workflows skip this JSONL gate because Phase 2 loads context through `trellis-before-dev`.
 
+## PRD Convergence Pass
+
+Before declaring planning ready or running `task.py start`, rewrite `prd.md` once against the final structure described in the artifact rules above. This is not optional cleanup; it is the final planning gate.
+
+The pass must be lossless:
+
+- Collapse repeated facts into one authoritative section.
+- Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions` into Goal, Background, Requirements, Technical Notes, or Acceptance Criteria.
+- Remove resolved open questions instead of leaving empty or already-answered sections.
+- Merge parallel bug and requirement lists when they describe the same work; keep each defect's severity, evidence, and file:line anchors on the owning requirement.
+- Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.
+- Keep only genuinely blocking open questions.
+
+After the pass, read `prd.md` top to bottom and verify that no fact is repeated across sections unless the repetition adds new information.
+
 ## Quality Bar
 
 Before declaring planning ready:
 
 - `prd.md` contains testable acceptance criteria.
+- `prd.md` has passed the PRD convergence pass: no unresolved temporary brainstorm sections, no duplicate facts across sections, and no lost anchors, decisions, or acceptance mappings.
 - Repository-answerable questions have already been answered through inspection.
 - Remaining open questions are genuinely about user intent or scope.
 - Complex tasks have `design.md` and `implement.md`.

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -3580,6 +3580,40 @@ print(len(entries))
     }
   });
 
+  it("[#320] brainstorm templates require lossless PRD convergence before start", () => {
+    const templateRoot = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "src",
+      "templates",
+    );
+    const brainstormFiles = [
+      "common/skills/brainstorm.md",
+      "codex/skills/brainstorm/SKILL.md",
+      "copilot/prompts/brainstorm.prompt.md",
+    ];
+
+    for (const relativePath of brainstormFiles) {
+      const content = fs.readFileSync(
+        path.join(templateRoot, relativePath),
+        "utf-8",
+      );
+      expect(content, relativePath).toContain(
+        "Before final review or `task.py start`, run the PRD convergence pass below.",
+      );
+      expect(content, relativePath).toContain("## PRD Convergence Pass");
+      expect(content, relativePath).toContain(
+        "Fold temporary brainstorm sections such as `What I already know`, `Assumptions`, and resolved `Open Questions`",
+      );
+      expect(content, relativePath).toContain(
+        "Preserve every file:line anchor, decision, constraint, requirement ID, and acceptance-criteria mapping.",
+      );
+      expect(content, relativePath).toContain(
+        "no unresolved temporary brainstorm sections, no duplicate facts across sections",
+      );
+    }
+  });
+
   it("[workflow-state-r3-no_task] template workflow.md [workflow-state:no_task] block is present and well-formed", () => {
     const wf = templateWorkflowMd();
     expect(wf).toMatch(


### PR DESCRIPTION
## Summary
- add a required PRD convergence pass to the brainstorm planning flow
- make the pass lossless: fold temporary sections, remove resolved questions, merge parallel bug/requirement lists, and preserve anchors/decisions/acceptance mappings
- keep common, Codex, Copilot, Claude, and dogfood brainstorm copies aligned
- add a regression test that locks the shipped brainstorm templates

Fixes #320.

## Validation
- pnpm --filter @mindfoldhq/trellis exec vitest run test/regression.test.ts -t "#320"
- pnpm typecheck
- pnpm lint
- pnpm test (after git submodule update --init --recursive)
- pnpm build
- git diff --check
- GitNexus detect_changes: low risk, 0 affected processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a required final “PRD convergence pass” to the planning workflow before review or starting implementation.
  * Expanded readiness checks so planning must produce a clean, lossless PRD with resolved temporary content, preserved mappings, and only truly blocking open questions.
  * Clarified that complex work needs supporting design/implementation planning and approval before implementation.

* **Tests**
  * Updated regression coverage to verify the new PRD convergence requirements across brainstorming templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->