### PR TITLE
fix(channel): 串行化 stdout 事件追加

### DIFF
--- a/packages/cli/src/commands/channel/supervisor/stdout.ts
+++ b/packages/cli/src/commands/channel/supervisor/stdout.ts
@@ -24,17 +24,20 @@ import type { TurnOutcome, TurnTracker } from "./turns.js";
 type Child = ChildProcessByStdio<Writable, Readable, Readable>;
 
 /**
- * Line-buffered stdout pump. Yields each non-empty line to `onLine` as
- * soon as a newline arrives, wraps the handler in a `.catch` so a thrown
- * await doesn't escape as `unhandledRejection`, and reports the failure
- * through `onError` for observability.
+ * 按行读取 stdout，并把非空行串行交给 onLine
+ *
+ * @param stream 子进程 stdout 可读流
+ * @param onLine stdout 单行处理器，按读取顺序串行执行
+ * @param onError onLine 抛错时的错误处理器，也在同一队列中执行
+ * @returns 无返回值
  */
 export function pumpStdout(
   stream: Readable,
   onLine: (line: string) => Promise<void> | void,
-  onError?: (err: Error) => void,
+  onError?: (err: Error) => Promise<void> | void,
 ): void {
   let buf = "";
+  let queue: Promise<void> = Promise.resolve();
   stream.on("data", (chunk: Buffer) => {
     buf += chunk.toString("utf-8");
     let nl: number;
@@ -42,17 +45,21 @@ export function pumpStdout(
       const line = buf.slice(0, nl);
       buf = buf.slice(nl + 1);
       if (line.trim()) {
-        Promise.resolve()
-          .then(() => onLine(line))
-          .catch((err) => {
+        queue = queue.then(async () => {
+          try {
+            await onLine(line);
+          } catch (err) {
             if (onError) {
               try {
-                onError(err instanceof Error ? err : new Error(String(err)));
+                await onError(
+                  err instanceof Error ? err : new Error(String(err)),
+                );
               } catch {
-                // swallow handler-of-handler errors
+                // 吞掉错误处理器自身的错误
               }
             }
-          });
+          }
+        });
       }
     }
   });
@@ -165,9 +172,9 @@ export function startStdoutPump(args: {
         turnTracker,
       );
     },
-    (err) => {
+    async (err) => {
       log.write(`[supervisor] stdout line handler failed: ${err.message}\n`);
-      void appendEvent(channelName, {
+      await appendEvent(channelName, {
         kind: "error",
         by: `supervisor:${workerName}`,
         message: `stdout pipeline error: ${err.message}`,

--- a/packages/cli/src/commands/channel/supervisor/stdout.ts
+++ b/packages/cli/src/commands/channel/supervisor/stdout.ts
@@ -38,6 +38,64 @@ export function pumpStdout(
 ): void {
   let buf = "";
   let queue: Promise<void> = Promise.resolve();
+  let pending = 0;
+  let paused = false;
+
+  /**
+   * 在有待处理行时暂停 stdout 读取
+   *
+   * @returns 无返回值
+   */
+  const pauseForBackpressure = (): void => {
+    if (!paused) {
+      stream.pause();
+      paused = true;
+    }
+  };
+
+  /**
+   * 在待处理行全部完成后恢复 stdout 读取
+   *
+   * @returns 无返回值
+   */
+  const resumeIfDrained = (): void => {
+    if (paused && pending === 0) {
+      paused = false;
+      stream.resume();
+    }
+  };
+
+  /**
+   * 将 stdout 单行追加到串行处理队列
+   *
+   * @param line 已切分出的 stdout 单行文本
+   * @returns 无返回值
+   */
+  const enqueue = (line: string): void => {
+    pending += 1;
+    pauseForBackpressure();
+    queue = queue
+      .then(async () => {
+        try {
+          await onLine(line);
+        } catch (err) {
+          if (onError) {
+            try {
+              await onError(
+                err instanceof Error ? err : new Error(String(err)),
+              );
+            } catch {
+              // 吞掉错误处理器自身的错误
+            }
+          }
+        } finally {
+          pending -= 1;
+          resumeIfDrained();
+        }
+      })
+      .catch(() => undefined);
+  };
+
   stream.on("data", (chunk: Buffer) => {
     buf += chunk.toString("utf-8");
     let nl: number;
@@ -45,21 +103,7 @@ export function pumpStdout(
       const line = buf.slice(0, nl);
       buf = buf.slice(nl + 1);
       if (line.trim()) {
-        queue = queue.then(async () => {
-          try {
-            await onLine(line);
-          } catch (err) {
-            if (onError) {
-              try {
-                await onError(
-                  err instanceof Error ? err : new Error(String(err)),
-                );
-              } catch {
-                // 吞掉错误处理器自身的错误
-              }
-            }
-          }
-        });
+        enqueue(line);
       }
     }
   });

--- a/packages/cli/test/commands/channel.test.ts
+++ b/packages/cli/test/commands/channel.test.ts
@@ -14,7 +14,10 @@ import { channelInterrupt } from "../../src/commands/channel/interrupt.js";
 import { channelMessages } from "../../src/commands/channel/messages.js";
 import { channelSend } from "../../src/commands/channel/send.js";
 import { runInboxWatcher } from "../../src/commands/channel/supervisor/inbox.js";
-import { applyParseResult } from "../../src/commands/channel/supervisor/stdout.js";
+import {
+  applyParseResult,
+  pumpStdout,
+} from "../../src/commands/channel/supervisor/stdout.js";
 import { TurnTracker } from "../../src/commands/channel/supervisor/turns.js";
 import {
   channelTitleClear,
@@ -596,5 +599,77 @@ describe("channel shared helpers", () => {
         { to: "arch" },
       ),
     ).toBe(false);
+  });
+});
+
+describe("channel stdout pump", () => {
+  it("serializes high-frequency line handling in input order", async () => {
+    const stream = new PassThrough();
+    const lines = Array.from({ length: 800 }, (_, i) => `line-${i}`);
+    const started: string[] = [];
+    const finished: string[] = [];
+    const errors: string[] = [];
+    let activeHandlers = 0;
+    let maxActiveHandlers = 0;
+
+    pumpStdout(
+      stream,
+      async (line) => {
+        activeHandlers += 1;
+        maxActiveHandlers = Math.max(maxActiveHandlers, activeHandlers);
+        started.push(line);
+        await Promise.resolve();
+        finished.push(line);
+        activeHandlers -= 1;
+      },
+      (err) => {
+        errors.push(err.message);
+      },
+    );
+
+    stream.write(lines.map((line) => `${line}\n`).join(""));
+
+    await vi.waitUntil(() => finished.length === lines.length, {
+      timeout: 5_000,
+    });
+
+    expect(started).toEqual(lines);
+    expect(finished).toEqual(lines);
+    expect(maxActiveHandlers).toBe(1);
+    expect(errors).toEqual([]);
+  });
+
+  it("awaits stdout handler errors before continuing to later lines", async () => {
+    const stream = new PassThrough();
+    const handled: string[] = [];
+
+    pumpStdout(
+      stream,
+      async (line) => {
+        handled.push(`line:${line}`);
+        if (line === "bad") {
+          throw new Error("bad line");
+        }
+      },
+      async (err) => {
+        handled.push(`error:${err.message}`);
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        handled.push("error:done");
+        throw new Error("error handler failed");
+      },
+    );
+
+    stream.write("bad\nafter\n");
+
+    await vi.waitUntil(() => handled.includes("line:after"), {
+      timeout: 1_000,
+    });
+
+    expect(handled).toEqual([
+      "line:bad",
+      "error:bad line",
+      "error:done",
+      "line:after",
+    ]);
   });
 });

--- a/packages/cli/test/commands/channel.test.ts
+++ b/packages/cli/test/commands/channel.test.ts
@@ -639,6 +639,49 @@ describe("channel stdout pump", () => {
     expect(errors).toEqual([]);
   });
 
+  it("pauses stdout reads while queued line handling drains", async () => {
+    const stream = new PassThrough();
+    const pause = vi.spyOn(stream, "pause");
+    const resume = vi.spyOn(stream, "resume");
+    const handled: string[] = [];
+    let releaseFirst!: () => void;
+    const firstDone = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    pumpStdout(stream, async (line) => {
+      handled.push(`start:${line}`);
+      if (line === "first") {
+        await firstDone;
+      }
+      handled.push(`finish:${line}`);
+    });
+
+    stream.write("first\n");
+
+    await vi.waitUntil(() => handled.includes("start:first"), {
+      timeout: 1_000,
+    });
+    expect(pause).toHaveBeenCalled();
+
+    stream.write("second\n");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handled).toEqual(["start:first"]);
+
+    releaseFirst();
+    await vi.waitUntil(() => handled.includes("finish:second"), {
+      timeout: 1_000,
+    });
+
+    expect(resume).toHaveBeenCalled();
+    expect(handled).toEqual([
+      "start:first",
+      "finish:first",
+      "start:second",
+      "finish:second",
+    ]);
+  });
+
   it("awaits stdout handler errors before continuing to later lines", async () => {
     const stream = new PassThrough();
     const handled: string[] = [];


### PR DESCRIPTION
Fixes #391

## 摘要

修复 `trellis channel` worker supervisor 的 stdout 处理并发问题。

之前 `pumpStdout()` 对每一行 stdout 都直接启动一个异步 `onLine(line)`，没有串行化或背压控制。worker 高频输出时，同一个 supervisor 进程内会并发调用 `appendEvent()`，竞争同一个 channel lock，最终可能出现锁超时，导致 `message` / `done` / `turn_finished` 事件没有持久化。

## 改动

- 在 `pumpStdout()` 内加入 promise 串行队列
- 保证 stdout 行按读取顺序依次执行 `onLine`
- 让 `onError` 也进入同一个队列并被等待
- 吞掉 `onLine` / `onError` 的异常，避免一次失败中断后续 stdout 行处理
- 添加回归测试，覆盖高频 stdout 输入不并发、顺序保持、错误处理后继续处理

## 验证

- `cd packages\cli && node_modules\.bin\vitest.cmd run test/commands/channel.test.ts`
- `cd packages\core && node_modules\.bin\eslint.cmd src/ test/`
- `cd packages\cli && node_modules\.bin\eslint.cmd src/ test/`
- `cd packages\core && node_modules\.bin\tsc.cmd --noEmit`
- `cd packages\cli && node_modules\.bin\tsc.cmd --noEmit`

## 备注

`pnpm test` 中 core 全量通过；cli 全量仍有既有失败，主要与 Windows 路径/CRLF、缺失 marketplace fixture、upgrade 测试 Windows 期望有关，和本次改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stdout handling to strictly serialize newline-delimited line processing in input order, preventing overlapping handler execution during bursts.
  - Added backpressure: reading pauses when queued lines are pending and resumes after processing drains.
  - Updated error handling so line-handler and error-handler completion is awaited, ensuring correct sequencing (while isolating failures inside error callbacks).

- **Tests**
  - Added coverage for ordered processing, pause/resume behavior under blocked handlers, and end-to-end error sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->