### PR TITLE
fix(cli): skip jsonl seeds for codex inline

### DIFF
--- a/.trellis/scripts/common/config.py
+++ b/.trellis/scripts/common/config.py
@@ -167,6 +167,7 @@ def _next_content_line(lines: list[str], start: int) -> tuple[int, str]:
 DEFAULT_SESSION_COMMIT_MESSAGE = "chore: record journal"
 DEFAULT_MAX_JOURNAL_LINES = 2000
 DEFAULT_SESSION_AUTO_COMMIT = True
+DEFAULT_CODEX_DISPATCH_MODE = "inline"
 
 CONFIG_FILE = "config.yaml"
 
@@ -241,6 +242,34 @@ def get_session_auto_commit(repo_root: Path | None = None) -> bool:
         file=sys.stderr,
     )
     return DEFAULT_SESSION_AUTO_COMMIT
+
+
+def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
+    """Return Codex dispatch mode.
+
+    Default is ``inline``. ``sub-agent`` is an explicit opt-in because Codex
+    sub-agents do not inherit the parent session context.
+    """
+    config = _load_config(repo_root)
+    codex = config.get("codex")
+    if codex is None:
+        return DEFAULT_CODEX_DISPATCH_MODE
+    if not isinstance(codex, dict):
+        print(
+            f"[WARN] invalid codex config: {codex!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+            file=sys.stderr,
+        )
+        return DEFAULT_CODEX_DISPATCH_MODE
+
+    raw = codex.get("dispatch_mode", DEFAULT_CODEX_DISPATCH_MODE)
+    mode = str(raw).strip().lower()
+    if mode in ("inline", "sub-agent"):
+        return mode
+    print(
+        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+        file=sys.stderr,
+    )
+    return DEFAULT_CODEX_DISPATCH_MODE
 
 
 def get_hooks(event: str, repo_root: Path | None = None) -> list[str]:

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 
 from .config import (
+    get_codex_dispatch_mode,
     get_packages,
     get_session_auto_commit,
     is_monorepo,
@@ -113,13 +114,13 @@ def _repo_relative_path(path: Path, repo_root: Path) -> str:
 
 # Config directories of platforms that consume implement.jsonl / check.jsonl.
 # Keep in sync with src/types/ai-tools.ts AI_TOOLS entries — these are the
-# platforms listed in workflow.md's "agent-capable" Skill Routing block
-# (Class-1 hook-inject + Class-2 pull-based preludes). Kilo / Antigravity /
-# Devin are NOT in this list: they do not consume JSONL.
+# platforms listed in workflow.md's "agent-capable" Skill Routing block.
+# Codex is checked separately because default inline mode does not consume
+# JSONL. Kilo / Antigravity / Devin are NOT in this list either: they load
+# specs through skills instead of JSONL.
 _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
     ".claude",
     ".cursor",
-    ".codex",
     ".kiro",
     ".gemini",
     ".opencode",
@@ -130,6 +131,7 @@ _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
     ".pi",        # Pi Agent
     ".omp",       # Oh My Pi
 )
