### PR TITLE
fix(zcode): write sub-agents to .zcode/agents/ (was .zcode/cli/agents/)

### DIFF
--- a/packages/cli/src/configurators/zcode.ts
+++ b/packages/cli/src/configurators/zcode.ts
@@ -5,7 +5,7 @@
  * Three output paths:
  * - `.agents/skills/` — shared skills, byte-identical with Codex/Gemini writes
  * - `.zcode/commands/trellis/` — slash commands (invoked as /trellis:<name>)
- * - `.zcode/cli/agents/` — sub-agent definitions with pull-based prelude
+ * - `.zcode/agents/` — sub-agent definitions with pull-based prelude
  */
 
 import path from "node:path";
@@ -45,9 +45,9 @@ export function collectZcodeTemplates(): Map<string, string> {
     files.set(`.zcode/commands/trellis/${cmd.name}.md`, cmd.content);
   }
 
-  // 3. Sub-agents → .zcode/cli/agents/ (with pull-based prelude)
+  // 3. Sub-agents → .zcode/agents/ (with pull-based prelude)
   for (const agent of applyPullBasedPreludeMarkdown(getAllAgents())) {
-    files.set(`.zcode/cli/agents/${agent.name}.md`, agent.content);
+    files.set(`.zcode/agents/${agent.name}.md`, agent.content);
   }
 
   return files;
@@ -74,9 +74,9 @@ export async function configureZcode(cwd: string): Promise<void> {
     await writeFile(path.join(commandsDir, `${cmd.name}.md`), cmd.content);
   }
 
