### PR TITLE
fix(channel): resolve node-script npm shims on Windows so codex workers can spawn

### DIFF
--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -75,32 +75,59 @@ type Child = ChildProcessByStdio<Writable, Readable, Readable>;
 
 const SHUTDOWN_GRACE_MS = 3000;
 
+interface ResolvedProviderPath {
+  command: string;
+  prefixArgs: string[];
+}
+
 /**
- * On Windows, npm installs CLI tools as `.cmd` shims where the real `.exe`
- * lives in `node_modules/`.  Node.js ≥18.20.2 (CVE-2024-27980) blocks
- * implicit `.cmd` execution via `spawn()` without `shell: true`.  Resolve
- * the real `.exe` path so we can spawn it directly — no shell, no injection.
+ * 在 Windows 上解析 npm `.cmd` shim 的真实启动目标
+ *
+ * @param provider provider 的 CLI 基名，例如 `codex` 或 `claude`
+ * @param cwd worker 启动目录，用于优先查找本地 `node_modules/.bin`
+ * @returns 可直接传给 `spawn()` 的命令与前置参数
  */
-function resolveProviderPath(provider: string): string {
-  if (process.platform !== "win32") return provider;
+export function resolveProviderPath(
+  provider: string,
+  cwd?: string,
+): ResolvedProviderPath {
+  const fallback = { command: provider, prefixArgs: [] };
+  if (process.platform !== "win32") return fallback;
   try {
     const cmdName = `${provider}.cmd`;
-    const dirs = (process.env.PATH ?? "").split(path.delimiter);
+    const dirs = [
+      ...(cwd ? [path.join(cwd, "node_modules", ".bin")] : []),
+      ...(process.env.PATH ?? "").split(path.delimiter),
+    ].filter(Boolean);
     for (const dir of dirs) {
       const cmdFile = path.join(dir, cmdName);
       if (!fs.existsSync(cmdFile)) continue;
       const content = fs.readFileSync(cmdFile, "utf8");
-      // npm-generated cmd shim format:  "%dp0%\node_modules\pkg\bin\name.exe" %*
-      const m = content.match(/"%dp0%\\(.+\.exe)"/i);
+      // npm 生成的可执行文件 shim 格式: "%dp0%\node_modules\pkg\bin\name.exe" %*
+      const m = content.match(/"%dp0%\\([^"]+?\.exe)"/i);
       if (m) {
         const exePath = path.join(dir, m[1]);
-        if (fs.existsSync(exePath)) return exePath;
+        if (
+          path.basename(exePath).toLowerCase() !== "node.exe" &&
+          fs.existsSync(exePath)
+        ) {
+          return { command: exePath, prefixArgs: [] };
+        }
+      }
+      // npm 生成的 Node 脚本 shim 格式:
+      // "%_prog%"  "%dp0%\node_modules\pkg\bin\name.js" %*
+      const js = content.match(/"%dp0%\\([^"]+?\.(?:js|cjs|mjs))"/i);
+      if (js) {
+        const jsPath = path.join(dir, js[1]);
+        if (fs.existsSync(jsPath)) {
+          return { command: process.execPath, prefixArgs: [jsPath] };
+        }
       }
     }
   } catch {
-    // resolve failure is non-fatal — fall back to bare name
+    // 解析失败不影响后续流程，回退到原始 provider 名称
   }
