### PR TITLE
fix(cli): ignore stale task branch in session logs

### DIFF
--- a/.trellis/scripts/add_session.py
+++ b/.trellis/scripts/add_session.py
@@ -14,7 +14,7 @@ Usage:
 
 Branch resolution order:
     1. --branch CLI arg (explicit)
-    2. task.json branch field (from active task)
+    2. task.json branch field (from active task, if still exists)
     3. git branch --show-current (auto-detect)
     4. None (omitted gracefully)
 """
@@ -44,6 +44,7 @@ from common.safe_commit import (
     safe_trellis_paths_to_add,
 )
 from common.tasks import load_task
+from common.types import TaskInfo
 from common.config import (
     get_packages,
     get_session_auto_commit,
@@ -124,6 +125,56 @@ def count_journal_files(dev_dir: Path, active_num: int) -> str:
         result_lines.append(f"| `{filename}` | ~{lines} | {status} |")
 
     return "\n".join(result_lines)
+
+
+def get_current_git_branch(repo_root: Path) -> str | None:
+    """Return the current checkout branch, or None for detached/non-git states."""
+    rc, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+    if rc != 0:
+        return None
+    detected = branch_out.strip()
+    return detected or None
+
+
+def branch_ref_exists(repo_root: Path, branch: str) -> bool:
+    """Return True when branch exists locally or as the local origin ref."""
+    for ref in (f"refs/heads/{branch}", f"refs/remotes/origin/{branch}"):
+        rc, _, _ = run_git(["show-ref", "--verify", "--quiet", ref], cwd=repo_root)
+        if rc == 0:
+            return True
+    return False
+
+
+def resolve_session_branch(
+    repo_root: Path,
+    cli_branch: str | None,
+    task_data: TaskInfo | None,
+) -> str | None:
+    """Resolve journal branch without trusting stale task.json branch fields."""
+    if cli_branch:
+        return cli_branch
+
+    current_branch = get_current_git_branch(repo_root)
+    raw_task_branch = task_data.raw.get("branch") if task_data else None
+    task_branch = raw_task_branch.strip() if isinstance(raw_task_branch, str) else ""
+    if not task_branch:
+        return current_branch
+
+    if branch_ref_exists(repo_root, task_branch):
+        return task_branch
+
+    if current_branch:
+        print(
+            f"Warning: task.json branch '{task_branch}' no longer exists locally or as origin/{task_branch}; using current branch '{current_branch}'.",
+            file=sys.stderr,
+        )
+        return current_branch
+
+    print(
+        f"Warning: task.json branch '{task_branch}' no longer exists locally or as origin/{task_branch}; omitting branch.",
+        file=sys.stderr,
+    )
+    return None
 
 
 def create_new_journal_file(
@@ -543,17 +594,7 @@ def main() -> int:
         task_package = task_data.package if task_data else None
         package = resolve_package(task_package, repo_root)
 
-    # Resolve branch: CLI → task.json → git auto-detect → None
-    branch = args.branch
-
-    if not branch:
-        if task_data and task_data.raw.get("branch"):
-            branch = task_data.raw["branch"]
-        else:
-            _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
-            detected = branch_out.strip()
-            if detected:
-                branch = detected
+    branch = resolve_session_branch(repo_root, args.branch, task_data)
 
     return add_session(
         args.title, args.commit, args.summary, extra_content,

--- a/packages/cli/src/templates/trellis/scripts/add_session.py
+++ b/packages/cli/src/templates/trellis/scripts/add_session.py
@@ -14,7 +14,7 @@ Usage:
 
 Branch resolution order:
     1. --branch CLI arg (explicit)
-    2. task.json branch field (from active task)
+    2. task.json branch field (from active task, if still exists)
     3. git branch --show-current (auto-detect)
     4. None (omitted gracefully)
 """
@@ -44,6 +44,7 @@ from common.safe_commit import (
     safe_trellis_paths_to_add,
 )
 from common.tasks import load_task
