### PR TITLE
Fix Trellis session templates

### DIFF
--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -41,8 +41,14 @@ import {
   scrubOpencodePackageJson,
   scrubPiSettings,
   scrubCodexConfigToml,
+  scrubManagedMarkdownBlock,
   type ScrubResult,
 } from "../utils/uninstall-scrubbers.js";
+import {
+  COPILOT_INSTRUCTIONS_BLOCK_END,
+  COPILOT_INSTRUCTIONS_BLOCK_START,
+  COPILOT_INSTRUCTIONS_PATH,
+} from "../templates/copilot/index.js";
 
 export interface UninstallOptions {
   yes?: boolean;
@@ -113,6 +119,16 @@ function buildStructuredFileSpecs(): Map<string, StructuredFileSpec> {
       posixPath: ".codex/config.toml",
       reason: "Remove trellis project_doc_fallback_filenames and notes",
       scrub: (content) => scrubCodexConfigToml(content),
+    },
+    {
+      posixPath: COPILOT_INSTRUCTIONS_PATH,
+      reason: "Remove Trellis Copilot guidance; preserve repo instructions",
+      scrub: (content) =>
+        scrubManagedMarkdownBlock(
+          content,
+          COPILOT_INSTRUCTIONS_BLOCK_START,
+          COPILOT_INSTRUCTIONS_BLOCK_END,
+        ),
     },
   ];
   const map = new Map<string, StructuredFileSpec>();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -45,6 +45,12 @@ import {
   workflowMdTemplate,
 } from "../templates/trellis/index.js";
 import { agentsMdContent } from "../templates/markdown/index.js";