+_CODEX_CONFIG_DIR = ".codex"
 
 _SEED_EXAMPLE = (
     "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. "
@@ -142,13 +144,15 @@ _SEED_EXAMPLE = (
 def _has_subagent_platform(repo_root: Path) -> bool:
     """Return True if any sub-agent-capable platform is configured.
 
-    Detected by probing well-known config directories at the repo root. Used
-    only to decide whether ``task.py create`` should seed empty
-    ``implement.jsonl`` / ``check.jsonl`` files.
+    Detected by probing well-known config directories at the repo root. Codex
+    only counts when ``codex.dispatch_mode`` explicitly opts into
+    ``sub-agent``; inline mode loads context through skills, not JSONL.
     """
     for config_dir in _SUBAGENT_CONFIG_DIRS:
         if (repo_root / config_dir).is_dir():
             return True
+    if (repo_root / _CODEX_CONFIG_DIR).is_dir():
+        return get_codex_dispatch_mode(repo_root) == "sub-agent"
     return False
 
 

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -391,6 +391,11 @@ a `.current-task` fallback or a Python hook directory.
   runtime state untouched.
 - `task.py create` without a context key creates the task and does not create
   `.trellis/.runtime/`.
+- `task.py create` creates `implement.jsonl` / `check.jsonl` only when the
+  repo has a platform configured that consumes those files. `.codex/` is not
+  enough by itself: Codex defaults to `codex.dispatch_mode: inline`, which
+  loads context through skills. Codex seeds JSONL only when
+  `codex.dispatch_mode: sub-agent` is explicitly configured.
 - `task.py start` writes session-local state only when a context key is
   available. Otherwise it enters degraded mode: no session pointer is persisted,
   `.trellis/.current-task` is not written, and `task.json.status` may still move
@@ -422,6 +427,8 @@ a `.current-task` fallback or a Python hook directory.
 | `create` with context key, default mode | Task files exist; session runtime points at the new task; activation and source are printed; no `.current-task` |
 | `create --no-start` with context key | Task files exist; existing session runtime is unchanged; skip notice is printed; no `.current-task` |
 | `create` without context key | Task files exist; no `.runtime`; no `.current-task` |
+| `create` with `.codex/` and no `codex.dispatch_mode` override | Task files exist; no `implement.jsonl`; no `check.jsonl` |
+| `create` with `.codex/` and `codex.dispatch_mode: sub-agent` | Task files exist; `implement.jsonl` and `check.jsonl` contain seed `_example` rows |
 | `start` without context key | Returns success in degraded mode; no `.runtime`; no `.current-task`; hints IDE/session identity or `TRELLIS_CONTEXT_ID` |
 | `start` with `TRELLIS_CONTEXT_ID` | Writes `.runtime/sessions/<key>.json`; does not require `.current-task` |
 | `current --source` with same context key | Prints `Source: session:<key>` |
@@ -1313,6 +1320,10 @@ Two near-misses worth remembering:
 
 - `codex.dispatch_mode` originally had its own ad-hoc YAML reader. A
   `# default` comment on the user's config silently broke dispatch routing.
+- `task.py create` must read `codex.dispatch_mode` through
+  `get_codex_dispatch_mode()` before deciding whether `.codex/` should seed
+  `implement.jsonl` / `check.jsonl`. Missing or invalid values default to
+  `inline`, not `sub-agent`.
 - `session_auto_commit` (0.5.11) almost shipped with a one-line
   `config.get(...).strip()` reader before being routed through
   `get_session_auto_commit`.

--- a/packages/cli/src/templates/trellis/scripts/common/config.py
+++ b/packages/cli/src/templates/trellis/scripts/common/config.py
@@ -167,6 +167,7 @@ def _next_content_line(lines: list[str], start: int) -> tuple[int, str]:
 DEFAULT_SESSION_COMMIT_MESSAGE = "chore: record journal"
 DEFAULT_MAX_JOURNAL_LINES = 2000
 DEFAULT_SESSION_AUTO_COMMIT = True
+DEFAULT_CODEX_DISPATCH_MODE = "inline"
 
 CONFIG_FILE = "config.yaml"
 
@@ -241,6 +242,34 @@ def get_session_auto_commit(repo_root: Path | None = None) -> bool:
         file=sys.stderr,
     )
     return DEFAULT_SESSION_AUTO_COMMIT
+
+
+def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
+    """Return Codex dispatch mode.
+
+    Default is ``inline``. ``sub-agent`` is an explicit opt-in because Codex
+    sub-agents do not inherit the parent session context.
+    """
+    config = _load_config(repo_root)
+    codex = config.get("codex")
+    if codex is None:
+        return DEFAULT_CODEX_DISPATCH_MODE
+    if not isinstance(codex, dict):
+        print(
+            f"[WARN] invalid codex config: {codex!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+            file=sys.stderr,
+        )
+        return DEFAULT_CODEX_DISPATCH_MODE
+
+    raw = codex.get("dispatch_mode", DEFAULT_CODEX_DISPATCH_MODE)
+    mode = str(raw).strip().lower()
+    if mode in ("inline", "sub-agent"):
+        return mode
+    print(
+        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+        file=sys.stderr,
+    )
+    return DEFAULT_CODEX_DISPATCH_MODE
 
 
 def get_hooks(event: str, repo_root: Path | None = None) -> list[str]:

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 
 from .config import (
+    get_codex_dispatch_mode,
     get_packages,
     get_session_auto_commit,
     is_monorepo,
@@ -113,13 +114,13 @@ def _repo_relative_path(path: Path, repo_root: Path) -> str:
 
 # Config directories of platforms that consume implement.jsonl / check.jsonl.
 # Keep in sync with src/types/ai-tools.ts AI_TOOLS entries — these are the
-# platforms listed in workflow.md's "agent-capable" Skill Routing block
-# (Class-1 hook-inject + Class-2 pull-based preludes). Kilo / Antigravity /
-# Devin are NOT in this list: they do not consume JSONL.
+# platforms listed in workflow.md's "agent-capable" Skill Routing block.
+# Codex is checked separately because default inline mode does not consume
+# JSONL. Kilo / Antigravity / Devin are NOT in this list either: they load
+# specs through skills instead of JSONL.
 _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
     ".claude",
     ".cursor",
-    ".codex",
     ".kiro",
     ".gemini",
     ".opencode",
@@ -132,6 +133,7 @@ _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
     ".omp",       # Oh My Pi
     ".zcode",     # ZCode
 )
+_CODEX_CONFIG_DIR = ".codex"
 
 _SEED_EXAMPLE = (
     "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. "
@@ -144,13 +146,15 @@ _SEED_EXAMPLE = (
 def _has_subagent_platform(repo_root: Path) -> bool:
     """Return True if any sub-agent-capable platform is configured.
 
-    Detected by probing well-known config directories at the repo root. Used
-    only to decide whether ``task.py create`` should seed empty
-    ``implement.jsonl`` / ``check.jsonl`` files.
+    Detected by probing well-known config directories at the repo root. Codex
+    only counts when ``codex.dispatch_mode`` explicitly opts into
+    ``sub-agent``; inline mode loads context through skills, not JSONL.
     """
     for config_dir in _SUBAGENT_CONFIG_DIRS:
         if (repo_root / config_dir).is_dir():
             return True
+    if (repo_root / _CODEX_CONFIG_DIR).is_dir():
+        return get_codex_dispatch_mode(repo_root) == "sub-agent"
     return False
 
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -3532,6 +3532,57 @@ describe("regression: current-task path normalization", () => {
     }
   });
 
+  it("[issue-373] task.py create does NOT seed jsonl for Codex inline mode", () => {
+    setupTaskRepo();
+    fs.mkdirSync(path.join(tmpDir, ".codex"), { recursive: true });
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "codex inline task" --slug codex-inline-task --assignee test-dev`,
+      { cwd: tmpDir, encoding: "utf-8" },
+    );
+
+    const taskDir = path.join(
+      tmpDir,
+      ".trellis",
+      "tasks",
+      fs
+        .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+        .find((d) => d.includes("codex-inline-task")) as string,
+    );
+    expect(fs.existsSync(path.join(taskDir, "implement.jsonl"))).toBe(false);
+    expect(fs.existsSync(path.join(taskDir, "check.jsonl"))).toBe(false);
+  });
+
+  it("[issue-373] task.py create seeds jsonl when Codex explicitly uses sub-agent dispatch", () => {
+    setupTaskRepo();
+    fs.mkdirSync(path.join(tmpDir, ".codex"), { recursive: true });
+    writeProjectFile(
+      path.join(".trellis", "config.yaml"),
+      'codex:\n  dispatch_mode: sub-agent  # opt into trellis-* sub-agents\n',
+    );
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "codex subagent task" --slug codex-subagent-task --assignee test-dev`,
+      { cwd: tmpDir, encoding: "utf-8" },
+    );
+
+    const taskDir = path.join(
+      tmpDir,
+      ".trellis",
+      "tasks",
+      fs
+        .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+        .find((d) => d.includes("codex-subagent-task")) as string,
+    );
+    for (const jsonlName of ["implement.jsonl", "check.jsonl"]) {
+      const row = JSON.parse(
+        fs.readFileSync(path.join(taskDir, jsonlName), "utf-8").trim(),
+      ) as Record<string, unknown>;
+      expect(row._example).toBeDefined();
+      expect(row.file).toBeUndefined();
+    }
+  });
+
   it("[init-context-removal] task.py init-context is deprecated with clear pointer to planning artifacts", () => {
     setupTaskRepo();
     const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
@@ -4975,10 +5026,14 @@ describe("regression: cli_adapter platform support (beta.9, beta.13, beta.16)", 
     // Sub-agent platform probe.
     expect(taskStore as string).toMatch(/_SUBAGENT_CONFIG_DIRS/);
     expect(taskStore as string).toContain('".claude"');
-    expect(taskStore as string).toContain('".codex"');
     expect(taskStore as string).toContain('".github/copilot"');
     expect(taskStore as string).toContain('".pi"');
     expect(taskStore as string).toContain('".zcode"');
+    expect(taskStore as string).toContain('_CODEX_CONFIG_DIR = ".codex"');
+    expect(taskStore as string).toContain(
+      'get_codex_dispatch_mode(repo_root) == "sub-agent"',
+    );
+    expect(commonConfig).toContain("def get_codex_dispatch_mode");
     // Seed row is self-describing and has no `file` field (so consumers skip
     // it naturally).
     expect(taskStore as string).toMatch(/_write_seed_jsonl/);


### PR DESCRIPTION
## Summary
- Treat Codex inline mode as not consuming implement.jsonl/check.jsonl seeds
- Add get_codex_dispatch_mode() and require explicit codex.dispatch_mode: sub-agent before .codex triggers JSONL seeding
- Cover Codex inline vs sub-agent behavior in regression tests and document the task creation contract

Closes #373

## Verification
- pnpm exec vitest run test/regression.test.ts -t "issue-373|init-context-removal"
- pnpm --filter @mindfoldhq/trellis lint
- pnpm --filter @mindfoldhq/trellis typecheck
- pnpm --filter @mindfoldhq/trellis test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Codex dispatch mode, with clear handling for inline and sub-agent modes.

* **Bug Fixes**
  * Prevented seed task files from being created when Codex is set to inline mode.
  * Ensured seed task files are created only when Codex is explicitly configured for sub-agent dispatch.

* **Documentation**
  * Updated CLI guidance to reflect the new Codex configuration behavior.

* **Tests**
  * Added regression coverage for both Codex dispatch modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->