+from common.types import TaskInfo
 from common.config import (
     get_packages,
     get_session_auto_commit,
@@ -130,6 +131,56 @@ def count_journal_files(dev_dir: Path, active_num: int) -> str:
         result_lines.append(f"| `{filename}` | ~{lines} | {status} |")
 
     return "\n".join(result_lines)
+
+
+def get_current_git_branch(repo_root: Path) -> str | None:
+    """Return the current checkout branch, or None for detached/non-git states."""
+    rc, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+    if rc != 0:
+        return None
+    detected = branch_out.strip()
+    return detected or None
+
+
+def branch_ref_exists(repo_root: Path, branch: str) -> bool:
+    """Return True when branch exists locally or as the local origin ref."""
+    for ref in (f"refs/heads/{branch}", f"refs/remotes/origin/{branch}"):
+        rc, _, _ = run_git(["show-ref", "--verify", "--quiet", ref], cwd=repo_root)
+        if rc == 0:
+            return True
+    return False
+
+
+def resolve_session_branch(
+    repo_root: Path,
+    cli_branch: str | None,
+    task_data: TaskInfo | None,
+) -> str | None:
+    """Resolve journal branch without trusting stale task.json branch fields."""
+    if cli_branch:
+        return cli_branch
+
+    current_branch = get_current_git_branch(repo_root)
+    raw_task_branch = task_data.raw.get("branch") if task_data else None
+    task_branch = raw_task_branch.strip() if isinstance(raw_task_branch, str) else ""
+    if not task_branch:
+        return current_branch
+
+    if branch_ref_exists(repo_root, task_branch):
+        return task_branch
+
+    if current_branch:
+        print(
+            f"Warning: task.json branch '{task_branch}' no longer exists locally or as origin/{task_branch}; using current branch '{current_branch}'.",
+            file=sys.stderr,
+        )
+        return current_branch
+
+    print(
+        f"Warning: task.json branch '{task_branch}' no longer exists locally or as origin/{task_branch}; omitting branch.",
+        file=sys.stderr,
+    )
+    return None
 
 
 def create_new_journal_file(
@@ -550,17 +601,7 @@ def main() -> int:
         task_package = task_data.package if task_data else None
         package = resolve_package(task_package, repo_root)
 
-    # Resolve branch: CLI → task.json → git auto-detect → None
-    branch = args.branch
-
-    if not branch:
-        if task_data and task_data.raw.get("branch"):
-            branch = task_data.raw["branch"]
-        else:
-            _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
-            detected = branch_out.strip()
-            if detected:
-                branch = detected
+    branch = resolve_session_branch(repo_root, args.branch, task_data)
 
     return add_session(
         args.title, args.commit, args.summary, extra_content,

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -303,18 +303,11 @@ ${separator}
     if (options?.taskBranch || options?.taskBaseBranch) {
       const taskDir = path.join(tmpDir, ".trellis", "tasks", "issue-106");
       fs.mkdirSync(taskDir, { recursive: true });
-      fs.mkdirSync(
-        path.join(tmpDir, ".trellis", ".runtime", "sessions"),
-        { recursive: true },
-      );
+      fs.mkdirSync(path.join(tmpDir, ".trellis", ".runtime", "sessions"), {
+        recursive: true,
+      });
       fs.writeFileSync(
-        path.join(
-          tmpDir,
-          ".trellis",
-          ".runtime",
-          "sessions",
-          "session-a.json",
-        ),
+        path.join(tmpDir, ".trellis", ".runtime", "sessions", "session-a.json"),
         JSON.stringify(
           {
             current_task: ".trellis/tasks/issue-106",
@@ -373,6 +366,13 @@ ${separator}
     });
   }
 
+  function createLocalBranch(branch: string): void {
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git commit --allow-empty -q -m init", { cwd: tmpDir });
+    execSync(`git branch ${JSON.stringify(branch)}`, { cwd: tmpDir });
+  }
+
   it("[issue-106] prefers explicit CLI branch over task.json and git", () => {
     setupSessionRepo({
       gitBranch: "feature/from-git",
@@ -406,6 +406,7 @@ ${separator}
       taskBranch: "task/from-task",
       taskBaseBranch: "main",
     });
+    createLocalBranch("task/from-task");
 
     runAddSession("Task branch wins");
 
@@ -1021,9 +1022,9 @@ describe("regression: agent-session Trellis update hint", () => {
         `${functionName} should not check Trellis updates`,
       ).not.toContain("_get_update_hint");
     }
-    expect(commonGitContext).toContain("if args.mode == \"record\":");
-    expect(commonGitContext).toContain("elif args.mode == \"packages\":");
-    expect(commonGitContext).toContain("elif args.mode == \"phase\":");
+    expect(commonGitContext).toContain('if args.mode == "record":');
+    expect(commonGitContext).toContain('elif args.mode == "packages":');
+    expect(commonGitContext).toContain('elif args.mode == "phase":');
     expect(commonGitContext).toContain("else:");
     expect(commonGitContext).toContain("output_text()");
   });
@@ -1083,7 +1084,8 @@ describe("regression: issue #252 polyrepo Git context", () => {
     if (kind === "record") {
       expression = "print(session_context.get_context_text_record(Path.cwd()))";
     } else if (kind === "json") {
-      expression = "print(json.dumps(session_context.get_context_json(Path.cwd())))";
+      expression =
+        "print(json.dumps(session_context.get_context_json(Path.cwd())))";
     }
     fs.writeFileSync(
       runnerPath,
@@ -1288,9 +1290,7 @@ describe("regression: current-task path normalization", () => {
     "CODEBUDDY_TRANSCRIPT_PATH",
   ] as const;
 
-  function sessionEnv(
-    overrides: NodeJS.ProcessEnv = {},
-  ): NodeJS.ProcessEnv {
+  function sessionEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     const blocked = new Set<string>(SESSION_ENV_KEYS);
     const env: NodeJS.ProcessEnv = {};
     for (const [key, value] of Object.entries(process.env)) {
@@ -1379,12 +1379,12 @@ describe("regression: current-task path normalization", () => {
     expect(output).toContain("TRELLIS_CONTEXT_ID");
 
     // No active-task pointer written
-    expect(
-      fs.existsSync(path.join(tmpDir, ".trellis", ".current-task")),
-    ).toBe(false);
-    expect(
-      fs.existsSync(path.join(tmpDir, ".trellis", ".runtime")),
-    ).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".trellis", ".current-task"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(tmpDir, ".trellis", ".runtime"))).toBe(
+      false,
+    );
 
     // task.json.status remains in_progress (was already in_progress; degraded
     // mode preserves the existing status when not planning)
@@ -1452,9 +1452,9 @@ describe("regression: current-task path normalization", () => {
       current_task: string;
     };
     expect(context.current_task).toBe(".trellis/tasks/issue-106");
-    expect(
-      fs.existsSync(path.join(tmpDir, ".trellis", ".current-task")),
-    ).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".trellis", ".current-task"))).toBe(
+      false,
+    );
   });
 
   it("[session-current-task] task.py finish deletes the session runtime context", () => {
@@ -1478,11 +1478,14 @@ describe("regression: current-task path normalization", () => {
     );
     expect(fs.existsSync(contextPath)).toBe(true);
 
-    const output = execSync(`${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`, {
-      cwd: tmpDir,
-      encoding: "utf-8",
-      env: sessionEnv({ TRELLIS_CONTEXT_ID: "session-finish" }),
-    });
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ TRELLIS_CONTEXT_ID: "session-finish" }),
+      },
+    );
 
     expect(output).toContain("Cleared current task");
     expect(output).toContain("Source: session:session-finish");
@@ -1681,11 +1684,14 @@ describe("regression: current-task path normalization", () => {
       JSON.stringify({ current_task: ".trellis/tasks/other-task" }, null, 2),
     );
 
-    execSync(`${pythonCmd} ${JSON.stringify(taskScriptPath)} archive issue-106 --no-commit`, {
-      cwd: tmpDir,
-      encoding: "utf-8",
-      env: sessionEnv(),
-    });
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} archive issue-106 --no-commit`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv(),
+      },
+    );
 
     expect(fs.existsSync(contextA)).toBe(false);
     expect(fs.existsSync(contextB)).toBe(false);
@@ -1753,7 +1759,10 @@ describe("regression: current-task path normalization", () => {
       "task.json",
     );
     const archivedPrdPath = path.join(archivedTaskDir as string, "prd.md");
-    const archivedTaskJsonBefore = fs.readFileSync(archivedTaskJsonPath, "utf-8");
+    const archivedTaskJsonBefore = fs.readFileSync(
+      archivedTaskJsonPath,
+      "utf-8",
+    );
     const archivedPrdBefore = fs.readFileSync(archivedPrdPath, "utf-8");
     const archivedTaskJson = JSON.parse(archivedTaskJsonBefore) as {
       status: string;
@@ -1974,7 +1983,9 @@ describe("regression: current-task path normalization", () => {
       }
     }
     for (const name of taskNames) {
-      expect(archivedNames.has(name), `task ${name} should be archived`).toBe(true);
+      expect(archivedNames.has(name), `task ${name} should be archived`).toBe(
+        true,
+      );
     }
   });
 
@@ -2074,9 +2085,9 @@ describe("regression: current-task path normalization", () => {
     );
 
     expect(output).toContain("No current task set");
-    expect(
-      fs.existsSync(path.join(tmpDir, ".trellis", ".current-task")),
-    ).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".trellis", ".current-task"))).toBe(
+      true,
+    );
   });
 
   it("[session-current-task] task.py current ignores legacy .current-task without context key", () => {
@@ -2087,15 +2098,18 @@ describe("regression: current-task path normalization", () => {
     let output = "";
     let status = 0;
     try {
-      execSync(`${pythonCmd} ${JSON.stringify(taskScriptPath)} current --source`, {
-        cwd: tmpDir,
-        encoding: "utf-8",
-        env: sessionEnv(),
-      });
+      execSync(
+        `${pythonCmd} ${JSON.stringify(taskScriptPath)} current --source`,
+        {
+          cwd: tmpDir,
+          encoding: "utf-8",
+          env: sessionEnv(),
+        },
+      );
     } catch (error) {
       status =
         typeof (error as { status?: unknown }).status === "number"
-          ? ((error as { status: number }).status)
+          ? (error as { status: number }).status
           : 1;
       output = String((error as { stdout?: unknown }).stdout ?? "");
     }
@@ -2583,7 +2597,9 @@ describe("regression: current-task path normalization", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toContain(
       "Task: cursor-task (in_progress)",
     );
-    expect(parsed.hookSpecificOutput.additionalContext).not.toContain("Source:");
+    expect(parsed.hookSpecificOutput.additionalContext).not.toContain(
+      "Source:",
+    );
     expect(parsed.hookSpecificOutput.additionalContext).not.toContain(
       "issue-106",
     );
@@ -2604,12 +2620,7 @@ describe("regression: current-task path normalization", () => {
       ),
     );
     writeProjectFile(
-      path.join(
-        ".trellis",
-        ".runtime",
-        "sessions",
-        "opencode_oc-a.json",
-      ),
+      path.join(".trellis", ".runtime", "sessions", "opencode_oc-a.json"),
       JSON.stringify(
         {
           current_task: ".trellis/tasks/opencode-task",
@@ -2731,7 +2742,9 @@ describe("regression: current-task path normalization", () => {
 
       const ctx = payload.hookSpecificOutput.additionalContext;
       expect(ctx).toContain("<first-reply-notice>");
-      expect(ctx).toMatch(/first visible assistant reply|First visible reply|Trellis SessionStart 已注入/);
+      expect(ctx).toMatch(
+        /first visible assistant reply|First visible reply|Trellis SessionStart 已注入/,
+      );
       expect(ctx).toMatch(/one-shot/i);
       expect(ctx.indexOf("<first-reply-notice>")).toBeLessThan(
         ctx.indexOf("<current-state>"),
@@ -2859,13 +2872,19 @@ describe("regression: current-task path normalization", () => {
         ?.content,
       "inject-workflow-state",
     );
-    writeProjectFile(path.join(".claude", "hooks", "session-start.py"), claudeSession);
+    writeProjectFile(
+      path.join(".claude", "hooks", "session-start.py"),
+      claudeSession,
+    );
     writeProjectFile(
       path.join(".claude", "hooks", "inject-workflow-state.py"),
       workflowState,
     );
 
-    const stdinPayload = JSON.stringify({ cwd: tmpDir, session_id: "session-a" });
+    const stdinPayload = JSON.stringify({
+      cwd: tmpDir,
+      session_id: "session-a",
+    });
 
     // Baseline: gate off, hooks emit content (sanity check)
     const baselineSession = runPython(
@@ -3570,21 +3589,27 @@ print(len(entries))
     ];
 
     for (const relativePath of agentFiles) {
-      const content = fs.readFileSync(path.join(templateRoot, relativePath), "utf-8");
+      const content = fs.readFileSync(
+        path.join(templateRoot, relativePath),
+        "utf-8",
+      );
       expect(content, `${relativePath} should mention recursion guard`).toMatch(
         /Recursion guard|Recursion Guard/,
       );
-      expect(content, `${relativePath} should scope dispatch to main session`).toContain(
-        "main session",
-      );
-      expect(content, `${relativePath} should mention workflow-state safety`).toMatch(
-        /workflow-state breadcrumbs|workflow.md/,
-      );
+      expect(
+        content,
+        `${relativePath} should scope dispatch to main session`,
+      ).toContain("main session");
+      expect(
+        content,
+        `${relativePath} should mention workflow-state safety`,
+      ).toMatch(/workflow-state breadcrumbs|workflow.md/);
 
       if (relativePath.includes("implement")) {
-        expect(content, `${relativePath} should forbid nested implement`).toContain(
-          "spawn another `trellis-implement`",
-        );
+        expect(
+          content,
+          `${relativePath} should forbid nested implement`,
+        ).toContain("spawn another `trellis-implement`");
         expect(content, `${relativePath} should forbid nested check`).toContain(
           "`trellis-check`",
         );
@@ -3592,9 +3617,10 @@ print(len(entries))
         expect(content, `${relativePath} should forbid nested check`).toContain(
           "spawn another `trellis-check`",
         );
-        expect(content, `${relativePath} should forbid nested implement`).toContain(
-          "`trellis-implement`",
-        );
+        expect(
+          content,
+          `${relativePath} should forbid nested implement`,
+        ).toContain("`trellis-implement`");
       }
     }
   });
@@ -3646,7 +3672,9 @@ print(len(entries))
     expect(match).toBeTruthy();
     const body = match?.[1] ?? "";
     expect(body).toMatch(/Lightweight: `prd\.md` can be enough/);
-    expect(body).toMatch(/Complex: finish `prd\.md`, `design\.md`, and `implement\.md`/);
+    expect(body).toMatch(
+      /Complex: finish `prd\.md`, `design\.md`, and `implement\.md`/,
+    );
     expect(body).toContain(
       "curate `implement.jsonl` and `check.jsonl` as spec/research manifests before start",
     );
@@ -3895,7 +3923,9 @@ print(len(entries))
       { cwd: tmpDir, encoding: "utf-8" },
     );
 
-    expect(output).toContain("The pull-based sub-agent definition auto-handles");
+    expect(output).toContain(
+      "The pull-based sub-agent definition auto-handles",
+    );
     expect(output).toContain(
       "Resolves the active task with `task.py current --source`",
     );
@@ -3977,7 +4007,8 @@ print(len(entries))
     };
     const ctx = payload.hookSpecificOutput.additionalContext;
 
-    const workflowMatch = /<trellis-workflow>([\s\S]*?)<\/trellis-workflow>/.exec(ctx);
+    const workflowMatch =
+      /<trellis-workflow>([\s\S]*?)<\/trellis-workflow>/.exec(ctx);
     if (!workflowMatch) throw new Error("workflow block not found in payload");
     const workflowBlock = workflowMatch[1];
 
@@ -4162,7 +4193,10 @@ print(len(entries))
     );
 
     const parsed = JSON.parse(
-      runPython(codexHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        codexHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("MAIN SESSION edits code");
@@ -4185,7 +4219,10 @@ print(len(entries))
     writeConfigYaml("codex:\n  dispatch_mode: sub-agent\n");
 
     const parsed = JSON.parse(
-      runPython(codexHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        codexHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("DISPATCH the trellis-implement");
@@ -4208,7 +4245,10 @@ print(len(entries))
     writeConfigYaml("codex:\n  dispatch_mode: inline\n");
 
     const parsed = JSON.parse(
-      runPython(codexHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        codexHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("MAIN SESSION edits code");
@@ -4241,7 +4281,10 @@ print(len(entries))
     writeConfigYaml("codex:\n  dispatch_mode: inline\n");
 
     const parsed = JSON.parse(
-      runPython(claudeHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        claudeHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("DISPATCH the trellis-implement");
@@ -4311,7 +4354,10 @@ print(len(entries))
       encoding: "utf-8",
     });
     const result = JSON.parse(
-      output.split("\n").filter((l) => l.startsWith("{")).pop() ?? "{}",
+      output
+        .split("\n")
+        .filter((l) => l.startsWith("{"))
+        .pop() ?? "{}",
     ) as Record<string, string>;
     expect(result.codex_inline).toBe("in_progress-inline");
     expect(result.codex_subagent).toBe("in_progress");
@@ -4361,7 +4407,10 @@ print(len(entries))
       encoding: "utf-8",
     });
     const parsed = JSON.parse(
-      output.split("\n").filter((l) => l.startsWith("{")).pop() ?? "{}",
+      output
+        .split("\n")
+        .filter((l) => l.startsWith("{"))
+        .pop() ?? "{}",
     ) as { codex?: { dispatch_mode?: string } };
     expect(parsed.codex?.dispatch_mode).toBe("inline");
   });
@@ -4391,7 +4440,10 @@ print(len(entries))
       encoding: "utf-8",
     });
     const result = JSON.parse(
-      output.split("\n").filter((l) => l.startsWith("{")).pop() ?? "{}",
+      output
+        .split("\n")
+        .filter((l) => l.startsWith("{"))
+        .pop() ?? "{}",
     ) as Record<string, string>;
     expect(result.codex_default).toBe("codex-inline");
     expect(result.codex_explicit_subagent).toBe("codex-sub-agent");
@@ -4421,7 +4473,10 @@ print(len(entries))
 
     // Default (no config.yaml) → inline banner.
     const defaultRun = JSON.parse(
-      runPython(codexHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        codexHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     expect(defaultRun.hookSpecificOutput.additionalContext).toContain(
       "<codex-mode>inline: the main session implements/checks directly; do not dispatch implement/check sub-agents.</codex-mode>",
@@ -4430,7 +4485,10 @@ print(len(entries))
     // Explicit sub-agent → sub-agent banner.
     writeConfigYaml("codex:\n  dispatch_mode: sub-agent\n");
     const subAgentRun = JSON.parse(
-      runPython(codexHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        codexHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     expect(subAgentRun.hookSpecificOutput.additionalContext).toContain(
       "<codex-mode>sub-agent: implement/check work defaults to Trellis sub-agents; the main session still coordinates, clarifies, updates specs, commits, and finishes.</codex-mode>",
@@ -4457,7 +4515,10 @@ print(len(entries))
     writeConfigYaml("codex:\n  dispatch_mode: inline\n");
 
     const result = JSON.parse(
-      runPython(claudeHookPath, JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" })),
+      runPython(
+        claudeHookPath,
+        JSON.stringify({ cwd: tmpDir, session_id: "workflow-a" }),
+      ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     expect(result.hookSpecificOutput.additionalContext).not.toContain(
       "<codex-mode>",
@@ -5227,8 +5288,7 @@ describe("regression: collectTemplates paths match init directory structure (0.3
     const keys = [...templates.keys()];
     for (const key of keys) {
       expect(
-        key.startsWith(".devin/workflows/") ||
-          key.startsWith(".devin/skills/"),
+        key.startsWith(".devin/workflows/") || key.startsWith(".devin/skills/"),
         `devin path should use workflows/ or skills/: ${key}`,
       ).toBe(true);
     }
@@ -5472,10 +5532,11 @@ describe("regression: class-2 platforms use pull-based sub-agent context", () =>
         // stay prelude-free so the injector is the single source.
         for (const file of preludeAgents) {
           const content = fs.readFileSync(path.join(tmpDir, file), "utf-8");
-          const occurrences = content.split(
-            "Required: Load Trellis Context First",
-          ).length - 1;
-          expect(occurrences, `${file} should have exactly one prelude`).toBe(1);
+          const occurrences =
+            content.split("Required: Load Trellis Context First").length - 1;
+          expect(occurrences, `${file} should have exactly one prelude`).toBe(
+            1,
+          );
         }
       });
 
@@ -5923,10 +5984,14 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
       "inject-shell-session-context.py",
     ];
     for (const name of sharedHookTargets) {
-      const script = getSharedHookScripts().find((h) => h.name === name)?.content;
+      const script = getSharedHookScripts().find(
+        (h) => h.name === name,
+      )?.content;
       expect(script, `shared-hooks/${name} should exist`).toBeTruthy();
       expect(script).toContain('os.environ.get("TRELLIS_HOOKS") == "0"');
-      expect(script).toContain('os.environ.get("TRELLIS_DISABLE_HOOKS") == "1"');
+      expect(script).toContain(
+        'os.environ.get("TRELLIS_DISABLE_HOOKS") == "1"',
+      );
     }
 
     // Platform-specific Python session-start variants (codex, copilot)
@@ -5934,10 +5999,14 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
       ["codex", getCodexHooks()],
       ["copilot", getCopilotHooks()],
     ] as const) {
-      const sessionStart = hooks.find((h) => h.name === "session-start.py")?.content;
+      const sessionStart = hooks.find(
+        (h) => h.name === "session-start.py",
+      )?.content;
       expect(sessionStart, `${label} session-start should exist`).toBeTruthy();
       expect(sessionStart).toContain('os.environ.get("TRELLIS_HOOKS") == "0"');
-      expect(sessionStart).toContain('os.environ.get("TRELLIS_DISABLE_HOOKS") == "1"');
+      expect(sessionStart).toContain(
+        'os.environ.get("TRELLIS_DISABLE_HOOKS") == "1"',
+      );
     }
 
     // OpenCode JS plugins (no TS export — read from disk)
@@ -5951,7 +6020,10 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
       "inject-subagent-context.js",
     ];
     for (const name of jsPlugins) {
-      const content = fs.readFileSync(path.join(openCodePluginDir, name), "utf-8");
+      const content = fs.readFileSync(
+        path.join(openCodePluginDir, name),
+        "utf-8",
+      );
       expect(content).toContain('process.env.TRELLIS_HOOKS === "0"');
       expect(content).toContain('process.env.TRELLIS_DISABLE_HOOKS === "1"');
     }
@@ -5971,9 +6043,7 @@ describe("regression: Gemini CLI 0.40.x template compatibility (#224)", () => {
     );
     // Must check for command-as-skill markers, not the bare
     // `.agents/skills/` prefix.
-    expect(updateSrc).toMatch(
-      /\.agents\/skills\/trellis-continue\/SKILL\.md/,
-    );
+    expect(updateSrc).toMatch(/\.agents\/skills\/trellis-continue\/SKILL\.md/);
     expect(updateSrc).toMatch(
       /\.agents\/skills\/trellis-finish-work\/SKILL\.md/,
     );
@@ -6010,7 +6080,8 @@ describe("regression: session-start.py f-string Python <=3.11 compat (0.5.2)", (
   ];
   // Match an f-string (f"..." or f'...') whose `{...}` body contains a `\`.
   // Backslash inside expression part is illegal under PEP 498.
-  const F_STRING_BACKSLASH = /f(?:"[^"\n]*\{[^}\n]*\\[^}\n]*\}[^"\n]*"|'[^'\n]*\{[^}\n]*\\[^}\n]*\}[^'\n]*')/;
+  const F_STRING_BACKSLASH =
+    /f(?:"[^"\n]*\{[^}\n]*\\[^}\n]*\}[^"\n]*"|'[^'\n]*\{[^}\n]*\\[^}\n]*\}[^'\n]*')/;
 
   for (const rel of HOOK_FILES) {
     it(`${rel} has no backslash inside any f-string expression part`, () => {
@@ -6038,7 +6109,8 @@ describe("regression: session-start.py f-string Python <=3.11 compat (0.5.2)", (
       );
       // If python3 is unavailable on the runner, skip silently — the regex
       // assertion above already covers the regression deterministically.
-      if (r.error && (r.error as NodeJS.ErrnoException).code === "ENOENT") return;
+      if (r.error && (r.error as NodeJS.ErrnoException).code === "ENOENT")
+        return;
       expect(
         r.status,
         `python3 ast.parse failed for ${rel}:\n${r.stderr ?? ""}`,
@@ -6079,17 +6151,61 @@ describe("regression: sub-agent context injection fallback (0.5.3)", () => {
 
   // 5 markdown class-1 platforms × 2 agents = 10 markdown files.
   // Kiro is a JSON file (separate test below).
-  const CLASS1_MD_AGENT_FILES: { platform: string; rel: string; agent: "implement" | "check" }[] = [
-    { platform: "claude", rel: "packages/cli/src/templates/claude/agents/trellis-implement.md", agent: "implement" },
-    { platform: "claude", rel: "packages/cli/src/templates/claude/agents/trellis-check.md", agent: "check" },
-    { platform: "cursor", rel: "packages/cli/src/templates/cursor/agents/trellis-implement.md", agent: "implement" },
-    { platform: "cursor", rel: "packages/cli/src/templates/cursor/agents/trellis-check.md", agent: "check" },
-    { platform: "codebuddy", rel: "packages/cli/src/templates/codebuddy/agents/trellis-implement.md", agent: "implement" },
-    { platform: "codebuddy", rel: "packages/cli/src/templates/codebuddy/agents/trellis-check.md", agent: "check" },
-    { platform: "opencode", rel: "packages/cli/src/templates/opencode/agents/trellis-implement.md", agent: "implement" },
-    { platform: "opencode", rel: "packages/cli/src/templates/opencode/agents/trellis-check.md", agent: "check" },
-    { platform: "droid", rel: "packages/cli/src/templates/droid/droids/trellis-implement.md", agent: "implement" },
-    { platform: "droid", rel: "packages/cli/src/templates/droid/droids/trellis-check.md", agent: "check" },
+  const CLASS1_MD_AGENT_FILES: {
+    platform: string;
+    rel: string;
+    agent: "implement" | "check";
+  }[] = [
+    {
+      platform: "claude",
+      rel: "packages/cli/src/templates/claude/agents/trellis-implement.md",
+      agent: "implement",
+    },
+    {
+      platform: "claude",
+      rel: "packages/cli/src/templates/claude/agents/trellis-check.md",
+      agent: "check",
+    },
+    {
+      platform: "cursor",
+      rel: "packages/cli/src/templates/cursor/agents/trellis-implement.md",
+      agent: "implement",
+    },
+    {
+      platform: "cursor",
+      rel: "packages/cli/src/templates/cursor/agents/trellis-check.md",
+      agent: "check",
+    },
+    {
+      platform: "codebuddy",
+      rel: "packages/cli/src/templates/codebuddy/agents/trellis-implement.md",
+      agent: "implement",
+    },
+    {
+      platform: "codebuddy",
+      rel: "packages/cli/src/templates/codebuddy/agents/trellis-check.md",
+      agent: "check",
+    },
+    {
+      platform: "opencode",
+      rel: "packages/cli/src/templates/opencode/agents/trellis-implement.md",
+      agent: "implement",
+    },
+    {
+      platform: "opencode",
+      rel: "packages/cli/src/templates/opencode/agents/trellis-check.md",
+      agent: "check",
+    },
+    {
+      platform: "droid",
+      rel: "packages/cli/src/templates/droid/droids/trellis-implement.md",
+      agent: "implement",
+    },
+    {
+      platform: "droid",
+      rel: "packages/cli/src/templates/droid/droids/trellis-check.md",
+      agent: "check",
+    },
   ];
 
   const __dirnameFb = path.dirname(fileURLToPath(import.meta.url));
@@ -6115,7 +6231,8 @@ describe("regression: sub-agent context injection fallback (0.5.3)", () => {
       expect(content).toContain("Active task:");
       // 4. Tells AI which task files to Read in fallback path
       expectTaskArtifactContract(content);
-      const expectedJsonl = agent === "implement" ? "implement.jsonl" : "check.jsonl";
+      const expectedJsonl =
+        agent === "implement" ? "implement.jsonl" : "check.jsonl";
       expect(content).toContain(expectedJsonl);
     });
   }
@@ -6133,7 +6250,8 @@ describe("regression: sub-agent context injection fallback (0.5.3)", () => {
       expect(prompt).toContain("Trellis Context Loading Protocol");
       expect(prompt).toContain("Active task:");
       expectTaskArtifactContract(prompt);
-      const expectedJsonl = agent === "implement" ? "implement.jsonl" : "check.jsonl";
+      const expectedJsonl =
+        agent === "implement" ? "implement.jsonl" : "check.jsonl";
       expect(prompt).toContain(expectedJsonl);
     });
   }
@@ -6155,7 +6273,10 @@ describe("regression: sub-agent context injection fallback (0.5.3)", () => {
   for (const agent of ["implement", "check"] as const) {
     it(`pi/${agent} agent references task artifacts`, () => {
       const content = fs.readFileSync(
-        path.join(repoRootFb, `packages/cli/src/templates/pi/agents/trellis-${agent}.md`),
+        path.join(
+          repoRootFb,
+          `packages/cli/src/templates/pi/agents/trellis-${agent}.md`,
+        ),
         "utf-8",
       );
       expectTaskArtifactContract(content);
@@ -6181,10 +6302,18 @@ describe("regression: sub-agent context injection fallback (0.5.3)", () => {
         hooks?: unknown;
       };
 
-      expect(data.prompt, `${agent}: prompt field present`).toBeTypeOf("string");
-      expect(data.instructions, `${agent}: instructions field removed`).toBeUndefined();
+      expect(data.prompt, `${agent}: prompt field present`).toBeTypeOf(
+        "string",
+      );
+      expect(
+        data.instructions,
+        `${agent}: instructions field removed`,
+      ).toBeUndefined();
       expect(Array.isArray(data.tools), `${agent}: tools is array`).toBe(true);
-      expect(Array.isArray(data.allowedTools), `${agent}: allowedTools is array`).toBe(true);
+      expect(
+        Array.isArray(data.allowedTools),
+        `${agent}: allowedTools is array`,
+      ).toBe(true);
 
       // hooks must be an OBJECT keyed by event name, not an array.
       expect(
@@ -6269,22 +6398,21 @@ describe("regression: configSectionsAdded (issue-codex-dispatch-mode)", () => {
   });
 
   it("[config-sections] applyConfigSectionsAdded appends section when sentinel missing, idempotent on rerun", async () => {
-    const { applyConfigSectionsAdded } = await import(
-      "../src/commands/update.js"
-    );
+    const { applyConfigSectionsAdded } =
+      await import("../src/commands/update.js");
     const trellisDir = path.join(tmpDir, ".trellis");
     fs.mkdirSync(trellisDir, { recursive: true });
     const userConfigPath = path.join(trellisDir, "config.yaml");
     const userConfig = [
       "# Trellis Configuration",
-      "session_commit_message: \"chore: record journal\"",
+      'session_commit_message: "chore: record journal"',
       "",
     ].join("\n");
     fs.writeFileSync(userConfigPath, userConfig);
 
     const bundledTemplate = [
       "# Trellis Configuration",
-      "session_commit_message: \"chore: record journal\"",
+      'session_commit_message: "chore: record journal"',
       "",
       "#-------------------------------------------------------------------------------",
       "# Codex (sub-agent dispatch behavior)",
@@ -6320,9 +6448,8 @@ describe("regression: configSectionsAdded (issue-codex-dispatch-mode)", () => {
   });
 
   it("[config-sections] applyConfigSectionsAdded skips when target file does not exist", async () => {
-    const { applyConfigSectionsAdded } = await import(
-      "../src/commands/update.js"
-    );
+    const { applyConfigSectionsAdded } =
+      await import("../src/commands/update.js");
     const result = applyConfigSectionsAdded(
       [
         {
@@ -6486,20 +6613,29 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
       ".trellis/.developer",
       "name=test-dev\ninitialized_at=2026-05-09T00:00:00\n",
     );
-    writeFile(".trellis/workspace/test-dev/journal-1.md",
+    writeFile(
+      ".trellis/workspace/test-dev/journal-1.md",
       "# Journal - test-dev (Part 1)\n\n---\n",
     );
     writeWorkspaceIndex();
     // Ignored caches/backups must exist on disk to prove they don't get
     // staged when -f is forced on specific paths.
-    writeFile(".trellis/.backup-2026-05-09/should-not-be-committed.txt",
+    writeFile(
+      ".trellis/.backup-2026-05-09/should-not-be-committed.txt",
       "secret-backup\n",
     );
-    writeFile(".trellis/worktrees/wt-a/should-not-be-committed.txt",
+    writeFile(
+      ".trellis/worktrees/wt-a/should-not-be-committed.txt",
       "secret-worktree\n",
     );
-    writeFile(".trellis/.template-hashes.json", '{"_": "should-not-be-committed"}\n');
-    writeFile(".trellis/.runtime/sessions/should-not-be-committed.json", "{}\n");
+    writeFile(
+      ".trellis/.template-hashes.json",
+      '{"_": "should-not-be-committed"}\n',
+    );
+    writeFile(
+      ".trellis/.runtime/sessions/should-not-be-committed.json",
+      "{}\n",
+    );
 
     if (options?.gitignoreTrellis) {
       writeFile(".gitignore", ".trellis/\n");
@@ -6573,9 +6709,7 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
       ),
     ).toBe(true);
     expect(
-      fs.existsSync(
-        path.join(tmpDir, ".trellis/workspace/test-dev/index.md"),
-      ),
+      fs.existsSync(path.join(tmpDir, ".trellis/workspace/test-dev/index.md")),
     ).toBe(true);
   });
 
@@ -6621,21 +6755,12 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
     );
     writeFile(".trellis/tasks/issue-500/prd.md", "# PRD\n");
 
-    const taskScriptPath = path.join(
-      tmpDir,
-      ".trellis",
-      "scripts",
-      "task.py",
-    );
-    const result = spawnSync(
-      pyCmd,
-      [taskScriptPath, "archive", "issue-500"],
-      {
-        cwd: tmpDir,
-        encoding: "utf-8",
-        env: { ...process.env, TRELLIS_CONTEXT_ID: "session-arch" },
-      },
-    );
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(pyCmd, [taskScriptPath, "archive", "issue-500"], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+      env: { ...process.env, TRELLIS_CONTEXT_ID: "session-arch" },
+    });
     const stderr = result.stderr ?? "";
     // 0.5.11: must NOT retry with -f, must NOT auto-commit. Warning must
     // surface so the user knows their .gitignore won.
@@ -6657,11 +6782,7 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
     const archiveExists = fs
       .readdirSync(path.join(tmpDir, ".trellis/tasks/archive"))
       .some((monthDir) => {
-        const monthPath = path.join(
-          tmpDir,
-          ".trellis/tasks/archive",
-          monthDir,
-        );
+        const monthPath = path.join(tmpDir, ".trellis/tasks/archive", monthDir);
         return (
           fs.statSync(monthPath).isDirectory() &&
           fs.existsSync(path.join(monthPath, "issue-500"))
@@ -6724,21 +6845,12 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
     );
     writeFile(".trellis/tasks/issue-600/prd.md", "# PRD\n");
 
-    const taskScriptPath = path.join(
-      tmpDir,
-      ".trellis",
-      "scripts",
-      "task.py",
-    );
-    const result = spawnSync(
-      pyCmd,
-      [taskScriptPath, "archive", "issue-600"],
-      {
-        cwd: tmpDir,
-        encoding: "utf-8",
-        env: { ...process.env, TRELLIS_CONTEXT_ID: "session-arch-2" },
-      },
-    );
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(pyCmd, [taskScriptPath, "archive", "issue-600"], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+      env: { ...process.env, TRELLIS_CONTEXT_ID: "session-arch-2" },
+    });
     const stderr = result.stderr ?? "";
     expect(stderr).not.toContain("Auto-committed");
     expect(stderr).toContain("session_auto_commit: false");
@@ -6753,11 +6865,7 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
     const archiveExists = fs
       .readdirSync(path.join(tmpDir, ".trellis/tasks/archive"))
       .some((monthDir) => {
-        const monthPath = path.join(
-          tmpDir,
-          ".trellis/tasks/archive",
-          monthDir,
-        );
+        const monthPath = path.join(tmpDir, ".trellis/tasks/archive", monthDir);
         return (
           fs.statSync(monthPath).isDirectory() &&
           fs.existsSync(path.join(monthPath, "issue-600"))
@@ -6771,9 +6879,7 @@ describe("regression: safe auto-commit when .trellis/ is gitignored (0.5.10 → 
     // common/config.py because parse_simple_yaml didn't strip ` #`. This
     // verifies the helper is shared with trellis_config.py's parser.
     setupRepo({ gitignoreTrellis: false });
-    writeConfigYaml(
-      "session_auto_commit: false  # disable for this project\n",
-    );
+    writeConfigYaml("session_auto_commit: false  # disable for this project\n");
 
     const { stderr } = runAddSession();
     expect(stderr).toContain("session_auto_commit: false");

--- a/packages/cli/test/scripts/add-session.integration.test.ts
+++ b/packages/cli/test/scripts/add-session.integration.test.ts
@@ -74,26 +74,35 @@ function setupRepo(tmp: string): void {
   }
 }
 
-function makeTask(repo: string, name: string, prdBody: string): void {
+function makeTask(
+  repo: string,
+  name: string,
+  prdBody: string,
+  branch?: string,
+): void {
   const dir = path.join(repo, ".trellis", "tasks", name);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, "prd.md"), prdBody);
+  const taskJson: Record<string, unknown> = {
+    id: name,
+    name,
+    title: name,
+    status: "in_progress",
+    priority: "P2",
+    createdAt: "2026-06-18",
+    assignee: DEVELOPER,
+    creator: DEVELOPER,
+    subtasks: [],
+    children: [],
+    relatedFiles: [],
+    meta: {},
+  };
+  if (branch) {
+    taskJson.branch = branch;
+  }
   fs.writeFileSync(
     path.join(dir, "task.json"),
-    JSON.stringify({
-      id: name,
-      name,
-      title: name,
-      status: "in_progress",
-      priority: "P2",
-      createdAt: "2026-06-18",
-      assignee: DEVELOPER,
-      creator: DEVELOPER,
-      subtasks: [],
-      children: [],
-      relatedFiles: [],
-      meta: {},
-    }) + "\n",
+    JSON.stringify(taskJson) + "\n",
   );
 }
 
@@ -103,12 +112,7 @@ function makeTask(repo: string, name: string, prdBody: string): void {
  * `get_current_task` returns this task without needing a platform context.
  */
 function setCurrentTask(repo: string, taskName: string): void {
-  const sessionsDir = path.join(
-    repo,
-    ".trellis",
-    ".runtime",
-    "sessions",
-  );
+  const sessionsDir = path.join(repo, ".trellis", ".runtime", "sessions");
   fs.mkdirSync(sessionsDir, { recursive: true });
   fs.writeFileSync(
     path.join(sessionsDir, "session.json"),
@@ -194,10 +198,36 @@ describe.skipIf(!hasPython())("add_session.py auto-commit", () => {
     expect(journal).toContain(
       "- Detailed change bullets were not supplied; see the summary above.",
     );
-    expect(journal).toContain("- Validation was not recorded for this session.");
+    expect(journal).toContain(
+      "- Validation was not recorded for this session.",
+    );
     expect(journal).not.toContain("(Add details)");
     expect(journal).not.toContain("(Add test results)");
     expect(journal).not.toContain("(Add summary)");
+  });
+
+  it("falls back to the current checkout branch when task.json branch is stale", () => {
+    makeTask(tmp, "task-a", "task A prd\n", "deleted-task-branch");
+    setCurrentTask(tmp, "task-a");
+    git(tmp, "add", "-A");
+    git(tmp, "commit", "-q", "-m", "initial");
+
+    runAddSession(tmp, "stale branch work");
+
+    const journal = fs.readFileSync(
+      path.join(tmp, ".trellis", "workspace", DEVELOPER, "journal-1.md"),
+      "utf-8",
+    );
+    const index = fs.readFileSync(
+      path.join(tmp, ".trellis", "workspace", DEVELOPER, "index.md"),
+      "utf-8",
+    );
+
+    expect(journal).toContain("**Branch**: `main`");
+    expect(index).toContain("| 1 |");
+    expect(index).toContain("| `main` |");
+    expect(journal).not.toContain("deleted-task-branch");
+    expect(index).not.toContain("deleted-task-branch");
   });
 
   it("does not wide-scan task dirs when the current task is unresolvable (>=2 sessions)", () => {
@@ -229,7 +259,13 @@ describe.skipIf(!hasPython())("add_session.py auto-commit", () => {
 
     runAddSession(tmp, "ambiguous-session work");
 
-    const lastFiles = git(tmp, "show", "HEAD", "--name-only", "--pretty=format:")
+    const lastFiles = git(
+      tmp,
+      "show",
+      "HEAD",
+      "--name-only",
+      "--pretty=format:",
+    )
       .split("\n")
       .map((s) => s.trim())
       .filter(Boolean);


### PR DESCRIPTION
## Summary
- validate active task task.json branch before using it for session journal/index branch stamps
- fall back to the current checkout branch when the task branch is stale
- add an add_session.py regression test for stale task branch handling

Fixes #398.

## Verification
- pnpm exec vitest run test/scripts/add-session.integration.test.ts
- pnpm --filter @mindfoldhq/trellis lint
- pnpm --filter @mindfoldhq/trellis typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session creation now resolves the session “branch” more reliably by preferring an explicit option, then using `task.json` only when it matches an existing local or remote ref, otherwise falling back to the current checkout branch.
  * If no usable branch can be determined, the session is created without a branch rather than using stale information.
  * Enhanced journal output to avoid displaying outdated branch names and to include clearer validation messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->