+import {
+  COPILOT_INSTRUCTIONS_BLOCK_END,
+  COPILOT_INSTRUCTIONS_BLOCK_START,
+  COPILOT_INSTRUCTIONS_PATH,
+  getCopilotInstructions,
+} from "../templates/copilot/index.js";
 
 import {
   ALL_MANAGED_DIRS,
@@ -114,35 +120,49 @@ const PROTECTED_PATHS = [
   `${DIR_NAMES.WORKFLOW}/.current-task`,
 ];
 
-function getTrellisManagedBlock(content: string): string | null {
-  const start = content.indexOf(TRELLIS_BLOCK_START);
+function getManagedBlock(
+  content: string,
+  startMarker: string,
+  endMarker: string,
+): string | null {
+  const start = content.indexOf(startMarker);
   if (start === -1) {
     return null;
   }
 
-  const end = content.indexOf(TRELLIS_BLOCK_END, start);
+  const end = content.indexOf(endMarker, start);
   if (end === -1) {
     return null;
   }
 
-  return content.slice(start, end + TRELLIS_BLOCK_END.length);
+  return content.slice(start, end + endMarker.length);
 }
 
-function replaceTrellisManagedBlock(
+function getTrellisManagedBlock(content: string): string | null {
+  return getManagedBlock(content, TRELLIS_BLOCK_START, TRELLIS_BLOCK_END);
+}
+
+function replaceManagedBlock(
   existingContent: string,
   templateContent: string,
+  startMarker: string,
+  endMarker: string,
 ): string | null {
-  const existingStart = existingContent.indexOf(TRELLIS_BLOCK_START);
+  const existingStart = existingContent.indexOf(startMarker);
   if (existingStart === -1) {
     return null;
   }
 
-  const existingEnd = existingContent.indexOf(TRELLIS_BLOCK_END, existingStart);
+  const existingEnd = existingContent.indexOf(endMarker, existingStart);
   if (existingEnd === -1) {
     return null;
   }
 
-  const templateBlock = getTrellisManagedBlock(templateContent);
+  const templateBlock = getManagedBlock(
+    templateContent,
+    startMarker,
+    endMarker,
+  );
   if (!templateBlock) {
     return null;
   }
@@ -150,35 +170,78 @@ function replaceTrellisManagedBlock(
   return (
     existingContent.slice(0, existingStart) +
     templateBlock +
-    existingContent.slice(existingEnd + TRELLIS_BLOCK_END.length)
+    existingContent.slice(existingEnd + endMarker.length)
   );
 }
 
-function buildAgentsMdTemplate(cwd: string): string {
-  const fullPath = path.join(cwd, FILE_NAMES.AGENTS);
-  if (!fs.existsSync(fullPath)) {
-    return agentsMdContent;
-  }
-
-  const existingContent = fs.readFileSync(fullPath, "utf-8");
-
-  // Existing file already has TRELLIS:START/END markers — replace just the
-  // managed block, preserving everything outside it.
-  const replaced = replaceTrellisManagedBlock(existingContent, agentsMdContent);
+function mergeManagedBlockContent(
+  existingContent: string,
+  templateContent: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  const replaced = replaceManagedBlock(
+    existingContent,
+    templateContent,
+    startMarker,
+    endMarker,
+  );
   if (replaced !== null) {
     return replaced;
   }
 
-  // Existing file has no managed-block markers (pre-0.5.0-beta.18 project, or
-  // user hand-wrote AGENTS.md without ever running through Trellis). Append
-  // the template's managed block at the end so user content is preserved
-  // instead of clobbered.
-  const templateBlock = getTrellisManagedBlock(agentsMdContent);
+  const templateBlock = getManagedBlock(
+    templateContent,
+    startMarker,
+    endMarker,
+  );
   if (!templateBlock) {
-    return agentsMdContent;
+    return templateContent;
   }
+
   const trimmed = existingContent.replace(/\s+$/, "");
   return `${trimmed}\n\n${templateBlock}\n`;
+}
+
+function buildManagedBlockTemplate(
+  cwd: string,
+  relativePath: string,
+  templateContent: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  const fullPath = path.join(cwd, ...relativePath.split("/"));
+  if (!fs.existsSync(fullPath)) {
+    return templateContent;
+  }
+
+  const existingContent = fs.readFileSync(fullPath, "utf-8");
+  return mergeManagedBlockContent(
+    existingContent,
+    templateContent,
+    startMarker,
+    endMarker,
+  );
+}
+
+function buildAgentsMdTemplate(cwd: string): string {
+  return buildManagedBlockTemplate(
+    cwd,
+    FILE_NAMES.AGENTS,
+    agentsMdContent,
+    TRELLIS_BLOCK_START,
+    TRELLIS_BLOCK_END,
+  );
+}
+
+function buildCopilotInstructionsTemplate(cwd: string): string {
+  return buildManagedBlockTemplate(
+    cwd,
+    COPILOT_INSTRUCTIONS_PATH,
+    getCopilotInstructions(),
+    COPILOT_INSTRUCTIONS_BLOCK_START,
+    COPILOT_INSTRUCTIONS_BLOCK_END,
+  );
 }
 
 function isKnownUntrackedTemplate(
@@ -195,6 +258,35 @@ function isKnownUntrackedTemplate(
   }
 
   return LEGACY_UNTRACKED_AGENTS_MD_BLOCK_HASHES.has(computeHash(managedBlock));
+}
+
+function isSafeUntrackedCopilotInstructionsMerge(
+  relativePath: string,
+  existingContent: string,
+  newContent: string,
+): boolean {
+  if (relativePath !== COPILOT_INSTRUCTIONS_PATH) {
+    return false;
+  }
+
+  if (
+    getManagedBlock(
+      existingContent,
+      COPILOT_INSTRUCTIONS_BLOCK_START,
+      COPILOT_INSTRUCTIONS_BLOCK_END,
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    mergeManagedBlockContent(
+      existingContent,
+      getCopilotInstructions(),
+      COPILOT_INSTRUCTIONS_BLOCK_START,
+      COPILOT_INSTRUCTIONS_BLOCK_END,
+    ) === newContent
+  );
 }
 
 /**
@@ -803,6 +895,12 @@ async function collectTemplateFiles(
       for (const [filePath, content] of platformFiles) {
         files.set(filePath, content);
       }
+      if (platformId === "copilot") {
+        files.set(
+          COPILOT_INSTRUCTIONS_PATH,
+          buildCopilotInstructionsTemplate(cwd),
+        );
+      }
     }
   }
 
@@ -894,7 +992,13 @@ function analyzeChanges(
         if (
           (storedHash && storedHash === currentHash) ||
           (!storedHash &&
-            isKnownUntrackedTemplate(relativePath, existingContent))
+            isKnownUntrackedTemplate(relativePath, existingContent)) ||
+          (!storedHash &&
+            isSafeUntrackedCopilotInstructionsMerge(
+              relativePath,
+              existingContent,
+              newContent,
+            ))
         ) {
           // Either the tracked hash matches, or this is a known pristine template
           // from before the path was hash-tracked. Safe to auto-update.
@@ -913,14 +1017,15 @@ function analyzeChanges(
   return result;
 }
 
-function collectMissingAgentsMdHash(
+function collectMissingManagedFileHashes(
   changes: ChangeAnalysis,
   hashes: TemplateHashes,
 ): Map<string, string> {
   const files = new Map<string, string>();
+  const managedFiles = new Set([FILE_NAMES.AGENTS, COPILOT_INSTRUCTIONS_PATH]);
 
   for (const file of changes.unchangedFiles) {
-    if (file.relativePath === FILE_NAMES.AGENTS && !hashes[file.relativePath]) {
+    if (managedFiles.has(file.relativePath) && !hashes[file.relativePath]) {
       files.set(file.relativePath, file.newContent);
     }
   }
@@ -1219,6 +1324,14 @@ async function getLatestNpmVersion(): Promise<string | null> {
  */
 function collectAllFiles(dirPath: string, cwd = process.cwd()): string[] {
   if (!fs.existsSync(dirPath)) return [];
+
+  const rootStat = fs.statSync(dirPath);
+  if (rootStat.isFile()) {
+    return [dirPath];
+  }
+  if (!rootStat.isDirectory()) {
+    return [];
+  }
 
   const files: string[] = [];
   const stack = [dirPath];
@@ -2122,7 +2235,10 @@ export async function update(options: UpdateOptions): Promise<void> {
 
   // Analyze changes (pass hashes for modification detection)
   const changes = analyzeChanges(cwd, hashes, templates);
-  const missingAgentsMdHash = collectMissingAgentsMdHash(changes, hashes);
+  const missingManagedFileHashes = collectMissingManagedFileHashes(
+    changes,
+    hashes,
+  );
 
   // Print summary
   printChangeSummary(changes);
@@ -2161,8 +2277,8 @@ export async function update(options: UpdateOptions): Promise<void> {
     !hasPendingMigrations &&
     !hasSafeDeletes
   ) {
-    if (!options.dryRun && missingAgentsMdHash.size > 0) {
-      updateHashes(cwd, missingAgentsMdHash);
+    if (!options.dryRun && missingManagedFileHashes.size > 0) {
+      updateHashes(cwd, missingManagedFileHashes);
     }
 
     if (isSameVersion) {
@@ -2435,7 +2551,7 @@ export async function update(options: UpdateOptions): Promise<void> {
   updateVersionFile(cwd);
 
   // Update template hashes for new, auto-updated, and overwritten files
-  const filesToHash = new Map<string, string>(missingAgentsMdHash);
+  const filesToHash = new Map<string, string>(missingManagedFileHashes);
   for (const file of changes.newFiles) {
     filesToHash.set(file.relativePath, file.newContent);
   }

--- a/packages/cli/src/configurators/copilot.ts
+++ b/packages/cli/src/configurators/copilot.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
 import { AI_TOOLS } from "../types/ai-tools.js";
-import { getAllHooks, getHooksConfig } from "../templates/copilot/index.js";
+import {
+  COPILOT_INSTRUCTIONS_PATH,
+  getAllHooks,
+  getCopilotInstructions,
+  getHooksConfig,
+} from "../templates/copilot/index.js";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
 import {
   resolvePlaceholders,
@@ -21,11 +26,18 @@ import {
  * - agents/{name}.agent.md — sub-agent definitions (note .agent.md suffix)
  * - copilot/hooks/ — platform-specific + shared hook scripts
  * - hooks config — hooks.json
+ * - copilot-instructions.md — repository-wide review guidance
  */
 export async function configureCopilot(cwd: string): Promise<void> {
   const config = AI_TOOLS.copilot;
   const ctx = config.templateContext;
   const copilotRoot = path.join(cwd, ".github", "copilot");
+
+  ensureDir(path.join(cwd, ".github"));
+  await writeFile(
+    path.join(cwd, ...COPILOT_INSTRUCTIONS_PATH.split("/")),
+    getCopilotInstructions(),
+  );
 
   const promptsDir = path.join(cwd, ".github", "prompts");
   ensureDir(promptsDir);

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -68,7 +68,9 @@ import {
 } from "../templates/codex/index.js";
 import {
   getAllHooks as getCopilotHooks,
+  getCopilotInstructions,
   getHooksConfig as getCopilotHooksConfig,
+  COPILOT_INSTRUCTIONS_PATH,
 } from "../templates/copilot/index.js";
 import {
   getAllAgents as getQoderAgents,
@@ -421,6 +423,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       )) {
         files.set(`.github/agents/${agent.name}.agent.md`, agent.content);
       }
+      files.set(COPILOT_INSTRUCTIONS_PATH, getCopilotInstructions());
       const hooksConfig = resolvePlaceholders(getCopilotHooksConfig());
       files.set(".github/copilot/hooks.json", hooksConfig);
       files.set(".github/hooks/trellis.json", hooksConfig);

--- a/packages/cli/src/templates/codex/hooks/session-start.py
+++ b/packages/cli/src/templates/codex/hooks/session-start.py
@@ -33,12 +33,12 @@ if sys.platform.startswith("win"):
             try:
                 _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
         elif hasattr(_stream, "detach"):
             try:
                 setattr(sys, _stream_name, _io.TextIOWrapper(_stream.detach(), encoding="utf-8", errors="replace"))
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
 
 
 def _normalize_windows_shell_path(path_str: str) -> str:
@@ -116,7 +116,7 @@ def configure_project_encoding(project_dir: Path) -> None:
 
         configure_encoding()
     except Exception:
-        pass
+        pass  # Optional encoding helper; host defaults are still usable.
 
 
 def _has_curated_jsonl_entry(jsonl_path: Path) -> bool:
@@ -243,7 +243,7 @@ def _get_task_status(trellis_dir: Path, hook_input: dict) -> str:
         try:
             task_data = json.loads(task_json_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, PermissionError):
-            pass
+            pass  # Optional task metadata; fall back to generic status.
 
     task_title = task_data.get("title", task_ref)
     task_status = task_data.get("status", "unknown")
@@ -386,7 +386,7 @@ def _build_compact_current_state(
                 if isinstance(data, dict):
                     status = str(data.get("status") or "unknown")
             except (json.JSONDecodeError, OSError):
-                pass
+                pass  # Optional task metadata; fall back to generic status.
         lines.append(f"Current task: {_repo_relative(repo_root, task_dir)}; status={status}.")
     else:
         lines.append("Current task: none.")
@@ -398,7 +398,7 @@ def _build_compact_current_state(
                 f"Active tasks: {task_count} total. Use `python3 ./.trellis/scripts/task.py list --mine` only if needed."
             )
         except Exception:
-            pass
+            pass  # Optional task summary; keep compact state available.
 
     if get_active_journal_file and count_lines:
         journal = get_active_journal_file(repo_root)

--- a/packages/cli/src/templates/copilot/copilot-instructions.md
+++ b/packages/cli/src/templates/copilot/copilot-instructions.md
@@ -1,0 +1,11 @@
+<!-- TRELLIS:COPILOT-GUIDANCE:START -->
+# Trellis Review Guidance
+
+When reviewing a Trellis-enabled repository:
+
+- Treat Trellis-generated runtime and platform payloads as copied integration files in consumer repositories. Examples include `.trellis/scripts/**`, `.trellis/agents/**`, `.trellis/workflow.md`, and platform Trellis files under `.agents/**`, `.claude/**`, `.codex/**`, `.cursor/**`, `.gemini/**`, `.github/**`, `.opencode/**`, `.qoder/**`, `.codebuddy/**`, `.factory/**`, `.pi/**`, `.reasonix/**`, `.trae/**`, and `.zcode/**`.
+- Do not leave line-by-line style, wording, or local refactor comments on those copied files unless the PR explicitly changes Trellis integration, the copied file is the primary subject, it leaks secrets, it has syntax or wiring breakage, or it contradicts the PR goal.
+- If a Trellis-generated file needs a behavior change, leave one handoff comment asking for an upstream Trellis fix. Include the affected path, expected behavior, observed evidence or reproduction steps, and why the fix belongs upstream.
+- Continue reviewing repo-owned `.trellis/spec/**`, `.trellis/tasks/**`, application code, migrations, tests, docs, and non-Trellis scripts normally.
+- Group duplicate root-cause findings into one comment and point to a deterministic local check when one already covers the issue class.
+<!-- TRELLIS:COPILOT-GUIDANCE:END -->

--- a/packages/cli/src/templates/copilot/hooks/session-start.py
+++ b/packages/cli/src/templates/copilot/hooks/session-start.py
@@ -34,12 +34,12 @@ if sys.platform.startswith("win"):
             try:
                 _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
         elif hasattr(_stream, "detach"):
             try:
                 setattr(sys, _stream_name, _io.TextIOWrapper(_stream.detach(), encoding="utf-8", errors="replace"))
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
 
 import json
 import os
@@ -121,7 +121,7 @@ def configure_project_encoding(project_dir: Path) -> None:
 
         configure_encoding()
     except Exception:
-        pass
+        pass  # Optional encoding helper; host defaults are still usable.
 
 
 def _has_curated_jsonl_entry(jsonl_path: Path) -> bool:
@@ -248,7 +248,7 @@ def _get_task_status(trellis_dir: Path, hook_input: dict) -> str:
         try:
             task_data = json.loads(task_json_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, PermissionError):
-            pass
+            pass  # Optional task metadata; fall back to generic status.
 
     task_title = task_data.get("title", task_ref)
     task_status = task_data.get("status", "unknown")
@@ -391,7 +391,7 @@ def _build_compact_current_state(
                 if isinstance(data, dict):
                     status = str(data.get("status") or "unknown")
             except (json.JSONDecodeError, OSError):
-                pass
+                pass  # Optional task metadata; fall back to generic status.
         lines.append(f"Current task: {_repo_relative(repo_root, task_dir)}; status={status}.")
     else:
         lines.append("Current task: none.")
@@ -403,7 +403,7 @@ def _build_compact_current_state(
                 f"Active tasks: {task_count} total. Use `python3 ./.trellis/scripts/task.py list --mine` only if needed."
             )
         except Exception:
-            pass
+            pass  # Optional task summary; keep compact state available.
 
     if get_active_journal_file and count_lines:
         journal = get_active_journal_file(repo_root)

--- a/packages/cli/src/templates/copilot/index.ts
+++ b/packages/cli/src/templates/copilot/index.ts
@@ -7,7 +7,8 @@
  *   copilot/
  *   ├── prompts/         # Slash-command prompts → .github/prompts/*.prompt.md
  *   ├── hooks/           # Hook scripts → .github/copilot/hooks/
- *   └── hooks.json       # Hooks config → .github/hooks/trellis.json
+ *   ├── hooks.json       # Hooks config → .github/hooks/trellis.json
+ *   └── copilot-instructions.md → .github/copilot-instructions.md
  */
 
 import { readdirSync, readFileSync } from "node:fs";
@@ -16,6 +17,12 @@ import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+export const COPILOT_INSTRUCTIONS_PATH = ".github/copilot-instructions.md";
+export const COPILOT_INSTRUCTIONS_BLOCK_START =
+  "<!-- TRELLIS:COPILOT-GUIDANCE:START -->";
+export const COPILOT_INSTRUCTIONS_BLOCK_END =
+  "<!-- TRELLIS:COPILOT-GUIDANCE:END -->";
 
 function readTemplate(relativePath: string): string {
   return readFileSync(join(__dirname, relativePath), "utf-8");
@@ -54,6 +61,10 @@ export function getAllHooks(): HookTemplate[] {
 
 export function getHooksConfig(): string {
   return readTemplate("hooks.json");
+}
+
+export function getCopilotInstructions(): string {
+  return readTemplate("copilot-instructions.md");
 }
 
 export function getAllPrompts(): PromptTemplate[] {

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -53,12 +53,12 @@ if sys.platform.startswith("win"):
             try:
                 _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
         elif hasattr(_stream, "detach"):
             try:
                 setattr(sys, _stream_name, _io.TextIOWrapper(_stream.detach(), encoding="utf-8", errors="replace"))
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
 from typing import Optional
 
 
@@ -316,12 +316,12 @@ def _load_hook_input() -> dict:
     short daemon read preserves that path while failing closed to `{}` for
     non-piping hosts.
     """
-    result_queue: "queue.Queue[str | BaseException]" = queue.Queue(maxsize=1)
+    result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
 
     def _read() -> None:
         try:
             result_queue.put(sys.stdin.read())
-        except BaseException as exc:
+        except Exception as exc:
             result_queue.put(exc)
 
     reader = threading.Thread(target=_read, daemon=True)
@@ -331,7 +331,7 @@ def _load_hook_input() -> dict:
     except queue.Empty:
         return {}
 
-    if isinstance(raw, BaseException):
+    if isinstance(raw, Exception):
         return {}
     try:
         data = json.loads(raw) if raw.strip() else {}

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -87,12 +87,12 @@ if sys.platform.startswith("win"):
             try:
                 _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
         elif hasattr(_stream, "detach"):
             try:
                 setattr(sys, _stream_name, _io.TextIOWrapper(_stream.detach(), encoding="utf-8", errors="replace"))
             except Exception:
-                pass
+                pass  # Optional Windows stream setup; keep hook startup non-fatal.
 
 
 
@@ -249,7 +249,7 @@ def _persist_context_key_for_bash(context_key: str | None) -> None:
         with open(env_file, "a", encoding="utf-8") as handle:
             handle.write(f"export TRELLIS_CONTEXT_ID={shlex.quote(context_key)}\n")
     except OSError:
-        pass
+        pass  # Optional shell bridge; keep session-start non-fatal.
 
 
 def _resolve_active_task(trellis_dir: Path, input_data: dict):
@@ -351,7 +351,7 @@ def _get_task_status(trellis_dir: Path, input_data: dict) -> str:
         try:
             task_data = json.loads(task_json_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, PermissionError):
-            pass
+            pass  # Optional task metadata; fall back to generic status.
 
     task_title = task_data.get("title", task_ref)
     task_status = task_data.get("status", "unknown")
@@ -453,7 +453,7 @@ def _load_trellis_config(trellis_dir: Path, input_data: dict) -> tuple:
                         if isinstance(tp, str) and tp:
                             task_pkg = tp
                 except (json.JSONDecodeError, OSError):
-                    pass
+                    pass  # Optional package metadata; fall back to default scope.
 
         default_pkg = get_default_package(repo_root)
         return is_mono, packages, scope, task_pkg, default_pkg
@@ -630,7 +630,7 @@ def _build_compact_current_state(
                 if isinstance(data, dict):
                     status = str(data.get("status") or "unknown")
             except (json.JSONDecodeError, OSError):
-                pass
+                pass  # Optional task metadata; fall back to generic status.
         lines.append(f"Current task: {_repo_relative(repo_root, task_dir)}; status={status}.")
     else:
         lines.append("Current task: none.")
@@ -642,7 +642,7 @@ def _build_compact_current_state(
                 f"Active tasks: {task_count} total. Use `python3 ./.trellis/scripts/task.py list --mine` only if needed."
             )
         except Exception:
-            pass
+            pass  # Optional task summary; keep compact state available.
 
     if get_active_journal_file and count_lines:
         journal = get_active_journal_file(repo_root)

--- a/packages/cli/src/templates/trellis/scripts/add_session.py
+++ b/packages/cli/src/templates/trellis/scripts/add_session.py
@@ -55,6 +55,12 @@ from common.config import (
 )
 
 
+DEFAULT_MAIN_CHANGES = (
+    "- Detailed change bullets were not supplied; see the summary above."
+)
+DEFAULT_TESTING = "- Validation was not recorded for this session."
+
+
 # =============================================================================
 # Helper Functions
 # =============================================================================
@@ -154,6 +160,7 @@ def generate_session_content(
     today: str,
     package: str | None = None,
     branch: str | None = None,
+    testing_content: str = DEFAULT_TESTING,
 ) -> str:
     """Generate session content."""
     if commit and commit != "-":
@@ -189,7 +196,7 @@ def generate_session_content(
 
 ### Testing
 
-- [OK] (Add test results)
+{testing_content}
 
 ### Status
 
@@ -395,8 +402,8 @@ def _auto_commit_workspace(repo_root: Path) -> None:
 def add_session(
     title: str,
     commit: str = "-",
-    summary: str = "(Add summary)",
-    extra_content: str = "(Add details)",
+    summary: str = "Session summary was not supplied.",
+    extra_content: str = DEFAULT_MAIN_CHANGES,
     auto_commit: bool = True,
     package: str | None = None,
     branch: str | None = None,
@@ -503,7 +510,7 @@ def main() -> int:
     )
     parser.add_argument("--title", required=True, help="Session title")
     parser.add_argument("--commit", default="-", help="Comma-separated commit hashes")
-    parser.add_argument("--summary", default="(Add summary)", help="Brief summary")
+    parser.add_argument("--summary", default="Session summary was not supplied.", help="Brief summary")
     parser.add_argument("--content-file", help="Path to file with detailed content")
     parser.add_argument("--package", help="Package name tag (e.g., cli, docs-site)")
     parser.add_argument("--branch", help="Branch name (auto-detected if omitted)")
@@ -514,7 +521,7 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    extra_content = "(Add details)"
+    extra_content = DEFAULT_MAIN_CHANGES
     if args.content_file:
         content_path = Path(args.content_file)
         if content_path.is_file():

--- a/packages/cli/src/templates/trellis/scripts/common/session_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/session_context.py
@@ -412,7 +412,7 @@ def _get_update_hint(repo_root: Path) -> str | None:
 
     return (
         f"Trellis update available: {current_version} -> {latest_version}, "
-        "run trellis upgrade"
+        "run trellis update"
     )
 
 

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -334,6 +334,7 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     configDir: ".github/copilot",
     extraManagedPaths: [
       ".github/agents",
+      ".github/copilot-instructions.md",
       ".github/hooks",
       ".github/prompts",
       ".github/skills",

--- a/packages/cli/src/utils/uninstall-scrubbers.ts
+++ b/packages/cli/src/utils/uninstall-scrubbers.ts
@@ -375,3 +375,30 @@ export function scrubCodexConfigToml(content: string): ScrubResult {
   const fullyEmpty = result.trim().length === 0;
   return { content: result, fullyEmpty };
 }
+
+export function scrubManagedMarkdownBlock(
+  content: string,
+  startMarker: string,
+  endMarker: string,
+): ScrubResult {
+  const start = content.indexOf(startMarker);
+  if (start === -1) {
+    return { content, fullyEmpty: false };
+  }
+
+  const end = content.indexOf(endMarker, start);
+  if (end === -1) {
+    return { content, fullyEmpty: false };
+  }
+
+  const blockEnd = end + endMarker.length;
+  const result = (content.slice(0, start) + content.slice(blockEnd))
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+  const normalized = result.length > 0 ? `${result}\n` : "";
+
+  return {
+    content: normalized,
+    fullyEmpty: normalized.trim().length === 0,
+  };
+}

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -51,6 +51,10 @@ import { VERSION } from "../../src/constants/version.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../../src/constants/paths.js";
 import { collectPlatformTemplates } from "../../src/configurators/index.js";
 import { computeHash } from "../../src/utils/template-hash.js";
+import {
+  COPILOT_INSTRUCTIONS_PATH,
+  getCopilotInstructions,
+} from "../../src/templates/copilot/index.js";
 import { execSync } from "node:child_process";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -441,6 +445,14 @@ describe("init() integration", () => {
     expect(
       fs.existsSync(path.join(tmpDir, ".github", "hooks", "trellis.json")),
     ).toBe(true);
+    const copilotInstructionsPath = path.join(
+      tmpDir,
+      ...COPILOT_INSTRUCTIONS_PATH.split("/"),
+    );
+    expect(fs.existsSync(copilotInstructionsPath)).toBe(true);
+    expect(fs.readFileSync(copilotInstructionsPath, "utf-8")).toBe(
+      getCopilotInstructions(),
+    );
 
     const hashFile = path.join(
       tmpDir,
@@ -456,6 +468,7 @@ describe("init() integration", () => {
     expect(trackedPaths).not.toContain(".github/prompts/start.prompt.md");
     expect(trackedPaths).toContain(".github/prompts/finish-work.prompt.md");
     expect(trackedPaths).toContain(".github/prompts/continue.prompt.md");
+    expect(trackedPaths).toContain(COPILOT_INSTRUCTIONS_PATH);
     expect(trackedPaths).toContain(".github/copilot/hooks.json");
     expect(trackedPaths).toContain(".github/hooks/trellis.json");
 
@@ -589,12 +602,12 @@ describe("init() integration", () => {
       ),
     ).toBe(true);
     expect(
-      fs.existsSync(
-        path.join(tmpDir, ".trae", "commands", "trellis-start.md"),
-      ),
+      fs.existsSync(path.join(tmpDir, ".trae", "commands", "trellis-start.md")),
     ).toBe(false);
     expect(
-      fs.existsSync(path.join(tmpDir, ".trae", "agents", "trellis-implement.md")),
+      fs.existsSync(
+        path.join(tmpDir, ".trae", "agents", "trellis-implement.md"),
+      ),
     ).toBe(true);
     expect(
       fs.readFileSync(

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -56,6 +56,12 @@ import { VERSION } from "../../src/constants/version.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../../src/constants/paths.js";
 import { computeHash } from "../../src/utils/template-hash.js";
 import { workflowMdTemplate } from "../../src/templates/trellis/index.js";
+import {
+  COPILOT_INSTRUCTIONS_BLOCK_END,
+  COPILOT_INSTRUCTIONS_BLOCK_START,
+  COPILOT_INSTRUCTIONS_PATH,
+  getCopilotInstructions,
+} from "../../src/templates/copilot/index.js";
 import { replacePythonCommandLiterals } from "../../src/configurators/shared.js";
 
 // A managed template file that update always handles (Python script)
@@ -243,9 +249,9 @@ describe("update() integration", () => {
   it("[issue-zcode-codex-upgrade] zcode .agents skills do not trigger legacy Codex backfill", async () => {
     await init({ yes: true, force: true, zcode: true });
 
-    expect(
-      fs.existsSync(projectFile(".zcode/commands/trellis/start.md")),
-    ).toBe(true);
+    expect(fs.existsSync(projectFile(".zcode/commands/trellis/start.md"))).toBe(
+      true,
+    );
     expect(
       fs.existsSync(projectFile(".agents/skills/trellis-start/SKILL.md")),
     ).toBe(false);
@@ -413,6 +419,66 @@ describe("update() integration", () => {
     );
     // Tail equals the canonical template (force-applied managed block).
     expect(result.endsWith(templateContent.trimEnd() + "\n")).toBe(true);
+  });
+
+  it("#4e appends Trellis Copilot guidance to existing repo instructions", async () => {
+    await init({ yes: true, force: true, copilot: true });
+
+    const userContent =
+      "# Repo Copilot Instructions\n\nReview app code first.\n";
+    writeProjectFile(COPILOT_INSTRUCTIONS_PATH, userContent);
+
+    const hashFile = hashFilePath();
+    const hashes = removeHashEntry(
+      readHashesV2(hashFile),
+      COPILOT_INSTRUCTIONS_PATH,
+    ) as Record<string, string>;
+    writeHashesV2(hashFile, hashes);
+
+    await update({});
+
+    const result = readProjectFile(COPILOT_INSTRUCTIONS_PATH);
+    expect(result).toContain("# Repo Copilot Instructions");
+    expect(result).toContain("Review app code first.");
+    expect(result).toContain(COPILOT_INSTRUCTIONS_BLOCK_START);
+    expect(result).toContain(COPILOT_INSTRUCTIONS_BLOCK_END);
+    expect(result).toContain("Trellis-generated runtime");
+    expect(result.indexOf("# Repo Copilot Instructions")).toBeLessThan(
+      result.indexOf(COPILOT_INSTRUCTIONS_BLOCK_START),
+    );
+    expect(readHashesV2(hashFile)[COPILOT_INSTRUCTIONS_PATH]).toBe(
+      computeHash(result),
+    );
+  });
+
+  it("#4f refreshes only the Trellis Copilot guidance block", async () => {
+    await init({ yes: true, force: true, copilot: true });
+
+    const oldBlock = getCopilotInstructions().replace(
+      "Group duplicate root-cause findings into one comment",
+      "Leave duplicate comments for every occurrence",
+    );
+    const existingContent = `# Repo Copilot Instructions\n\n${oldBlock}\n\n## Local Notes\n\nKeep this.\n`;
+    writeProjectFile(COPILOT_INSTRUCTIONS_PATH, existingContent);
+
+    const hashFile = hashFilePath();
+    const hashes = readHashesV2(hashFile);
+    hashes[COPILOT_INSTRUCTIONS_PATH] = computeHash(existingContent);
+    writeHashesV2(hashFile, hashes);
+
+    await update({});
+
+    const result = readProjectFile(COPILOT_INSTRUCTIONS_PATH);
+    expect(result).toContain("# Repo Copilot Instructions");
+    expect(result).toContain("## Local Notes");
+    expect(result).toContain("Keep this.");
+    expect(result).toContain(
+      "Group duplicate root-cause findings into one comment",
+    );
+    expect(result).not.toContain("Leave duplicate comments");
+    expect(readHashesV2(hashFile)[COPILOT_INSTRUCTIONS_PATH]).toBe(
+      computeHash(result),
+    );
   });
 
   it("#5 force overwrites user-modified files", async () => {
@@ -608,9 +674,7 @@ describe("update() integration", () => {
     expect(readProjectFile(PATHS.WORKFLOW_GUIDE_FILE)).toContain(
       "[codex-inline, Kilo, Antigravity, Devin]",
     );
-    expect(readProjectFile(PATHS.WORKFLOW_GUIDE_FILE)).not.toContain(
-      "[Codex]",
-    );
+    expect(readProjectFile(PATHS.WORKFLOW_GUIDE_FILE)).not.toContain("[Codex]");
 
     // Version-specific additive config sections still apply to a user-modified
     // config.yaml, while preserving the local content around the append.
@@ -623,9 +687,7 @@ describe("update() integration", () => {
 
     // User-modified template files are skipped under skipAll and their hashes
     // are not rewritten to bless the local modification as a template.
-    expect(readProjectFile(userModifiedScript)).toBe(
-      userModifiedScriptContent,
-    );
+    expect(readProjectFile(userModifiedScript)).toBe(userModifiedScriptContent);
     const hashes = readHashesV2(hashFilePath());
     expect(hashes[PATHS.WORKFLOW_GUIDE_FILE]).toBe(
       computeHash(expectedWorkflow),

--- a/packages/cli/test/configurators/index.test.ts
+++ b/packages/cli/test/configurators/index.test.ts
@@ -13,6 +13,7 @@ import {
   resolveCliFlag,
 } from "../../src/configurators/index.js";
 import { AI_TOOLS, type AITool } from "../../src/types/ai-tools.js";
+import { COPILOT_INSTRUCTIONS_PATH } from "../../src/templates/copilot/index.js";
 
 // =============================================================================
 // Derived Constants
@@ -370,9 +371,9 @@ describe("collectPlatformTemplates", () => {
           `${skillRoot}/trellis-meta/references/local-architecture/overview.md`,
         ),
       ).toBe(true);
-      expect(
-        result?.has(`${skillRoot}/trellis-spec-bootstrap/SKILL.md`),
-      ).toBe(true);
+      expect(result?.has(`${skillRoot}/trellis-spec-bootstrap/SKILL.md`)).toBe(
+        true,
+      );
       expect(
         result?.has(
           `${skillRoot}/trellis-spec-bootstrap/references/spec-writing.md`,
@@ -403,6 +404,7 @@ describe("collectPlatformTemplates", () => {
     expect(result?.has(".github/prompts/start.prompt.md")).toBe(false);
     expect(result?.has(".github/prompts/finish-work.prompt.md")).toBe(true);
     expect(result?.has(".github/prompts/continue.prompt.md")).toBe(true);
+    expect(result?.has(COPILOT_INSTRUCTIONS_PATH)).toBe(true);
     expect(result?.has(".github/copilot/hooks.json")).toBe(true);
     expect(result?.has(".github/hooks/trellis.json")).toBe(true);
   });

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -16,7 +16,9 @@ import {
   getHooksConfig as getCodexHooksConfig,
 } from "../../src/templates/codex/index.js";
 import {
+  COPILOT_INSTRUCTIONS_PATH,
   getAllHooks as getAllCopilotHooks,
+  getCopilotInstructions,
   getHooksConfig as getCopilotHooksConfig,
 } from "../../src/templates/copilot/index.js";
 import { getHooksConfig as getCursorHooksConfig } from "../../src/templates/cursor/index.js";
@@ -447,10 +449,7 @@ describe("configurePlatform", () => {
     }
 
     // IDE `.kiro.hook` written with PYTHON_CMD resolved and valid schema.
-    const ideHookPath = path.join(
-      hooksDir,
-      "trellis-workflow-state.kiro.hook",
-    );
+    const ideHookPath = path.join(hooksDir, "trellis-workflow-state.kiro.hook");
     expect(fs.existsSync(ideHookPath)).toBe(true);
     const ideRaw = fs.readFileSync(ideHookPath, "utf-8");
     expect(ideRaw).not.toContain("{{PYTHON_CMD}}");
@@ -671,13 +670,7 @@ describe("configurePlatform", () => {
     ).toBe(false);
     expect(
       fs.existsSync(
-        path.join(
-          tmpDir,
-          ".agents",
-          "skills",
-          "trellis-continue",
-          "SKILL.md",
-        ),
+        path.join(tmpDir, ".agents", "skills", "trellis-continue", "SKILL.md"),
       ),
     ).toBe(false);
 
@@ -767,6 +760,15 @@ describe("configurePlatform", () => {
 
   it("configurePlatform('copilot') writes prompts + skills", async () => {
     await configurePlatform("copilot", tmpDir);
+
+    const instructionsPath = path.join(
+      tmpDir,
+      ...COPILOT_INSTRUCTIONS_PATH.split("/"),
+    );
+    expect(fs.existsSync(instructionsPath)).toBe(true);
+    expect(fs.readFileSync(instructionsPath, "utf-8")).toBe(
+      getCopilotInstructions(),
+    );
 
     // Prompts (commands)
     const promptsDir = path.join(tmpDir, ".github", "prompts");
@@ -894,9 +896,9 @@ describe("configurePlatform", () => {
     for (const file of walk(tmpDir)) {
       expect(path.basename(file)).not.toBe("statusline.py");
       if (path.basename(file) === "settings.json") {
-        expect(
-          JSON.parse(fs.readFileSync(file, "utf-8")),
-        ).not.toHaveProperty("statusLine");
+        expect(JSON.parse(fs.readFileSync(file, "utf-8"))).not.toHaveProperty(
+          "statusLine",
+        );
       }
     }
   });
@@ -1169,6 +1171,9 @@ describe("configurePlatform", () => {
     );
     expect(templates?.get(".github/hooks/trellis.json")).toBe(
       resolvePlaceholders(getCopilotHooksConfig()),
+    );
+    expect(templates?.get(COPILOT_INSTRUCTIONS_PATH)).toBe(
+      getCopilotInstructions(),
     );
   });
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -941,7 +941,8 @@ describe("regression: agent-session Trellis update hint", () => {
     );
 
     expect(output).toContain("Trellis update available: 0.5.0 -> 0.5.9");
-    expect(output).toContain("run trellis upgrade");
+    expect(output).toContain("run trellis update");
+    expect(output).not.toContain("run trellis upgrade");
     expect(output).toContain("SESSION CONTEXT");
   });
 

--- a/packages/cli/test/scripts/add-session.integration.test.ts
+++ b/packages/cli/test/scripts/add-session.integration.test.ts
@@ -178,6 +178,28 @@ describe.skipIf(!hasPython())("add_session.py auto-commit", () => {
     expect(status).toMatch(/\.trellis\/tasks\/task-b\/prd\.md/);
   });
 
+  it("uses explicit fallback text instead of journal placeholders", () => {
+    makeTask(tmp, "task-a", "task A prd\n");
+    setCurrentTask(tmp, "task-a");
+    git(tmp, "add", "-A");
+    git(tmp, "commit", "-q", "-m", "initial");
+
+    runAddSession(tmp, "placeholder-free work");
+
+    const journal = fs.readFileSync(
+      path.join(tmp, ".trellis", "workspace", DEVELOPER, "journal-1.md"),
+      "utf-8",
+    );
+
+    expect(journal).toContain(
+      "- Detailed change bullets were not supplied; see the summary above.",
+    );
+    expect(journal).toContain("- Validation was not recorded for this session.");
+    expect(journal).not.toContain("(Add details)");
+    expect(journal).not.toContain("(Add test results)");
+    expect(journal).not.toContain("(Add summary)");
+  });
+
   it("does not wide-scan task dirs when the current task is unresolvable (>=2 sessions)", () => {
     makeTask(tmp, "task-a", "task A prd\n");
     makeTask(tmp, "task-b", "task B prd v1\n");

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -19,6 +19,8 @@ const EXPECTED_AGENT_NAMES = [
   "trellis-research",
 ];
 
+const EMPTY_EXCEPT_PASS_RE = /except[^\n]*:\n\s*pass\s*$/m;
+
 // Shared skills are now sourced from common/ via resolveAllAsSkills
 describe("codex shared skills (from common source)", () => {
   it("resolves all common templates for codex context", () => {
@@ -127,5 +129,10 @@ describe("codex session-start.py compact SessionStart context", () => {
     expect(content).not.toContain("<sub-agent-notice>");
     expect(content).not.toContain("guides (inlined");
     expect(content).not.toContain("Project spec indexes are listed by path below");
+  });
+
+  it("documents fail-open exception suppression", () => {
+    const content = fs.readFileSync(hookPath, "utf-8");
+    expect(content).not.toMatch(EMPTY_EXCEPT_PASS_RE);
   });
 });

--- a/packages/cli/test/templates/copilot.test.ts
+++ b/packages/cli/test/templates/copilot.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../src/templates/copilot/index.js";
 
 const EXPECTED_HOOK_NAMES = ["session-start.py"];
+const EMPTY_EXCEPT_PASS_RE = /except[^\n]*:\n\s*pass\s*$/m;
 
 describe("copilot getAllHooks", () => {
 	it("returns the expected hook set", () => {
@@ -35,6 +36,13 @@ describe("copilot getAllHooks", () => {
 		expect(content).not.toContain("systemMessage");
 		expect(content).not.toContain("currently ignores sessionStart hook output");
 		expect(content).not.toMatch(/Copilot[^\n]*ignores hook output/);
+	});
+
+	it("session-start.py documents fail-open exception suppression", () => {
+		const hooks = getAllHooks();
+		const sessionStart = hooks.find((h) => h.name === "session-start.py");
+		expect(sessionStart).toBeDefined();
+		expect(sessionStart?.content ?? "").not.toMatch(EMPTY_EXCEPT_PASS_RE);
 	});
 });
 

--- a/packages/cli/test/templates/shared-hooks.test.ts
+++ b/packages/cli/test/templates/shared-hooks.test.ts
@@ -13,6 +13,8 @@ const ALL_HOOK_FILES = [
   "inject-subagent-context.py",
 ] as const;
 
+const EMPTY_EXCEPT_PASS_RE = /except[^\n]*:\n\s*pass\s*$/m;
+
 describe("shared-hooks capability table", () => {
   it("every capability-table entry names a real shared-hook file", () => {
     const realFiles = new Set(getSharedHookScripts().map((h) => h.name));
@@ -145,5 +147,16 @@ describe("shared-hooks capability table", () => {
     expect(content).toContain("complex task must add");
     expect(content).not.toContain("Status: READY");
     expect(content).not.toContain("<workflow>");
+  });
+
+  it("generated session and workflow-state hooks document fail-open exception suppression", () => {
+    for (const name of ["session-start.py", "inject-workflow-state.py"]) {
+      const hook = getSharedHookScripts().find((h) => h.name === name);
+      expect(hook, `${name} is missing from shared-hooks/`).toBeDefined();
+      const content = hook?.content ?? "";
+
+      expect(content).not.toContain("BaseException");
+      expect(content).not.toMatch(EMPTY_EXCEPT_PASS_RE);
+    }
   });
 });

--- a/packages/cli/test/utils/uninstall-scrubbers.test.ts
+++ b/packages/cli/test/utils/uninstall-scrubbers.test.ts
@@ -13,6 +13,7 @@ import {
   scrubOpencodePackageJson,
   scrubPiSettings,
   scrubCodexConfigToml,
+  scrubManagedMarkdownBlock,
 } from "../../src/utils/uninstall-scrubbers.js";
 
 const CLAUDE_DELETE_PATHS = [
@@ -27,6 +28,9 @@ const CURSOR_DELETE_PATHS = [
   ".cursor/hooks/inject-workflow-state.py",
   ".cursor/hooks/inject-shell-session-context.py",
 ];
+
+const TEST_BLOCK_START = "<!-- TRELLIS:TEST:START -->";
+const TEST_BLOCK_END = "<!-- TRELLIS:TEST:END -->";
 
 describe("scrubHooksJson — nested schema", () => {
   it("strips trellis hook entries from a Claude-style file", () => {
@@ -270,7 +274,8 @@ describe("scrubHooksJson — flat schema", () => {
           {
             type: "command",
             bash: "python3 .github/copilot/hooks/inject-workflow-state.py",
-            powershell: "python3 .github/copilot/hooks/inject-workflow-state.py",
+            powershell:
+              "python3 .github/copilot/hooks/inject-workflow-state.py",
             timeoutSec: 5,
           },
         ],
@@ -326,6 +331,63 @@ describe("scrubOpencodePackageJson", () => {
     const parsed = JSON.parse(content);
     expect(parsed.name).toBe("my-project");
     expect(parsed.dependencies).toEqual({ lodash: "^4.0.0" });
+    expect(fullyEmpty).toBe(false);
+  });
+});
+
+describe("scrubManagedMarkdownBlock", () => {
+  it("removes the managed block and preserves user markdown", () => {
+    const input = `# User Guidance
+
+Keep this.
+
+${TEST_BLOCK_START}
+# Managed
+Remove this.
+${TEST_BLOCK_END}
+
+## Tail
+
+Also keep this.
+`;
+
+    const { content, fullyEmpty } = scrubManagedMarkdownBlock(
+      input,
+      TEST_BLOCK_START,
+      TEST_BLOCK_END,
+    );
+
+    expect(content).toBe(`# User Guidance
+
+Keep this.
+
+## Tail
+
+Also keep this.
+`);
+    expect(fullyEmpty).toBe(false);
+  });
+
+  it("reports fullyEmpty when only the managed block remains", () => {
+    const { content, fullyEmpty } = scrubManagedMarkdownBlock(
+      `${TEST_BLOCK_START}\nmanaged\n${TEST_BLOCK_END}\n`,
+      TEST_BLOCK_START,
+      TEST_BLOCK_END,
+    );
+
+    expect(content).toBe("");
+    expect(fullyEmpty).toBe(true);
+  });
+
+  it("leaves malformed marker pairs untouched", () => {
+    const input = `${TEST_BLOCK_START}\nmanaged\n`;
+    const { content, fullyEmpty } = scrubManagedMarkdownBlock(
+      input,
+      TEST_BLOCK_START,
+      TEST_BLOCK_END,
+    );
+
+    expect(content).toBe(input);
     expect(fullyEmpty).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Replace placeholder session journal defaults with explicit fallback text
- Document intentional fail-open exception handling in generated Python hooks and avoid catching BaseException
- Correct the session context update hint to recommend trellis update
- Add Trellis-managed Copilot review guidance in .github/copilot-instructions.md so generated Trellis payload feedback gets handed upstream instead of patched in consumer repos
- Preserve repo-authored Copilot instructions during update/uninstall by merging or scrubbing only the Trellis managed block

## Verification
- pnpm --filter @mindfoldhq/trellis exec vitest run test/configurators/platforms.test.ts test/configurators/index.test.ts test/commands/init.integration.test.ts test/commands/update.integration.test.ts test/utils/uninstall-scrubbers.test.ts
- pnpm --filter @mindfoldhq/trellis lint
- pnpm --filter @mindfoldhq/trellis typecheck
- pnpm --filter @mindfoldhq/trellis test
- pnpm test
- pnpm build
- git diff --check
- NPM_CONFIG_CACHE=/private/tmp/trellis-npm-cache npx gitnexus detect-changes --scope compare --base-ref main --limit 80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When generating new sessions, defaults now use clearer fallback “Main Changes” and “Testing” text if you don’t provide them.
  * Added Copilot “Trellis Review Guidance” instructions under `.github`, and ensure they’re managed during platform setup and updates.

* **Bug Fixes**
  * The concise version update hint now recommends the correct command.
  * Improved resilience around optional startup/input-reading and stream setup failures (non-blocking behavior preserved).

* **Tests**
  * Expanded regression coverage to prevent placeholder text from reappearing and to guard against overly broad exception suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->