-  return provider;
+  return fallback;
 }
 
 /**
@@ -141,16 +168,24 @@ export async function runSupervisor(
 
   const logPath = workerFile(channelName, workerName, "log", project);
   const log = fs.createWriteStream(logPath);
-  const providerPath = resolveProviderPath(adapter.provider);
+  const resolvedProvider = resolveProviderPath(adapter.provider, config.cwd);
+  const resolvedProviderDisplay = [
+    resolvedProvider.command,
+    ...resolvedProvider.prefixArgs,
+  ].join(" ");
   log.write(
-    `[supervisor] starting ${adapter.provider} (resolved: ${providerPath}) ${args.join(" ")}\n`,
+    `[supervisor] starting ${adapter.provider} (resolved: ${resolvedProviderDisplay}) ${args.join(" ")}\n`,
   );
 
-  const child = spawn(providerPath, args, {
-    cwd: config.cwd,
-    env,
-    stdio: ["pipe", "pipe", "pipe"],
-  }) as Child;
+  const child = spawn(
+    resolvedProvider.command,
+    [...resolvedProvider.prefixArgs, ...args],
+    {
+      cwd: config.cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  ) as Child;
 
   // ── shutdown controller declared before listener attachment ──
   // Node fires `error` on next tick when spawn fails (ENOENT / EACCES);

--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -81,11 +81,11 @@ interface ResolvedProviderPath {
 }
 
 /**
- * 在 Windows 上解析 npm `.cmd` shim 的真实启动目标
+ * Resolve the real launch target for npm `.cmd` shims on Windows.
  *
- * @param provider provider 的 CLI 基名，例如 `codex` 或 `claude`
- * @param cwd worker 启动目录，用于优先查找本地 `node_modules/.bin`
- * @returns 可直接传给 `spawn()` 的命令与前置参数
+ * @param provider CLI basename for the provider, such as `codex` or `claude`.
+ * @param cwd Worker launch directory, used to check local `node_modules/.bin` first.
+ * @returns Command and prefix arguments that can be passed directly to `spawn()`.
  */
 export function resolveProviderPath(
   provider: string,
@@ -103,7 +103,7 @@ export function resolveProviderPath(
       const cmdFile = path.join(dir, cmdName);
       if (!fs.existsSync(cmdFile)) continue;
       const content = fs.readFileSync(cmdFile, "utf8");
-      // npm 生成的可执行文件 shim 格式: "%dp0%\node_modules\pkg\bin\name.exe" %*
+      // npm-generated executable shim format: "%dp0%\node_modules\pkg\bin\name.exe" %*
       const m = content.match(/"%dp0%\\([^"]+?\.exe)"/i);
       if (m) {
         const exePath = path.join(dir, m[1]);
@@ -114,7 +114,7 @@ export function resolveProviderPath(
           return { command: exePath, prefixArgs: [] };
         }
       }
-      // npm 生成的 Node 脚本 shim 格式:
+      // npm-generated Node script shim format:
       // "%_prog%"  "%dp0%\node_modules\pkg\bin\name.js" %*
       const js = content.match(/"%dp0%\\([^"]+?\.(?:js|cjs|mjs))"/i);
       if (js) {
@@ -125,7 +125,7 @@ export function resolveProviderPath(
       }
     }
   } catch {
-    // 解析失败不影响后续流程，回退到原始 provider 名称
+    // Resolution failures are non-fatal; fall back to the raw provider name.
   }
   return fallback;
 }