-  // 3. Sub-agents → .zcode/cli/agents/ (with pull-based prelude)
+  // 3. Sub-agents → .zcode/agents/ (with pull-based prelude)
   await writeAgents(
-    path.join(cwd, ".zcode", "cli", "agents"),
+    path.join(cwd, ".zcode", "agents"),
     applyPullBasedPreludeMarkdown(getAllAgents()),
   );
 }

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-agents.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-agents.md
@@ -25,7 +25,7 @@ When the user wants to change `trellis-research`, `trellis-implement`, or `trell
 | Factory Droid | `.factory/droids/trellis-*.md` |
 | Pi Agent | `.pi/agents/trellis-*.md` |
 | Reasonix | `.reasonix/skills/trellis-*/SKILL.md` (subagent frontmatter) |
-| ZCode | `.zcode/cli/agents/trellis-*.md` |
+| ZCode | `.zcode/agents/trellis-*.md` |
 
 Use the actual paths in the user project as authoritative.
 

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/generated-files.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/generated-files.md
@@ -41,7 +41,7 @@ Different platforms generate different directories. Common categories:
 | --- | --- | --- |
 | hooks | `.claude/hooks/`, `.codex/hooks/`, `.cursor/hooks/` | Inject session context, workflow-state, and sub-agent context. |
 | settings | `.claude/settings.json`, `.codex/hooks.json`, `.qoder/settings.json`, `.trae/hooks.json` | Tell the platform when to run hooks or plugins. |
-| agents | `.claude/agents/`, `.codex/agents/`, `.kiro/agents/`, `.zcode/cli/agents/` | Define agents such as `trellis-research`, `trellis-implement`, and `trellis-check`. |
+| agents | `.claude/agents/`, `.codex/agents/`, `.kiro/agents/`, `.zcode/agents/` | Define agents such as `trellis-research`, `trellis-implement`, and `trellis-check`. |
 | skills | `.claude/skills/`, `.agents/skills/`, `.qoder/skills/` | Skills that auto-trigger or can be read by AI. |
 | commands/prompts/workflows | `.cursor/commands/`, `.github/prompts/`, `.devin/workflows/`, `.zcode/commands/` | Explicit user-invoked command or workflow entry points. |
 

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/agents.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/agents.md
@@ -33,7 +33,7 @@ Agent files should not become generic chat prompts. They should define input sou
 | Factory Droid | `.factory/droids/trellis-*.md` |
 | Pi Agent | `.pi/agents/trellis-*.md` |
 | Reasonix | `.reasonix/skills/trellis-*/SKILL.md` (subagent frontmatter) |
-| ZCode | `.zcode/cli/agents/trellis-*.md` |
+| ZCode | `.zcode/agents/trellis-*.md` |
 
 GitHub Copilot agent/prompt support is provided by a combination of directories such as `.github/agents/`, `.github/prompts/`, and `.github/skills/`; inspect the files actually generated in the user project.
 

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
@@ -22,7 +22,7 @@ This page lists common Trellis file locations in a user project by platform. Whe
 | Pi Agent | `--pi` | `.pi/` | `.pi/skills/` | `.pi/agents/` | `.pi/extensions/trellis/` (native `trellis_subagent` tool) + `.pi/settings.json` |
 | Trae IDE | `--trae` | `.trae/` | `.trae/skills/` | `.trae/agents/` | `.trae/hooks/` + `.trae/hooks.json` |
 | Reasonix | `--reasonix` | `.reasonix/` | `.reasonix/skills/` | None — sub-agents are skills with `runAs: subagent` frontmatter | None |
-| ZCode | `--zcode` | `.zcode/` | `.agents/skills/` | `.zcode/cli/agents/` | pull-based prelude (no hooks) |
+| ZCode | `--zcode` | `.zcode/` | `.agents/skills/` | `.zcode/agents/` | pull-based prelude (no hooks) |
 
 ## Capability Groups
 

--- a/packages/cli/src/templates/zcode/index.ts
+++ b/packages/cli/src/templates/zcode/index.ts
@@ -2,7 +2,7 @@
  * ZCode template module.
  *
  * ZCode (智谱) is an agentic AI coding tool that supports multi-agent
- * collaboration. It stores agents as `.zcode/cli/agents/<name>.md`
+ * collaboration. It stores agents as `.zcode/agents/<name>.md`
  * (Markdown with YAML frontmatter: name, description, color).
  *
  * Sub-agent definitions (trellis-implement, trellis-check) use pull-based

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -403,7 +403,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     templateDirs: ["common", "zcode"],
     configDir: ".zcode",
     supportsAgentSkills: true,
-    extraManagedPaths: [".zcode/cli/agents", ".zcode/commands"],
+    extraManagedPaths: [".zcode/agents", ".zcode/commands"],
     cliFlag: "zcode",
     defaultChecked: false,
     hasPythonHooks: false,

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -403,7 +403,17 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     templateDirs: ["common", "zcode"],
     configDir: ".zcode",
     supportsAgentSkills: true,
-    extraManagedPaths: [".zcode/agents", ".zcode/commands"],
+    // `.zcode/cli/agents` is the pre-ZCode-update discovery path. Kept managed
+    // during the transition so `trellis update --migrate` (rename-dir →
+    // `.zcode/agents/`) and `trellis uninstall` can clean up the now-empty
+    // `.zcode/cli/` parent. Drop this entry once the migration has shipped and
+    // no project still holds the legacy dir. Only empty dirs are ever removed,
+    // so user files are never touched (see cleanupEmptyDirs in update.ts).
+    extraManagedPaths: [
+      ".zcode/cli/agents",
+      ".zcode/agents",
+      ".zcode/commands",
+    ],
     cliFlag: "zcode",
     defaultChecked: false,
     hasPythonHooks: false,

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -643,7 +643,7 @@ describe("init() integration", () => {
     ).toBe(true);
     expect(
       fs.existsSync(
-        path.join(tmpDir, ".zcode", "cli", "agents", "trellis-implement.md"),
+        path.join(tmpDir, ".zcode", "agents", "trellis-implement.md"),
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
Closes #374 

## Summary

ZCode (Zhipu AI's coding tool) updated its sub-agent discovery path from
`.zcode/cli/agents/` to `.zcode/agents/` (it dropped the intermediate `cli/`
segment). As a result, `trellis init --zcode` / `trellis update` were emitting
sub-agents (`trellis-implement`, `trellis-check`) into a directory the new
ZCode no longer scans, so the generated agents were effectively invisible.

This PR aligns every place that referenced the old path so that fresh
`trellis init --zcode` installs write to the correct location. For projects
already initialized on 0.6.3–0.6.5 (which still have the stale
`.zcode/cli/agents/` directory), a suggested `rename-dir` migration for the
maintainer to ship with the next release is included in a dedicated section
below — it is intentionally **not** part of this PR (version numbering and
release manifests are maintainer-owned).

The commands path (`.zcode/commands/trellis/`) is unaffected — only the
sub-agent directory changed.

## Root cause

ZCode is a class-2 (pull-based, no hooks) platform; its agent discovery path
is a platform-side convention Trellis must honor. When ZCode support landed in
#330 (0.6.3), the then-correct path `.zcode/cli/agents/` was hard-coded across
the configurator write logic, the registry's `extraManagedPaths`, the template
entry, the bundled-skills reference docs, and a test assertion. ZCode's path
change requires syncing all of these.

## Changes

### Code (3 files)

| File | Change |
|------|--------|
| `packages/cli/src/configurators/zcode.ts` | Write path in `configureZcode()` (`writeAgents`) + diff-tracking path in `collectZcodeTemplates()` (`files.set`) + file header comment: `.zcode/cli/agents` → `.zcode/agents` |
| `packages/cli/src/types/ai-tools.ts` | `AI_TOOLS.zcode.extraManagedPaths`: `".zcode/cli/agents"` → `".zcode/agents"` |
| `packages/cli/src/templates/zcode/index.ts` | File header comment: `.zcode/cli/agents/<name>.md` → `.zcode/agents/<name>.md` |

### Documentation templates (4 files — bundled-skills source)

These are the truth-of-source; per-platform installed copies (`.claude/`,
`.agents/`, `.cursor/`, …) are regenerated by `trellis update`, so they are not
hand-edited in this PR.

| File | Change |
|------|--------|
| `trellis-meta/references/platform-files/platform-map.md` | ZCode row, agent column |
| `trellis-meta/references/platform-files/agents.md` | ZCode row |
| `trellis-meta/references/customize-local/change-agents.md` | ZCode row |
| `trellis-meta/references/local-architecture/generated-files.md` | `agents` row: `.zcode/cli/agents/` → `.zcode/agents/` |

### Tests (1 file)

| File | Change |
|------|--------|
| `packages/cli/test/commands/init.integration.test.ts` | `#3m` assertion: `path.join(tmpDir, ".zcode", "cli", "agents", ...)` → `path.join(tmpDir, ".zcode", "agents", ...)` |

