### PR TITLE
fix(cli): improve task create hygiene

### DIFF
--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -290,11 +290,21 @@ def cmd_create(args: argparse.Namespace) -> int:
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
 
+    description = (args.description or "").strip()
+    if not description.strip():
+        print(
+            colored(
+                "warning: task description is empty; pass --description to improve search and later audits.",
+                Colors.YELLOW,
+            ),
+            file=sys.stderr,
+        )
+
     task_data = {
         "id": slug,
         "name": slug,
         "title": args.title,
-        "description": args.description or "",
+        "description": description,
         "status": "planning",
         "dev_type": None,
         "scope": None,
@@ -322,7 +332,7 @@ def cmd_create(args: argparse.Namespace) -> int:
     prd_path = task_dir / "prd.md"
     if not prd_path.exists():
         prd_path.write_text(
-            _default_prd_content(args.title, args.description),
+            _default_prd_content(args.title, description),
             encoding="utf-8",
         )
 
@@ -365,16 +375,31 @@ def cmd_create(args: argparse.Namespace) -> int:
     # outside an AI session) — the task is still created, the user can run
     # task.py start later. Pointer is session-scoped so this never affects
     # other AI sessions.
-    try:
-        from .active_task import resolve_context_key, set_active_task
-        if resolve_context_key():
-            try:
-                rel_dir = task_dir.relative_to(repo_root).as_posix()
-            except ValueError:
-                rel_dir = str(task_dir)
-            set_active_task(rel_dir, repo_root)
-    except Exception:
-        pass
+    if getattr(args, "no_start", False):
+        print(
+            colored(
+                "Skipped session activation (--no-start); run task.py start when ready.",
+                Colors.YELLOW,
+            ),
+            file=sys.stderr,
+        )
+    else:
+        try:
+            from .active_task import resolve_context_key, set_active_task
+            if resolve_context_key():
+                try:
+                    rel_dir = task_dir.relative_to(repo_root).as_posix()
+                except ValueError:
+                    rel_dir = str(task_dir)
+                active = set_active_task(rel_dir, repo_root)
+                if active:
+                    print(
+                        colored(f"Activated task for this session: {active.task_path}", Colors.GREEN),
+                        file=sys.stderr,
+                    )
+                    print(f"Source: {active.source}", file=sys.stderr)
+        except Exception:
+            pass
 
     print(colored(f"Created task: {dir_name}", Colors.GREEN), file=sys.stderr)
     print("", file=sys.stderr)

--- a/.trellis/scripts/task.py
+++ b/.trellis/scripts/task.py
@@ -4,7 +4,7 @@
 Task Management Script.
 
 Usage:
-    python3 task.py create "<title>" [--slug <name>] [--assignee <dev>] [--priority P0|P1|P2|P3] [--parent <dir>] [--package <pkg>]
+    python3 task.py create "<title>" [--slug <name>] [--assignee <dev>] [--priority P0|P1|P2|P3] [--parent <dir>] [--package <pkg>] [--no-start]
     python3 task.py add-context <dir> <file> <path> [reason] # Add jsonl entry
     python3 task.py validate <dir>              # Validate jsonl files
     python3 task.py list-context <dir>          # List jsonl entries
@@ -307,6 +307,7 @@ Usage:
   python3 task.py create <title>                     Create new task directory
   python3 task.py create <title> --package <pkg>     Create task for a specific package
   python3 task.py create <title> --parent <dir>      Create task as child of parent
+  python3 task.py create <title> --no-start          Create without making it active in this session
   python3 task.py add-context <dir> <jsonl> <path> [reason]  Add entry to jsonl
   python3 task.py validate <dir>                     Validate jsonl files
   python3 task.py list-context <dir>                 List jsonl entries
@@ -398,6 +399,11 @@ def main() -> int:
     p_create.add_argument("--description", "-d", help="Task description")
     p_create.add_argument("--parent", help="Parent task directory (establishes subtask link)")
     p_create.add_argument("--package", help="Package name for monorepo projects")
+    p_create.add_argument(
+        "--no-start",
+        action="store_true",
+        help="Create the task without making it active in this session",
+    )
 
     # add-context
     p_add = subparsers.add_parser("add-context", help="Add context entry")

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -367,7 +367,7 @@ a `.current-task` fallback or a Python hook directory.
 
 ##### 2. Signatures
 
-- `python3 .trellis/scripts/task.py create "<title>" [--slug <slug>]`
+- `python3 .trellis/scripts/task.py create "<title>" [--slug <slug>] [--description <text>] [--no-start]`
 - `python3 .trellis/scripts/task.py start <task-dir>`
 - `python3 .trellis/scripts/task.py current [--source]`
 - `python3 .trellis/scripts/task.py finish`
@@ -377,12 +377,24 @@ a `.current-task` fallback or a Python hook directory.
 
 ##### 3. Contracts
 
-- `task.py create` creates only task-owned files under
-  `.trellis/tasks/<date-slug>/`. It must not create `.trellis/.runtime/` and
-  must not write `.trellis/.current-task`.
+- `task.py create` always creates task-owned files under
+  `.trellis/tasks/<date-slug>/`. It must never write `.trellis/.current-task`.
+- `task.py create` normalizes `--description` with `.strip()` before writing
+  `task.json` and `prd.md`. Missing or whitespace-only descriptions are stored
+  as `""` and emit a warning on stderr.
+- Unless `--no-start` is passed, `task.py create` best-effort activates the new
+  task for the current session when a context key is available. This writes
+  `.trellis/.runtime/sessions/<session-key>.json` and prints both the activated
+  task and `Source: session:<key>` on stderr.
+- `task.py create --no-start` must not change any session pointer, even when a
+  context key is available. It prints a skip notice and leaves existing session
+  runtime state untouched.
+- `task.py create` without a context key creates the task and does not create
+  `.trellis/.runtime/`.
 - `task.py start` writes session-local state only when a context key is
-  available. Otherwise it exits non-zero and must not write
-  `.trellis/.current-task`.
+  available. Otherwise it enters degraded mode: no session pointer is persisted,
+  `.trellis/.current-task` is not written, and `task.json.status` may still move
+  from `planning` to `in_progress`.
 - Session state is stored at
   `.trellis/.runtime/sessions/<session-key>.json`. The runtime directory is
   created lazily by the JSON write path.
@@ -406,8 +418,11 @@ a `.current-task` fallback or a Python hook directory.
 
 | Condition | Required behavior |
 |-----------|-------------------|
-| `create` succeeds | Task files exist; no `.runtime`; no `.current-task` |
-| `start` without context key | Fails; no `.runtime`; no `.current-task`; hints IDE/session identity or `TRELLIS_CONTEXT_ID` |
+| `create` without description or with whitespace-only description | Warns on stderr; stores `task.json.description == ""`; initial `prd.md` goal falls back to `TBD.` |
+| `create` with context key, default mode | Task files exist; session runtime points at the new task; activation and source are printed; no `.current-task` |
+| `create --no-start` with context key | Task files exist; existing session runtime is unchanged; skip notice is printed; no `.current-task` |
+| `create` without context key | Task files exist; no `.runtime`; no `.current-task` |
+| `start` without context key | Returns success in degraded mode; no `.runtime`; no `.current-task`; hints IDE/session identity or `TRELLIS_CONTEXT_ID` |
 | `start` with `TRELLIS_CONTEXT_ID` | Writes `.runtime/sessions/<key>.json`; does not require `.current-task` |
 | `current --source` with same context key | Prints `Source: session:<key>` |
 | `current --source` without context | Prints `(none)` and `Source: none` |
@@ -421,15 +436,23 @@ a `.current-task` fallback or a Python hook directory.
 - Good: Cursor provides `conversation_id`; resolver writes
   `cursor_<conversation-id>.json` and hook/plugin output includes the
   session source (statuslines shorten it to `[session]`).
-- Base: A normal shell command has no session env; `task.py start` fails with
-  a session identity hint and does not create `.current-task`.
-- Bad: `task.py create` pre-creates `.runtime`, or any resolver reads/writes
-  `.trellis/.current-task` as an active-task fallback.
+- Base: A normal shell command has no session env; `task.py create` creates the
+  task without `.runtime`, and `task.py start` degrades with a session identity
+  hint instead of writing `.current-task`.
+- Bad: `task.py create --no-start` changes an existing session pointer, or any
+  resolver reads/writes `.trellis/.current-task` as an active-task fallback.
 
 ##### 6. Tests Required
 
-- Regression tests for `create` producing no runtime/current-task state.
-- Regression tests for `start` without a context key failing without creating
+- Regression tests for `create` with a context key writing session runtime and
+  surfacing the session source.
+- Regression tests for `create --no-start` preserving an existing session
+  pointer.
+- Regression tests for blank and whitespace-only `--description` warning and
+  normalized `task.json.description`.
+- Regression tests for `create` without a context key producing no runtime or
+  current-task state.
+- Regression tests for `start` without a context key degrading without creating
   `.current-task`.
 - Regression tests for `TRELLIS_CONTEXT_ID` and platform-native env keys.
 - Hook/statusline/plugin tests proving the resolver source is surfaced.
@@ -441,19 +464,22 @@ a `.current-task` fallback or a Python hook directory.
 ###### Wrong
 
 ```python
-# Wrong: silently creates or deletes repo-global task state when no session
-# identity exists.
-if not resolve_context_key():
-    write_file(".trellis/.current-task", task_path)
+# Wrong: batch creation silently moves the current session pointer and gives no
+# escape hatch.
+set_active_task(task_path, repo_root)
+print(f"Created task: {dir_name}")
 ```
 
 ###### Correct
 
 ```python
-context_key = resolve_context_key(platform_input, platform)
-if not context_key:
-    return ActiveTask(None, "none")
-clear_session_context(context_key)
+if args.no_start:
+    print("Skipped session activation (--no-start)", file=sys.stderr)
+elif resolve_context_key():
+    active = set_active_task(task_path, repo_root)
+    if active:
+        print(f"Activated task for this session: {active.task_path}", file=sys.stderr)
+        print(f"Source: {active.source}", file=sys.stderr)
 ```
 
 ### `common/types.py` — Typed Data Model

--- a/.trellis/spec/cli/backend/workflow-state-contract.md
+++ b/.trellis/spec/cli/backend/workflow-state-contract.md
@@ -155,7 +155,7 @@ a new writer requires updating this spec.**
 
 | # | Writer | File:Line | Value | Trigger |
 |---|--------|-----------|-------|---------|
-| 1 | `cmd_create` | `packages/cli/src/templates/trellis/scripts/common/task_store.py:206` | `"planning"` | `task.py create "<title>"` (also auto-sets the session active-task pointer when session identity is available — see R7 in 04-30-workflow-state-commit-gap PRD) |
+| 1 | `cmd_create` | `packages/cli/src/templates/trellis/scripts/common/task_store.py:206` | `"planning"` | `task.py create "<title>"` (also visibly auto-sets the session active-task pointer when session identity is available; `--no-start` skips pointer movement for backlog batching — see R7 in 04-30-workflow-state-commit-gap PRD) |
 | 2 | `cmd_start` | `packages/cli/src/templates/trellis/scripts/task.py:114-115, 128-129` | `"in_progress"` (gated on prior `"planning"`; both branches in `cmd_start`) | `task.py start <dir>` |
 | 3 | `cmd_archive` | `packages/cli/src/templates/trellis/scripts/common/task_store.py:337` | `"completed"` (unconditional flip + archive `mv`) | `task.py archive <dir>` |
 | 4 | `emptyTaskJson` factory | `packages/cli/src/utils/task-json.ts:54` | `"planning"` (default) | TS callers (init, update) |

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -292,11 +292,21 @@ def cmd_create(args: argparse.Namespace) -> int:
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
 
+    description = (args.description or "").strip()
+    if not description.strip():
+        print(
+            colored(
+                "warning: task description is empty; pass --description to improve search and later audits.",
+                Colors.YELLOW,
+            ),
+            file=sys.stderr,
+        )
+
     task_data = {
         "id": slug,
         "name": slug,
         "title": args.title,
-        "description": args.description or "",
+        "description": description,
         "status": "planning",
         "dev_type": None,
         "scope": None,
@@ -324,7 +334,7 @@ def cmd_create(args: argparse.Namespace) -> int:
     prd_path = task_dir / "prd.md"
     if not prd_path.exists():
         prd_path.write_text(
-            _default_prd_content(args.title, args.description),
+            _default_prd_content(args.title, description),
             encoding="utf-8",
         )
 
@@ -367,16 +377,31 @@ def cmd_create(args: argparse.Namespace) -> int:
     # outside an AI session) — the task is still created, the user can run
     # task.py start later. Pointer is session-scoped so this never affects
     # other AI sessions.
-    try:
-        from .active_task import resolve_context_key, set_active_task
-        if resolve_context_key():
-            try:
-                rel_dir = task_dir.relative_to(repo_root).as_posix()
-            except ValueError:
-                rel_dir = str(task_dir)
-            set_active_task(rel_dir, repo_root)
-    except Exception:
-        pass
+    if getattr(args, "no_start", False):
+        print(
+            colored(
+                "Skipped session activation (--no-start); run task.py start when ready.",
+                Colors.YELLOW,
+            ),
+            file=sys.stderr,
+        )
+    else:
+        try:
+            from .active_task import resolve_context_key, set_active_task
+            if resolve_context_key():
+                try:
+                    rel_dir = task_dir.relative_to(repo_root).as_posix()
+                except ValueError:
+                    rel_dir = str(task_dir)
+                active = set_active_task(rel_dir, repo_root)
+                if active:
+                    print(
+                        colored(f"Activated task for this session: {active.task_path}", Colors.GREEN),
+                        file=sys.stderr,
+                    )
+                    print(f"Source: {active.source}", file=sys.stderr)
+        except Exception:
+            pass
 
     print(colored(f"Created task: {dir_name}", Colors.GREEN), file=sys.stderr)
     print("", file=sys.stderr)

--- a/packages/cli/src/templates/trellis/scripts/task.py
+++ b/packages/cli/src/templates/trellis/scripts/task.py
@@ -4,7 +4,7 @@
 Task Management Script.
 
 Usage:
-    python3 task.py create "<title>" [--slug <name>] [--assignee <dev>] [--priority P0|P1|P2|P3] [--parent <dir>] [--package <pkg>]
+    python3 task.py create "<title>" [--slug <name>] [--assignee <dev>] [--priority P0|P1|P2|P3] [--parent <dir>] [--package <pkg>] [--no-start]
     python3 task.py add-context <dir> <file> <path> [reason] # Add jsonl entry
     python3 task.py validate <dir>              # Validate jsonl files
     python3 task.py list-context <dir>          # List jsonl entries
@@ -307,6 +307,7 @@ Usage:
   python3 task.py create <title>                     Create new task directory
   python3 task.py create <title> --package <pkg>     Create task for a specific package
   python3 task.py create <title> --parent <dir>      Create task as child of parent
+  python3 task.py create <title> --no-start          Create without making it active in this session
   python3 task.py add-context <dir> <jsonl> <path> [reason]  Add entry to jsonl
   python3 task.py validate <dir>                     Validate jsonl files
   python3 task.py list-context <dir>                 List jsonl entries
@@ -398,6 +399,11 @@ def main() -> int:
     p_create.add_argument("--description", "-d", help="Task description")
     p_create.add_argument("--parent", help="Parent task directory (establishes subtask link)")
     p_create.add_argument("--package", help="Package name for monorepo projects")
+    p_create.add_argument(
+        "--no-start",
+        action="store_true",
+        help="Create the task without making it active in this session",
+    )
 
     # add-context
     p_add = subparsers.add_parser("add-context", help="Add context entry")

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -1537,6 +1537,111 @@ describe("regression: current-task path normalization", () => {
     expect(context.current_task).toBe(`.trellis/tasks/${taskDir}`);
   });
 
+  it("[issue-397] task.py create warns on blank description and reports session activation", () => {
+    writeTrellisScripts();
+    writeProjectFile(
+      path.join(".trellis", ".developer"),
+      "name=test-dev\ninitialized_at=2026-03-27T00:00:00\n",
+    );
+    writeProjectFile(path.join(".trellis", "workflow.md"), "# Workflow\n");
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(
+      pythonCmd,
+      [
+        taskScriptPath,
+        "create",
+        "blank description task",
+        "--slug",
+        "blank-description",
+        "--assignee",
+        "test-dev",
+      ],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ TRELLIS_CONTEXT_ID: "issue-397-session" }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("task description is empty");
+    expect(result.stderr).toContain("Activated task for this session");
+    expect(result.stderr).toContain("Source: session:issue-397-session");
+
+    const taskDir = fs
+      .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+      .find((d) => d.includes("blank-description"));
+    expect(taskDir).toBeDefined();
+    const taskJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "tasks", taskDir as string, "task.json"),
+        "utf-8",
+      ),
+    ) as { description: string };
+    expect(taskJson.description).toBe("");
+  });
+
+  it("[issue-397] task.py create --no-start does not move the session pointer", () => {
+    writeTrellisScripts();
+    writeProjectFile(
+      path.join(".trellis", ".developer"),
+      "name=test-dev\ninitialized_at=2026-03-27T00:00:00\n",
+    );
+    writeProjectFile(path.join(".trellis", "workflow.md"), "# Workflow\n");
+    writeSessionContext("batch-session", ".trellis/tasks/existing-task");
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(
+      pythonCmd,
+      [
+        taskScriptPath,
+        "create",
+        "batch backlog task",
+        "--slug",
+        "batch-backlog",
+        "--assignee",
+        "test-dev",
+        "--description",
+        "   ",
+        "--no-start",
+      ],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ TRELLIS_CONTEXT_ID: "batch-session" }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("Skipped session activation (--no-start)");
+    const context = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          tmpDir,
+          ".trellis",
+          ".runtime",
+          "sessions",
+          "batch-session.json",
+        ),
+        "utf-8",
+      ),
+    ) as { current_task: string };
+    expect(context.current_task).toBe(".trellis/tasks/existing-task");
+
+    const taskDir = fs
+      .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+      .find((d) => d.includes("batch-backlog"));
+    expect(taskDir).toBeDefined();
+    const taskJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "tasks", taskDir as string, "task.json"),
+        "utf-8",
+      ),
+    ) as { description: string };
+    expect(taskJson.description).toBe("");
+  });
+
   it("[workflow-state-r7] task.py create degrades silently without session identity (no .runtime side effect)", () => {
     // R7 contract: best-effort activation. No context key (CLI shell with no
     // session env) → task is still created, but no .runtime/sessions/ file is


### PR DESCRIPTION
## Summary
- warn when `task.py create` is called without a non-blank description
- make automatic session activation visible when `create` sets the active task
- add `task.py create --no-start` for backlog batch creation without moving the session pointer
- cover issue #397 with regression tests

Closes #397

## Tests
- `pnpm exec vitest run test/regression.test.ts -t "issue-397|workflow-state-r7"`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-start` option for `task.py create` to create tasks without activating them in the current session, with a clear notice to start later.
* **Bug Fixes**
  * Empty/whitespace-only `--description` values now warn and are consistently stored as `""`.
  * The normalized description is now used consistently for initial PRD content generation.
* **Documentation**
  * Updated `task.py` help/usage text to include `--no-start`.
* **Tests**
  * Added regression coverage for blank/whitespace descriptions, including `--no-start` behavior and session pointer preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->