--- a/packages/cli/test/commands/channel-supervisor-path.test.ts
+++ b/packages/cli/test/commands/channel-supervisor-path.test.ts
@@ -67,11 +67,18 @@ describe("resolveProviderPath", () => {
   it("checks local node_modules bin before PATH", () => {
     const projectDir = path.join(tmpDir, "project");
     const binDir = path.join(projectDir, "node_modules", ".bin");
+    const globalBinDir = path.join(tmpDir, "global-bin");
     const jsPath = writeShimTarget(
       "node_modules\\@openai\\codex\\bin\\codex.js",
       binDir,
     );
-    process.env.PATH = path.join(tmpDir, "global-bin");
+    writeShimTarget("node_modules\\global-codex\\bin\\codex.js", globalBinDir);
+    fs.writeFileSync(
+      path.join(globalBinDir, "codex.cmd"),
+      '"%_prog%"  "%dp0%\\node_modules\\global-codex\\bin\\codex.js" %*\r\n',
+      "utf8",
+    );
+    process.env.PATH = globalBinDir;
     fs.writeFileSync(
       path.join(binDir, "codex.cmd"),
       '"%_prog%"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n',

--- a/packages/cli/test/commands/channel-supervisor-path.test.ts
+++ b/packages/cli/test/commands/channel-supervisor-path.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveProviderPath } from "../../src/commands/channel/supervisor.js";
+
+describe("resolveProviderPath", () => {
+  let tmpDir: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-provider-"));
+    originalPath = process.env.PATH;
+    process.env.PATH = tmpDir;
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeShimTarget(relativeTarget: string, baseDir = tmpDir): string {
+    const target = path.join(baseDir, relativeTarget);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "", "utf8");
+    return target;
+  }
+
+  it("resolves direct exe npm shims without prefix args", () => {
+    const exePath = writeShimTarget(
+      "node_modules\\@anthropic-ai\\claude\\claude.exe",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "claude.cmd"),
+      '@IF EXIST "%dp0%\\node_modules\\@anthropic-ai\\claude\\claude.exe" "%dp0%\\node_modules\\@anthropic-ai\\claude\\claude.exe" %*\r\n',
+      "utf8",
+    );
+    expect(resolveProviderPath("claude")).toEqual({
+      command: exePath,
+      prefixArgs: [],
+    });
+  });
+
+  it("resolves node-script npm shims through the current Node executable", () => {
+    const jsPath = writeShimTarget(
+      "node_modules\\@openai\\codex\\bin\\codex.js",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "codex.cmd"),
+      '@IF EXIST "%dp0%\\node.exe" (\r\n  "%dp0%\\node.exe"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n) ELSE (\r\n  "%_prog%"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n)\r\n',
+      "utf8",
+    );
+    expect(resolveProviderPath("codex")).toEqual({
+      command: process.execPath,
+      prefixArgs: [jsPath],
+    });
+  });
+
+  it("checks local node_modules bin before PATH", () => {
+    const projectDir = path.join(tmpDir, "project");
+    const binDir = path.join(projectDir, "node_modules", ".bin");
+    const jsPath = writeShimTarget(
+      "node_modules\\@openai\\codex\\bin\\codex.js",
+      binDir,
+    );
+    process.env.PATH = path.join(tmpDir, "global-bin");
+    fs.writeFileSync(
+      path.join(binDir, "codex.cmd"),
+      '"%_prog%"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n',
+      "utf8",
+    );
+    expect(resolveProviderPath("codex", projectDir)).toEqual({
+      command: process.execPath,
+      prefixArgs: [jsPath],
+    });
+  });
+
+  it("falls back to the provider name when no shim target can be resolved", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "codex.cmd"),
+      '"%_prog%"  "%dp0%\\missing\\codex.js" %*\r\n',
+      "utf8",
+    );
+    expect(resolveProviderPath("codex")).toEqual({
+      command: "codex",
+      prefixArgs: [],
+    });
+  });
+});


### PR DESCRIPTION
Fixes #387.

This fixes Windows provider spawning for npm-generated `.cmd` shims that launch Node scripts, such as the current Codex npm package. Node.js 18.20.2+ no longer allows implicit `.cmd` execution through `spawn()` without `shell: true`, so the supervisor now resolves the shim target and spawns it directly.

Changes:
- Resolve `.exe` npm shim targets directly
- Ignore shim-local `node.exe` as the final provider target
- Resolve `.js`, `.cjs`, and `.mjs` shim targets through the current Node executable
- Prefer local `cwd\node_modules\.bin` before global PATH
- Keep fallback behavior when no shim target can be resolved

Validation:
- `vitest channel-supervisor-path.test.ts` passed, 4 tests
- `pnpm --filter @mindfoldhq/trellis typecheck` passed
- `pnpm --filter @mindfoldhq/trellis lint` passed
- `pnpm build` passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker process launching on Windows with more reliable command resolution.
  * Enhanced handling of npm-style command shims, including node-executed script shims.
  * Now prefers local project binaries when resolving commands.
  * Startup logs now display the resolved command details to simplify troubleshooting.
* **Tests**
  * Added coverage for Windows shim resolution behavior to ensure consistent command selection and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->