## Suggested migration (for the maintainer — not part of this PR)

For projects already initialized on 0.6.3–0.6.5, a stale `.zcode/cli/agents/`
directory may linger on disk. The recommended way to clean it up is a
`rename-dir` migration **shipped with the next release** (version numbering and
release manifests are maintainer-owned, so it is intentionally not added here).
Mirrors the `0.6.3` Windsurf→Devin `rename-dir` precedent.

- **New installs** (`trellis init --zcode`): unaffected — agents are written
  straight to `.zcode/agents/` once this PR lands.
- **Existing projects** initialized on 0.6.3–0.6.5: would run
  `trellis update --migrate` once to relocate `.zcode/cli/agents/` →
  `.zcode/agents/`. Projects that never had the old directory are silently
  skipped (idempotent). Plain `trellis update` prints a soft hint prompting
  `--migrate`. The now-empty `.zcode/cli/` parent can be removed manually if it
  holds nothing else.

Drop-in snippet for the next release manifest (`manifests/{next-version}.json`),
`migrations` array:

```json
{
  "type": "rename-dir",
  "from": ".zcode/cli/agents",
  "to": ".zcode/agents",
  "description": "ZCode: move installed sub-agents from the legacy `.zcode/cli/agents/` directory to the new `.zcode/agents/` discovery path.",
  "reason": "ZCode dropped the intermediate `cli/` segment from its sub-agent discovery path. Trellis now writes to `.zcode/agents/`; this relocation keeps already-initialized projects consistent without leaving a stale directory behind."
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ZCode agent markdown files are now generated under `.zcode/agents/` instead of `.zcode/cli/agents/`.
  * ZCode configuration/template outputs were updated so generated assets align with the new agent directory layout.
* **Documentation**
  * Updated CLI and template reference docs to use the new `.zcode/agents/` path for ZCode agent files.
* **Tests**
  * Updated integration tests to assert the new `.zcode/agents/trellis-implement.md` location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->