### PR TITLE
chore: sync marketplace workflow mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
+      - 'marketplace'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
+      - 'marketplace'
       - '.github/workflows/ci.yml'
 
 jobs:


### PR DESCRIPTION
## Summary
- bump the `marketplace` submodule to include the native workflow mirror sync for Trae
- restore `packages/cli/test/templates/trellis.test.ts` byte-for-byte mirror assertion after PR #359
- include the `marketplace` submodule pointer in CI path filters so these mirror fixes trigger Actions on PRs and main pushes

## Related
- marketplace mirror PR: https://github.com/mindfold-ai/marketplace/pull/5
- failing run: https://github.com/mindfold-ai/Trellis/actions/runs/28142230852

## Verification
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/templates/trellis.test.ts`
- `pnpm --filter @mindfoldhq/trellis test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the marketplace component to a newer revision.
* **CI**
  * Adjusted CI triggers so the pipeline runs when changes occur within the marketplace path, in addition to the existing manifest and package checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->