### PR TITLE
fix: close all 8 blocker findings from the 2026-07-10 audit (data-loss guards)

### DIFF
--- a/.trellis/scripts/common/io.py
+++ b/.trellis/scripts/common/io.py
@@ -8,6 +8,8 @@ for JSON file operations across all Trellis scripts.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 
@@ -25,13 +27,28 @@ def read_json(path: Path) -> dict | None:
 def write_json(path: Path, data: dict) -> bool:
     """Write dict to JSON file with pretty formatting.
 
+    The write is atomic: content goes to a temp file in the same directory
+    and is then renamed over the target. A crash or Ctrl-C mid-write leaves
+    the existing file intact rather than truncated, so a corrupted task.json
+    can never make a task silently vanish from `task.py list`.
+
     Returns True on success, False on error.
     """
+    payload = json.dumps(data, indent=2, ensure_ascii=False)
     try:
-        path.write_text(
-            json.dumps(data, indent=2, ensure_ascii=False),
-            encoding="utf-8",
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
         )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
         return True
     except (OSError, IOError):
         return False

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -51,6 +51,7 @@ from .safe_commit import (
 from .task_utils import (
     archive_task_complete,
     find_task_by_name,
+    is_within_tasks_dir,
     resolve_task_dir,
     run_task_hooks,
 )
@@ -451,6 +452,17 @@ def cmd_archive(args: argparse.Namespace) -> int:
         from .tasks import iter_active_tasks
         for t in iter_active_tasks(tasks_dir):
             print(f"  - {t.dir_name}/", file=sys.stderr)
+        return 1
+
+    # Refuse to archive anything that isn't a real task directly under
+    # .trellis/tasks/. A mistyped name (e.g. "src") resolves to repo_root/src,
+    # which is a dir but not a task — without this guard archive would move the
+    # user's source directory out of the repo.
+    if not is_within_tasks_dir(task_dir, repo_root):
+        print(colored(
+            f"Error: refusing to archive '{task_name}': "
+            f"{task_dir} is not a task under {tasks_dir}",
+            Colors.RED), file=sys.stderr)
         return 1
 
     dir_name = task_dir.name

--- a/.trellis/scripts/common/task_utils.py
+++ b/.trellis/scripts/common/task_utils.py
@@ -69,6 +69,28 @@ def is_safe_task_path(task_path: str, repo_root: Path | None = None) -> bool:
     return True
 
 
+def is_within_tasks_dir(task_dir_abs: Path, repo_root: Path | None = None) -> bool:
+    """Check that a resolved task directory really is a task under the tasks dir.
+
+    A real task lives directly at ``.trellis/tasks/<name>``. This returns True
+    only when ``task_dir_abs`` is an immediate child of the tasks directory.
+
+    Guards archive: ``resolve_task_dir`` falls back to ``repo_root/<name>`` for
+    an unknown name, so a mistyped ``task.py archive src`` resolves to the real
+    ``src/`` source directory. Without this check archive would ``shutil.move``
+    it out of the repo. Also rejects the tasks dir itself and anything nested
+    under ``archive/`` (already-archived tasks).
+    """
+    if repo_root is None:
+        repo_root = get_repo_root()
+    try:
+        resolved = task_dir_abs.resolve()
+        tasks_resolved = get_tasks_dir(repo_root).resolve()
+    except (OSError, RuntimeError):
+        return False
+    return resolved.parent == tasks_resolved
+
+
 # =============================================================================
 # Task Lookup
 # =============================================================================

--- a/.trellis/spec/cli/backend/commands-channel.md
+++ b/.trellis/spec/cli/backend/commands-channel.md
@@ -255,11 +255,12 @@ channelRoot(): string                                       // TRELLIS_CHANNEL_R
 projectKey(cwd: string): string                             // sanitize: /[\\/_]/g→"-" then /[^A-Za-z0-9.-]/g→"-"
 currentProjectKey(): string                                 // TRELLIS_CHANNEL_PROJECT env ?? projectKey(process.cwd())
 projectDir(project?: string): string                        // <root>/<project>
-channelDir(name, project?: string): string                  // <root>/<project>/<name>
+assertSafeName(name, kind = "channel"): void                // ^[A-Za-z0-9._-]+$, rejects "."/".."; throws "Invalid <kind> name: ..."
+channelDir(name, project?: string): string                  // <root>/<project>/<name> — calls assertSafeName(name) first; the one chokepoint every helper below routes through, so create/rm/run/spawn all reject traversal names (see filesystem-safety.md §2)
 eventsPath(name, project?): string                          // <channelDir>/events.jsonl
 lockPath(name, project?): string                            // <channelDir>/<name>.lock
-workerFile(name, worker, suffix, project?): string          // <channelDir>/<worker>.<suffix>
-workerLockPath(name, worker, project?): string              // <channelDir>/<worker>.spawnlock
+workerFile(name, worker, suffix, project?): string          // <channelDir>/<worker>.<suffix> — calls assertSafeName(worker, "worker")
+workerLockPath(name, worker, project?): string              // <channelDir>/<worker>.spawnlock — calls assertSafeName(worker, "worker")
 migrateLegacyChannels(): void                               // idempotent; moves flat → _legacy/
 ensureBucketMarker(project: string): void                   // touch <project>/.bucket
 listProjects(): string[]                                    // bucket names (has .bucket OR is reserved)
@@ -958,7 +959,8 @@ only applies to per-worker supervisor cleanup.
 
 | Surface | Validator | Reject behavior |
 |---------|-----------|-----------------|
-| Worker / channel name in protocol prompt | `safeIdentifier(s)` strips `/[\r\n\x00-\x08\x0b-\x1f\x7f]/` | silent strip (still produces a valid string) |
+| Channel / worker name as a path segment (create/rm/run/spawn/…) | `assertSafeName(name, kind)` — `^[A-Za-z0-9._-]+$`, rejects `.`/`..` — called inside `channelDir` (and `workerFile`/`workerLockPath` for the worker segment), the one chokepoint every path helper routes through | throw `"Invalid <kind> name: ..."` before any filesystem call (see [Filesystem Safety](./filesystem-safety.md) §2) |
+| Worker / channel name in protocol prompt | `safeIdentifier(s)` strips `/[\r\n\x00-\x08\x0b-\x1f\x7f]/` | silent strip (still produces a valid string) — defense-in-depth on top of the `assertSafeName` chokepoint above, not a substitute for it |
 | `--file <path>` | `jailedRealpath(path, cwd)` requires `realpath(path).startsWith(realpath(cwd) + sep)` | skip file, stderr warn |
 | `--jsonl <path>` | same jail | skip manifest entry, stderr warn |
 | Symlink swap during read | `lstat` BEFORE `stat` to detect symlinks before resolve | treat as not found |
@@ -1123,6 +1125,7 @@ trellis channel send trellis-issue --scope global --as main --thread forum-mode 
 | `channel run` failure preserves | e2e | run with bad provider; assert exit 1, stderr matches "channel kept for inspection:", channel directory still exists, `events.jsonl` has create+error |
 | `--ephemeral` create + list + prune | integration | (a) `list` default hides, (b) `list --all` shows with `*`, (c) `list` footer prints "(N ephemeral channels hidden ...)", (d) `prune --ephemeral` only deletes ephemeral, (e) `prune --ephemeral --idle 1h` throws mutex error |
 | Path-traversal jail | security | `--file /etc/passwd` from cwd `/tmp/work` → file skipped, stderr warn |
+| `assertSafeName` / `channelDir` traversal guard | security | (a) `".."`, `"."`, `"../x"`, `"../../x"`, `"a/b"`, `"a\b"` → throw `Invalid channel name`, (b) ordinary names (`"a"`, `"chat-only"`, `"a.b"`) accepted, (c) `channelDir("../../escape")` throws before resolving a path — duplicated in both `core` and `cli` copies of `paths.ts` |
 | Agent name validator | security | `--agent ../../evil` → throw |
 | Frontmatter prototype pollution | security | a `.trellis/agents/<name>.md` fixture with `__proto__: ...` frontmatter → key dropped, no pollution observable |
 | `safeIdentifier` | unit | newline / NUL / control chars stripped from worker name in protocol prompt |

--- a/.trellis/spec/cli/backend/commands-uninstall.md
+++ b/.trellis/spec/cli/backend/commands-uninstall.md
@@ -13,9 +13,9 @@ How the uninstall command removes every Trellis-written file from a project, scr
 - **Manifest is authoritative.** The single source of truth for "what trellis wrote" is `.trellis/.template-hashes.json`. Files outside that manifest are never touched, regardless of where they live (e.g. user-added scripts under `.claude/hooks/`, custom commands under `.cursor/commands/`).
 - **No user-modification gate.** Whether the user has edited a manifest-listed file or not, it is removed. `update` semantics (warn / preserve modified files) do not apply here — the user's intent is to remove Trellis entirely.
 - **Two file classes.** Manifest entries fall into:
-  1. *Opaque content files* (`.py`, `.md`, `.toml`, `.json` agents, etc.) — unlinked outright.
-  2. *Structured config files* (`settings.json`, `hooks.json`, `package.json`, `config.toml`) — passed through a scrubber that removes only the trellis-owned fields and writes the trimmed result back. If nothing meaningful remains, the scrubber returns `fullyEmpty: true` and the file is deleted instead of rewritten.
-- **`.trellis/` is removed unconditionally.** Tasks, runtime state, workspace journal, config — all of it. Users who want to keep historical task records must back up `.trellis/tasks/` themselves before running `uninstall`.
+  1. *Opaque content files* (most `.py`, `.md`, `.toml`, `.json` agents, etc.) — unlinked outright.
+  2. *Structured config files* (`settings.json`, `hooks.json`, `package.json`, `config.toml`, and mixed-ownership markdown like `AGENTS.md`) — passed through a scrubber that removes only the trellis-owned fields/block and writes the trimmed result back. If nothing meaningful remains, the scrubber returns `fullyEmpty: true` and the file is deleted instead of rewritten.
+- **`.trellis/` is removed unconditionally once execution proceeds.** Tasks, runtime state, workspace journal, config — all of it; there is no `--keep-tasks` flag. A pre-execution guard warns about (and, for scripted `--yes` runs, can fail closed on) uncommitted specs/tasks/workspace files before that deletion happens — see *Dirty-Data Guard* under *`.trellis/` Handling* below, and [Filesystem Safety § Destructive-op ownership / backup gate](./filesystem-safety.md).
 - **Idempotent.** Re-running on a project that has no `.trellis/` is a friendly no-op. Re-running after a partial failure picks up whatever is still on disk and converges.
 - **Best-effort cleanup.** Permission errors on individual `unlink`/`rmdir` calls are swallowed; the command never aborts halfway. The summary at the end reports counts but does not enumerate per-file failures.
 
@@ -86,6 +86,9 @@ A `Map<posixPath, StructuredFileSpec>` built once per command invocation. Each e
 | `.opencode/package.json` | `scrubOpencodePackageJson` | n/a |
 | `.pi/settings.json` | `scrubPiSettings` | n/a |
 | `.codex/config.toml` | `scrubCodexConfigToml` | n/a |
+| `AGENTS.md` | `scrubManagedMarkdownBlock` | n/a |
+
+`AGENTS.md` is not a hooks-JSON file — it's a mixed-ownership markdown file. Trellis owns only the `<!-- TRELLIS:START/END -->` block (markers exported from `update.ts`); the user owns everything outside it. It shares `scrubManagedMarkdownBlock` with the Copilot-instructions scrubber: strip the block, keep the rest, and only fall through to deletion (`fullyEmpty`) when nothing user-authored remains. Before this spec was added, `AGENTS.md` had no dispatch-table row and was `unlinkSync`'d whole by the plain-deletion path, destroying any pre-existing user content outside the block.
 
 Adding a new platform that ships a structured config file means adding one row to this table — the planner picks it up automatically. **Per-file scrub semantics live in `uninstall-scrubbers.md`; do not duplicate them here.**
 
@@ -135,7 +138,7 @@ While deleting, the parent directory of each deleted file is added to a `Set<str
 
 ### Phase 3 — Drop `.trellis/` recursively
 
-`fs.rmSync(trellisDir, { recursive: true, force: true })`. Whole directory tree gone in one call. This is unconditional within `executePlan`; the only gate is the pre-check at the top of `uninstall()` which establishes that the directory exists and a manifest is present.
+`fs.rmSync(trellisDir, { recursive: true, force: true })`. Whole directory tree gone in one call. This is unconditional within `executePlan`; the gates all live earlier in `uninstall()` — the pre-checks that the directory exists and a manifest is present, the confirmation prompt (or `--yes`), and the *Dirty-Data Guard* below.
 
 ### Phase 4 — Prune empty managed sub-directories
 
@@ -170,9 +173,20 @@ Returns `{ deletedFiles, modifiedFiles, deletedDirs }` for the green summary lin
 | `.trellis/.current-task` | Removed. |
 | `.trellis/.template-hashes.json` | Removed. |
 
-This is **deliberately destructive** for user data inside `.trellis/`. Users are responsible for backing up `tasks/` or `workspace/` before running `uninstall` if they want history preserved. The plan output prints `WORKFLOW/  (entire directory, including tasks/runtime/config)` so this is visible before the confirmation prompt.
+This is **deliberately destructive** for user data inside `.trellis/`. Users are responsible for backing up `spec/`, `tasks/`, or `workspace/` before running `uninstall` if they want history preserved — the command does not create a backup itself. The plan output prints `WORKFLOW/  (entire directory — including your specs, task PRDs, journals, and memory)` so this is visible before the confirmation prompt.
 
 > Rationale: a "soft uninstall" that leaves orphan `.trellis/` content behind is a worse state than either fully-installed or fully-uninstalled — the leftover files reference removed scripts (`.trellis/scripts/`) and broken sub-agent configs (`.trellis/tasks/<id>/implement.jsonl` pointing at deleted spec files). Either keep Trellis or remove it cleanly. There is no half-Trellis mode.
+
+### Dirty-Data Guard — `collectUncommittedTrellisData`
+
+`.trellis/spec/`, `.trellis/tasks/`, and `.trellis/workspace/` are the same subdirectories `update.ts` marks PROTECTED (user-authored specs, task PRDs, journals). Because Phase 3 deletes them with no backup, `uninstall()` calls `collectUncommittedTrellisData(cwd)` right after `renderPlan` (before the dry-run exit and before the confirmation prompt). It shells out to `git status --porcelain -- .trellis/spec .trellis/tasks .trellis/workspace` and returns the list of modified/staged/untracked paths under those three dirs. A non-git repo, or `git` being unavailable, makes it return `[]` — the guard is a no-op in that case, and uninstall proceeds exactly as it did before this fix.
+
+- **Any hits** print a red warning (up to 20 paths, then a "`… and N more`" tail) before the prompt/dry-run message.
+- **Interactive runs** (no `--yes`) only see the warning; the existing `Continue? [Y/n]` prompt is the abort point.
+- **`--dry-run`** shows the warning too (for visibility) but returns before any fail-closed check, since dry-run never mutates anything.
+- **Scripted `--yes` runs fail closed**: if uncommitted data was found and `--dry-run` was not passed, the command prints an error and `process.exit(1)`s *before* `executePlan` runs any write/unlink/rm — unless the environment variable `TRELLIS_ALLOW_DIRTY_UNINSTALL=1` is set, which mirrors the existing homedir-guard bypass pattern (`utils/cwd-guard.ts`).
+
+See [Filesystem Safety § Destructive-op ownership / backup gate](./filesystem-safety.md) for the cross-cutting contract this guard implements.
 
 ---
 
@@ -261,6 +275,8 @@ If you ever need to extend the scrubber to match different command shapes (e.g. 
 
 Tests live in `packages/cli/test/commands/uninstall.integration.test.ts`. The file pattern: each test runs `init({ ..., force: true })` in a fresh tmpdir to set up a real Trellis install, then exercises one path through `uninstall()`.
 
+Two behaviors documented above have their own dedicated integration test files rather than living in the main table below: the `AGENTS.md` block-scrub fix is covered by `test/commands/init-uninstall-overdelete.integration.test.ts`, and the *Dirty-Data Guard* is covered by `test/commands/uninstall-dirty-guard.integration.test.ts` (skipped when `git`/`python3` are unavailable, since it shells out to real `git status`).
+
 Reference cases (number = test ID in the file):
 
 | # | Scenario | What it pins down |
@@ -303,4 +319,6 @@ Do **not** mock `fs` for these tests; they all use real tmpdirs. The pattern is:
 | `cleanupEmptyDirs` | `commands/update.ts:cleanupEmptyDirs` (re-exported) |
 | `ALL_MANAGED_DIRS` / `isManagedRootDir` | `configurators/index.ts` |
 | `DIR_NAMES.WORKFLOW` | `constants/paths.ts:DIR_NAMES` |
-| Scrubbers (`scrubHooksJson`, `scrubOpencodePackageJson`, `scrubPiSettings`, `scrubCodexConfigToml`) | `utils/uninstall-scrubbers.ts` — see `uninstall-scrubbers.md` |
+| `collectUncommittedTrellisData` | `commands/uninstall.ts:collectUncommittedTrellisData` (exported) |
+| `TRELLIS_ALLOW_DIRTY_UNINSTALL` (env bypass) | checked via `dirtyUninstallBypassEnabled` in `commands/uninstall.ts` |
+| Scrubbers (`scrubHooksJson`, `scrubOpencodePackageJson`, `scrubPiSettings`, `scrubCodexConfigToml`, `scrubManagedMarkdownBlock`) | `utils/uninstall-scrubbers.ts` — see `uninstall-scrubbers.md` |

--- a/.trellis/spec/cli/backend/commands-update.md
+++ b/.trellis/spec/cli/backend/commands-update.md
@@ -142,7 +142,7 @@ Permits `cliVersion < projectVersion`. Without it, `update()` exits early with a
 Opt-in to apply file migrations (renames/deletes/dir renames). Without it: migrations are listed in the plan but not executed; a "Tip: Use --migrate" hint prints. With it:
 
 1. `commands/update.ts:executeMigrations` runs on the classified plan.
-2. The hardcoded 0.2.0 `traces-*.md → journal-*.md` rename in `update()` runs (workspace/<dev>/ pattern walk; cannot live in the manifest because the path includes a variable developer slug).
+2. The hardcoded 0.2.0 `traces-*.md → journal-*.md` rename runs via `commands/update.ts:renameTracesToJournal(workspaceDir)` (workspace/<dev>/ pattern walk; cannot live in the manifest because the path includes a variable developer slug). It never overwrites: if the `journal-*.md` target already exists, that file is left as-is and reported back in a `skipped` list instead of being renamed over — `.trellis/workspace/` is outside the backup snapshot, so an overwrite there would be unrecoverable. See [Filesystem Safety § 3](./filesystem-safety.md).
 
 `safe-file-delete` migrations are independent of `--migrate` — they always run when their hash gate passes (see Apply Phase). Rationale in `migrations.md`.
 
@@ -165,7 +165,9 @@ Migration state is then run through `commands/update.ts:classifyMigrations` agai
 | `auto` | source unmodified, target free or matches template |
 | `confirm` | source modified by user (hash mismatch) |
 | `conflict` | both source and target exist with user content |
-| `skip` | source missing, or path is `PROTECTED_PATHS` |
+| `skip` | source missing, path is `PROTECTED_PATHS`, or (see below) an unowned `rename-dir` source |
+
+`rename-dir` has an extra ownership gate when the target is absent: `commands/update.ts:dirHasManifestEntries(item.from, hashes)` must find at least one manifest-tracked file under that source directory before it lands in `auto`. If the manifest has no record of the directory — e.g. a user's own `.windsurf/` editor config that merely shares a path with a retired Trellis platform dir — the item goes to `skip` instead, even under `--force` (skip never executes). See [Filesystem Safety § 2–3](./filesystem-safety.md) for the rationale and the other ownership/backup gates it's modeled after.
 
 Sorting before execution is by `commands/update.ts:sortMigrationsForExecution`: deeper `rename-dir` first, then other `rename-dir`, then `rename` / `delete`. Critical for nested directory renames — without depth ordering, a parent move would leave child entries pointing at a dead source.
 
@@ -210,7 +212,7 @@ Order of operations in `commands/update.ts:update` (after the `Proceed?` confirm
 
 1. **Backup** — `commands/update.ts:createFullBackup` snapshots every `BACKUP_DIRS` (= `configurators/index.ts:ALL_MANAGED_DIRS`) entry plus `BACKUP_FILES` (= `AGENTS.md`) into `.trellis/.backup-<ISO-timestamp>/`. `commands/update.ts:shouldExcludeFromBackup` filters out previous backups, `node_modules/`, user-data dirs (`workspace/`, `tasks/`, `spec/`, `backlog/`, `agent-traces/`), and platform-native worktree dirs (`/worktrees/`, `/worktree/`). Symlinks (and Windows directory junctions) are never followed in `commands/update.ts:collectAllFiles` — a junction to an ancestor would loop forever.
 
-2. **Migrations** (only if `--migrate`) — `commands/update.ts:executeMigrations` runs `auto` items first (sorted by depth), then `confirm` items via `commands/update.ts:promptMigrationAction` (or `--force` / `--skip-all` short-circuits). Default action for prompts is `backup-rename`: leaves `<new-path>.backup` of the user's modified content alongside the rename, so users can diff inline without digging through the snapshot. Hash tracking is updated via `utils/template-hash.ts:renameHash` / `removeHash`. Empty source dirs are pruned by `commands/update.ts:cleanupEmptyDirs` (gated by `configurators/index.ts:isManagedPath` + `isManagedRootDir` — never deletes managed roots themselves, never crosses into unmanaged paths). After regular migrations, the hardcoded `traces-*.md → journal-*.md` workspace walk runs.
+2. **Migrations** (only if `--migrate`) — `commands/update.ts:executeMigrations` runs `auto` items first (sorted by depth), then `confirm` items via `commands/update.ts:promptMigrationAction` (or `--force` / `--skip-all` short-circuits). Default action for prompts is `backup-rename`: leaves `<new-path>.backup` of the user's modified content alongside the rename, so users can diff inline without digging through the snapshot. Hash tracking is updated via `utils/template-hash.ts:renameHash` / `removeHash`. Empty source dirs are pruned by `commands/update.ts:cleanupEmptyDirs` (gated by `configurators/index.ts:isManagedPath` + `isManagedRootDir` — never deletes managed roots themselves, never crosses into unmanaged paths). After regular migrations, the hardcoded `traces-*.md → journal-*.md` workspace walk (`commands/update.ts:renameTracesToJournal`) runs; files whose journal target already exists are skipped (not overwritten) and printed as a yellow "Kept ... its journal target already exists" warning.
 
 3. **`safe-file-delete`** — `commands/update.ts:executeSafeFileDeletes` deletes files in the `delete` action bucket (hash matched, not protected, not in `update.skip` unless bypassed), removes their hash entries, and prunes empty parent directories. `migrations.md` covers the full classification matrix.
 
@@ -241,6 +243,8 @@ Order of operations in `commands/update.ts:update` (after the `Proceed?` confirm
 - `isTemplateModified(cwd, path, hashes)` in `classifyMigrations`
 - `renameHash` / `removeHash` during migrations
 - `updateHashes(cwd, files)` at the end
+
+`saveHashes` (called by `updateHashes`/`renameHash`/`removeHash`) writes `.trellis/.template-hashes.json` via `writeFileAtomic` (temp file in the same dir + rename), not a direct `writeFileSync`. A crash mid-write can no longer truncate the manifest to `{}`, which would otherwise make every managed file look user-modified on the next run. See [Filesystem Safety § 1](./filesystem-safety.md).
 
 `migrations.md` documents the relationship to `allowed_hashes` in `safe-file-delete` migrations: the hash file tracks "Trellis-installed bytes" (so update can detect user edits); `allowed_hashes` is a bounded set of "known-pristine bytes" the manifest blesses for auto-deletion. They are different sets — a user file might have a recorded hash but not be `allowed_hashes`-eligible.
 

--- a/.trellis/spec/cli/backend/filesystem-safety.md
+++ b/.trellis/spec/cli/backend/filesystem-safety.md
@@ -1,0 +1,133 @@
+# Filesystem Safety — Atomic Writes & Destructive-Op Guards
+
+> Cross-cutting contract for any code that **writes, deletes, moves, or
+> overwrites** files in a user's repo. Trellis ships as a CLI that runs inside
+> real git repos, so a truncated write or a mistargeted delete is user data
+> loss, not a transient bug. These are the guardrails the 2026-07-10 audit's
+> two root causes distilled to.
+
+Applies to: `commands/update.ts`, `commands/uninstall.ts`, `utils/*`,
+`core/channel/**`, and the shipped Python under `templates/trellis/scripts/`.
+
+---
+
+## 1. Atomic writes — never truncate a state file in place
+
+**Rule**: a file that holds durable state (attribution manifest, `task.json`,
+`config.yaml`, session pointer, channel events cursor) must be written
+**temp-in-same-dir + rename**, never `fs.writeFileSync(path, ...)` /
+`path.write_text(...)` directly. In-place writes truncate the target as their
+first step, so a crash / Ctrl-C / ENOSPC mid-write leaves a half-file. A
+truncated `.template-hashes.json` heals to `{}` (every managed file then looks
+user-modified); a truncated `task.json` reads back as `None` (the task vanishes
+from `task.py list`).
+
+### Signatures
+
+```ts
+// packages/cli/src/utils/atomic-write.ts
+export function writeFileAtomic(filePath: string, data: string | Uint8Array): void
+// writes `<dir>/.<basename>.<pid>.tmp` then fs.renameSync over filePath;
+// removes the tmp and rethrows on failure. Same-dir tmp keeps rename atomic.
+```
+
+```python
+# templates/trellis/scripts/common/io.py
+def write_json(path: Path, data: dict) -> bool
+# tempfile.mkstemp(dir=path.parent) -> os.fdopen write -> os.replace(tmp, path);
+# unlinks tmp and re-raises on BaseException (Ctrl-C included).
+```
+
+### Wrong vs Correct
+
+```ts
+// Wrong — truncates on entry; a crash here corrupts the manifest to {}
+fs.writeFileSync(hashesPath, JSON.stringify(payload, null, 2));
+
+// Correct
+writeFileAtomic(hashesPath, JSON.stringify(payload, null, 2));
+```
+
+> **Note**: atomic write fixes the *crash window*. It does **not** fix
+> concurrent last-writer-wins (multiple processes RMW the same file). File
+> locking / seq reconciliation is a separate, still-open concern.
+
+---
+
+## 2. Path & name safety — validate at the chokepoint, before `path.join`
+
+**Rule**: any user- or agent-supplied string that becomes a path segment must be
+validated **before** it flows into `path.join` / `shutil.move` / `rmSync`. A
+name like `../../x` resolves outside the intended tree and a later recursive
+delete escapes the store.
+
+| Concern | Guard | Location |
+|---|---|---|
+| channel / worker name | `assertSafeName(name, kind)` — `^[A-Za-z0-9._-]+$`, rejects `.`/`..` — called inside `channelDir` (the single chokepoint every path helper passes through) | `core` + `cli` `channel/store/paths.ts` |
+| `task.py archive <name>` target | `is_within_tasks_dir(task_dir_abs, repo_root)` — dir must be a direct child of `.trellis/tasks/` | `scripts/common/task_utils.py` |
+| rename-dir migration source | `dirHasManifestEntries(fromDir, hashes)` — only auto-move a dir Trellis provably created | `commands/update.ts` |
+
+> **Why the chokepoint, not the entrypoint**: validating inside `channelDir`
+> (not in each of create/rm/run) means one guard covers every current and future
+> caller. Per-command validation rots — `spawn.ts` once carried a "CLI already
+> validates names" comment that was false.
+
+```ts
+// Correct: guard lives in the shared path builder
+export function channelDir(name: string, project = currentProjectKey()): string {
+  assertSafeName(name);
+  return path.join(projectDir(project), name);
+}
+```
+
+---
+
+## 3. Destructive-op ownership / backup gate
+
+Before deleting, moving, or overwriting anything that **could be user data**,
+one of these must hold. Pick by operation:
+
+| Operation | Required guard |
+|---|---|
+| Delete a mixed-ownership file (e.g. `AGENTS.md`) | Strip only the managed block (`scrubManagedMarkdownBlock`); delete only if nothing user-authored remains. Never `unlinkSync` the whole file. |
+| Move a dir that may be user-owned (rename-dir) | Ownership check (`dirHasManifestEntries`); unowned + target-absent → **skip** (safe even under `--force`, since skip never executes). |
+| Overwrite a dir from a remote source | Download to a temp dir; `rm` + copy the old dir **only after** the download succeeds (`downloadWithStrategy` `overwrite`). Never delete-then-download. |
+| Rename onto a possibly-existing target | `fs.existsSync(newPath)` first; skip/renumber instead of clobbering (`renameTracesToJournal`). Especially when the dir is excluded from backup. |
+| `rm -rf` a tree with user data (`uninstall`) | `collectUncommittedTrellisData(cwd)` (git status over `spec/tasks/workspace`); scripted `--yes` fails closed unless `TRELLIS_ALLOW_DIRTY_UNINSTALL=1`. Disclosure must name what user data is deleted. |
+
+**Env override precedent**: a fail-closed guard on a `--yes`/`--force` path gets
+an explicit env bypass, mirroring `TRELLIS_ALLOW_HOMEDIR`
+(`TRELLIS_ALLOW_DIRTY_UNINSTALL=1`). Warn-and-continue is not enough on
+`--yes` — nobody reads scrollback in a script.
+
+---
+
+## 4. Dogfood twin sync
+
+Shipped Python (`packages/cli/src/templates/trellis/scripts/**`) has a dogfood
+twin at repo `.trellis/scripts/**`. When you change a shipped script, sync the
+twin **iff** they were identical first (`diff` before `cp`); if the twin has
+drifted, apply the same edit surgically so unrelated local drift is preserved.
+`packages/cli/dist/**` and `.trellis/.backup-*/**` are generated/history —
+never hand-edit.
+
+---
+
+## 5. Tests required
+
+Every guard here leaves a runnable regression test whose assertion **fails
+without the guard**:
+
+- Atomic write: write-succeeds + no tmp leftover + original survives a failed write (`test/utils/atomic-write.test.ts`; Python covered via `task-archive` integration).
+- Path traversal: `create '../../victim' --force` / `rm '../../victim'` throw and the external dir survives — reproduce in a sandbox (`test/channel/name-safety`, `test/commands/channel-name-safety`).
+- Ownership/backup gates: unowned source skipped (`update-internals` rename-dir gate), `archive src` refused with `src/` intact (`task-archive` integration), overwrite-fails-preserves-spec (`template-fetcher-overwrite`), uninstall refuses dirty `--yes` (`uninstall-dirty-guard`, real git).
+
+---
+
+## Related
+
+- [`trellis update` Command](./commands-update.md) — migration classification/apply
+- [`trellis uninstall` Command](./commands-uninstall.md) — plan/execute phases
+- [`trellis channel` Command](./commands-channel.md) — store paths, project buckets
+- [Script Conventions](./script-conventions.md) — Python `io.py` contract
+- [Migrations](./migrations.md) — rename/rename-dir/delete semantics

--- a/.trellis/spec/cli/backend/filesystem-safety.md
+++ b/.trellis/spec/cli/backend/filesystem-safety.md
@@ -69,8 +69,9 @@ delete escapes the store.
 
 > **Why the chokepoint, not the entrypoint**: validating inside `channelDir`
 > (not in each of create/rm/run) means one guard covers every current and future
-> caller. Per-command validation rots — `spawn.ts` once carried a "CLI already
-> validates names" comment that was false.
+> caller. `spawn.ts` had long *asserted* this — a "CLI layer already validates
+> names" comment — while no such validation existed; adding the guard at the
+> `channelDir` chokepoint is what finally made that comment true.
 
 ```ts
 // Correct: guard lives in the shared path builder

--- a/.trellis/spec/cli/backend/index.md
+++ b/.trellis/spec/cli/backend/index.md
@@ -20,6 +20,7 @@ This directory contains guidelines for backend development. Fill in each file wi
 | [Quality Guidelines](./quality-guidelines.md) | Code standards, forbidden patterns | Done |
 | [Logging Guidelines](./logging-guidelines.md) | Structured logging, log levels | Done |
 | [Migrations](./migrations.md) | Version migration system for template files | Done |
+| [Filesystem Safety](./filesystem-safety.md) | Atomic writes (temp+rename / `os.replace`), path/name chokepoint validation, destructive-op ownership & backup gates, dogfood twin sync | Done |
 | [Release Process](./release-process.md) | CI-only publishing, package versioning, release tracks, manifest continuity, submodule ordering | Done |
 | [Trellis Core SDK](./trellis-core-sdk.md) | `@mindfoldhq/trellis-core` / CLI package boundary, public exports, build and versioning contracts | Done |
 | [Platform Integration](./platform-integration.md) | How to add support for new AI CLI platforms | Done |
@@ -44,6 +45,7 @@ Before writing backend code, read the relevant guidelines based on your task:
 - Modifying `init.ts` flow (new triggers, dispatch branches, bootstrap/joiner) → [platform-integration.md "Bootstrap & Joiner Task Auto-Generation"](./platform-integration.md) — two-point wiring + `.developer` signal
 - Script work → [script-conventions.md](./script-conventions.md)
 - Migration system → [migrations.md](./migrations.md)
+- Writing/deleting/moving/overwriting files in a user repo (any `writeFileSync`, `rmSync`, `renameSync`, `shutil.move`, or user/agent-supplied path segment) → [filesystem-safety.md](./filesystem-safety.md)
 - Cutting a release / cross-branch submodule coordination / manifest continuity / npm publishing → [release-process.md](./release-process.md)
 - Editing `packages/core/**`, moving reusable CLI logic into core, or changing CLI imports from `@mindfoldhq/trellis-core` → [trellis-core-sdk.md](./trellis-core-sdk.md)
 - Adding any native (`.node` / C++ / `node-gyp`) dependency → [quality-guidelines.md "Native dependency policy"](./quality-guidelines.md)

--- a/.trellis/spec/cli/backend/migrations.md
+++ b/.trellis/spec/cli/backend/migrations.md
@@ -95,6 +95,7 @@ src/migrations/
 - 自动批量更新 hash 追踪
 - 移动后自动清理空的源目录
 - 嵌套目录按深度优先处理（避免父目录先移动导致子目录找不到）
+- 目标目录不存在时，是否自动执行取决于归属：只有当 manifest 记录了 `from` 目录下的文件（即这个目录是 trellis 自己建的）才会 `auto`；否则视为可能是用户自建的同名目录（例如真实的 `.windsurf/` 编辑器配置），路由到 `skip`（即使 `--force` 也不执行）。详见下方分类逻辑与 [Filesystem Safety](./filesystem-safety.md)。
 
 ### safe-file-delete 示例
 
@@ -127,10 +128,10 @@ src/migrations/
 
 | 分类 | 条件 | 行为 |
 |------|------|------|
-| `auto` | 文件未被用户修改 / rename-dir | 自动迁移 |
+| `auto` | 文件未被用户修改 / rename-dir 目标不存在且源目录有 manifest 记录（trellis 建的）/ rename-dir 目标存在且只含未修改模板文件 | 自动迁移 |
 | `confirm` | 文件已被用户修改 | 默认询问，`-f` 强制，`-s` 跳过 |
-| `conflict` | 新旧路径都存在 | 跳过并提示手动解决 |
-| `skip` | 旧路径不存在 / 路径受保护 | 无需操作 |
+| `conflict` | 新旧路径都存在且新路径含用户修改内容 | 跳过并提示手动解决 |
+| `skip` | 旧路径不存在 / 路径受保护 / rename-dir 目标不存在且源目录无 manifest 记录（疑似用户自建同名目录，即使 `--force` 也不执行） | 无需操作 |
 
 ## `configSectionsAdded`（追加式 config.yaml 节）
 

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -25,7 +25,7 @@ All workflow scripts target **Python 3.9+** for cross-platform compatibility (ma
 │   ├── types.py          # TaskData (TypedDict), TaskInfo (dataclass), AgentRecord
 │   ├── tasks.py          # load_task(), iter_active_tasks() — typed task access
 │   ├── active_task.py    # Session-scoped active task resolver
-│   ├── task_utils.py     # resolve_task_dir(), run_task_hooks()
+│   ├── task_utils.py     # resolve_task_dir(), is_within_tasks_dir(), run_task_hooks()
 │   ├── task_store.py     # Task CRUD (create, archive, set-branch, etc.)
 │   ├── task_context.py   # JSONL context management (add-context, validate, list-context)
 │   ├── task_queue.py     # Task queue CRUD
@@ -272,6 +272,15 @@ The single source of truth for all JSON file operations. Replaces 8 duplicated `
 - Always uses `encoding="utf-8"` and `ensure_ascii=False`
 - `write_json` outputs with `indent=2` (pretty-printed)
 - Callers must check return value — no exceptions are raised
+- `write_json` is atomic: it writes to a temp file in `path.parent`
+  (`tempfile.mkstemp`) then `os.replace(tmp, path)`. It never
+  `path.write_text()`s over the target in place. A crash or Ctrl-C mid-write
+  leaves the existing file intact instead of truncated. On failure the tmp
+  file is unlinked; a `BaseException` (e.g. `KeyboardInterrupt`) is re-raised,
+  while `OSError`/`IOError` from the write itself are caught and return
+  `False` as before. This matters for `task.json`: a truncated file reads
+  back as `None` from `read_json`, which makes the task silently vanish from
+  `task.py list`. See [Filesystem Safety](./filesystem-safety.md#1-atomic-writes--never-truncate-a-state-file-in-place).
 
 ### `common/log.py` — Terminal Output
 
@@ -418,6 +427,14 @@ a `.current-task` fallback or a Python hook directory.
   `.trellis/.current-task`.
 - `task.py archive <task>` deletes every runtime session file whose
   `current_task` points at the archived task before moving the task directory.
+- Before moving anything, `cmd_archive` (`task_store.py`) calls
+  `is_within_tasks_dir(task_dir_abs, repo_root)` (`task_utils.py`) and refuses
+  with "refusing to archive ..." (exit 1) unless the resolved dir is a direct
+  child of `.trellis/tasks/`. `resolve_task_dir` falls back to
+  `repo_root / <name>` for a name it can't find, so a mistyped
+  `task.py archive src` would otherwise resolve to and `shutil.move` the
+  repo's real `src/` directory. See
+  [Filesystem Safety](./filesystem-safety.md#2-path--name-safety--validate-at-the-chokepoint-before-pathjoin).
 
 ##### 4. Validation & Error Matrix
 
@@ -437,6 +454,7 @@ a `.current-task` fallback or a Python hook directory.
 | `finish` with context key and active task | Deletes `.runtime/sessions/<key>.json` |
 | `finish` without context key | Returns no current task; does not delete `.current-task` |
 | `archive` for a task referenced by runtime sessions | Deletes those session files even when `finish` was skipped |
+| `archive` on a name that resolves outside `.trellis/tasks/` (e.g. `archive src` falling back to `repo_root/src`) | Refuses with "refusing to archive ..." and exit 1; source directory is left untouched |
 
 ##### 5. Good/Base/Bad Cases
 

--- a/packages/cli/src/commands/channel/guard.ts
+++ b/packages/cli/src/commands/channel/guard.ts
@@ -29,6 +29,7 @@ import {
   channelDir,
   channelRoot,
   currentProjectKey,
+  isSafeName,
   projectDir,
   workerFile,
 } from "./store/paths.js";
@@ -309,6 +310,10 @@ export function scanLiveWorkers(
   const out: LiveWorker[] = [];
   for (const entry of entries) {
     if (entry.startsWith(".")) continue;
+    // Stores created before name validation may hold channel dirs with
+    // now-invalid names (spaces, CJK, ...). They can never host workers —
+    // skip them instead of letting workerFile/channelDir throw mid-scan.
+    if (!isSafeName(entry)) continue;
     const dir = path.join(bucket, entry);
     try {
       if (!fs.statSync(dir).isDirectory()) continue;

--- a/packages/cli/src/commands/channel/guard.ts
+++ b/packages/cli/src/commands/channel/guard.ts
@@ -26,6 +26,7 @@ import {
 import { DIR_NAMES } from "../../constants/paths.js";
 
 import {
+  channelDir,
   channelRoot,
   currentProjectKey,
   projectDir,
@@ -378,7 +379,7 @@ function readReservationWorkers(
   channel: string,
   project: string,
 ): WorkerState[] {
-  const dir = path.join(projectDir(project), channel);
+  const dir = channelDir(channel, project);
   let files: string[];
   try {
     files = fs.readdirSync(dir);

--- a/packages/cli/src/commands/channel/store/paths.ts
+++ b/packages/cli/src/commands/channel/store/paths.ts
@@ -63,13 +63,23 @@ const BUCKET_MARKER = ".bucket";
 const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
 
 /**
+ * Whether a channel/worker name is usable as a filesystem segment.
+ * Discovery scans use this to skip directories created before name
+ * validation existed (spaces, CJK, ...) — they can never be valid
+ * channels, and `assertSafeName` throwing mid-scan would kill the scan.
+ */
+export function isSafeName(name: string): boolean {
+  return name !== "." && name !== ".." && SAFE_SEGMENT_RE.test(name);
+}
+
+/**
  * Reject names that would escape their bucket when joined into a path.
  * A channel/worker name becomes a filesystem segment; without this guard
  * a name like `../../x` lets `path.join` resolve outside the store and a
  * later `fs.rmSync(recursive)` deletes arbitrary directories.
  */
 export function assertSafeName(name: string, kind = "channel"): void {
-  if (name === "." || name === ".." || !SAFE_SEGMENT_RE.test(name)) {
+  if (!isSafeName(name)) {
     throw new Error(
       `Invalid ${kind} name: ${JSON.stringify(name)}. ` +
         `Names may only contain letters, digits, '.', '_' and '-'.`,

--- a/packages/cli/src/commands/channel/store/paths.ts
+++ b/packages/cli/src/commands/channel/store/paths.ts
@@ -59,6 +59,24 @@ export function projectDir(project: string = currentProjectKey()): string {
  *  flat-layout channel. New project buckets touch this on first use. */
 const BUCKET_MARKER = ".bucket";
 
+/** Characters allowed in a channel or worker name used as a path segment. */
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Reject names that would escape their bucket when joined into a path.
+ * A channel/worker name becomes a filesystem segment; without this guard
+ * a name like `../../x` lets `path.join` resolve outside the store and a
+ * later `fs.rmSync(recursive)` deletes arbitrary directories.
+ */
+export function assertSafeName(name: string, kind = "channel"): void {
+  if (name === "." || name === ".." || !SAFE_SEGMENT_RE.test(name)) {
+    throw new Error(
+      `Invalid ${kind} name: ${JSON.stringify(name)}. ` +
+        `Names may only contain letters, digits, '.', '_' and '-'.`,
+    );
+  }
+}
+
 /**
  * Channel directory inside its project bucket. Defaults to the current
  * project (cwd-derived); pass an explicit project for cross-project
@@ -68,6 +86,7 @@ export function channelDir(
   name: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(name);
   return path.join(projectDir(project), name);
 }
 
@@ -91,6 +110,7 @@ export function workerFile(
   suffix: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(worker, "worker");
   return path.join(channelDir(name, project), `${worker}.${suffix}`);
 }
 
@@ -99,6 +119,7 @@ export function workerLockPath(
   worker: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(worker, "worker");
   return path.join(channelDir(name, project), `${worker}.spawnlock`);
 }
 

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -23,9 +23,13 @@ import readline from "node:readline";
 import chalk from "chalk";
 import inquirer from "inquirer";
 
-import { DIR_NAMES } from "../constants/paths.js";
+import { DIR_NAMES, FILE_NAMES } from "../constants/paths.js";
 import { loadHashes } from "../utils/template-hash.js";
-import { cleanupEmptyDirs } from "./update.js";
+import {
+  cleanupEmptyDirs,
+  TRELLIS_BLOCK_START,
+  TRELLIS_BLOCK_END,
+} from "./update.js";
 import {
   ALL_MANAGED_DIRS,
   getConfiguredPlatforms,
@@ -128,6 +132,20 @@ function buildStructuredFileSpecs(): Map<string, StructuredFileSpec> {
           content,
           COPILOT_INSTRUCTIONS_BLOCK_START,
           COPILOT_INSTRUCTIONS_BLOCK_END,
+        ),
+    },
+    {
+      // AGENTS.md is a mixed-ownership file: Trellis owns the
+      // <!-- TRELLIS:START/END --> block, the user owns everything around
+      // it (update.ts preserves that outer content). Strip only the block;
+      // delete the file only when nothing user-authored remains.
+      posixPath: FILE_NAMES.AGENTS,
+      reason: "Strip Trellis managed block; preserve user instructions",
+      scrub: (content) =>
+        scrubManagedMarkdownBlock(
+          content,
+          TRELLIS_BLOCK_START,
+          TRELLIS_BLOCK_END,
         ),
     },
   ];

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -17,6 +17,7 @@
  * (per the PRD: "全删"). The `.trellis/` tree is removed unconditionally.
  */
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
@@ -257,7 +258,7 @@ function renderPlan(cwd: string, plan: UninstallPlan): void {
   if (plan.removeTrellisDir && fs.existsSync(trellisDir)) {
     console.log(
       `  ${chalk.red("-")} ${DIR_NAMES.WORKFLOW}/  ${chalk.gray(
-        "(entire directory, including tasks/runtime/config)",
+        "(entire directory — including your specs, task PRDs, journals, and memory)",
       )}`,
     );
   }
@@ -403,6 +404,45 @@ function executePlan(
 }
 
 /**
+ * List uncommitted (modified, staged, or untracked) files under the
+ * user-data subdirectories of `.trellis/` — spec/, tasks/, workspace/ — which
+ * hold user-authored specs, task PRDs, and journals that `update.ts` marks as
+ * PROTECTED. Uninstall deletes the whole `.trellis/` tree with no backup, so
+ * these are surfaced before the destructive step. Returns `[]` when this is
+ * not a git repo or git is unavailable (nothing we can check).
+ */
+export function collectUncommittedTrellisData(cwd: string): string[] {
+  const w = DIR_NAMES.WORKFLOW;
+  const userDataDirs = [
+    `${w}/${DIR_NAMES.SPEC}`,
+    `${w}/${DIR_NAMES.TASKS}`,
+    `${w}/${DIR_NAMES.WORKSPACE}`,
+  ];
+  try {
+    const out = execFileSync(
+      "git",
+      ["-C", cwd, "status", "--porcelain", "--", ...userDataDirs],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return (
+      out
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        // Strip the 2-char status code, then keep the post-rename path if any.
+        .map((line) => line.replace(/^\S+\s+/, "").replace(/^.*\s->\s/, ""))
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Whether the uncommitted-data guard has been explicitly overridden. */
+function dirtyUninstallBypassEnabled(): boolean {
+  return process.env.TRELLIS_ALLOW_DIRTY_UNINSTALL === "1";
+}
+
+/**
  * Entry point.
  */
 export async function uninstall(options: UninstallOptions = {}): Promise<void> {
@@ -470,9 +510,43 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   const plan = buildPlan(cwd, prunedHashes);
   renderPlan(cwd, plan);
 
+  // .trellis/ holds user-authored specs, task PRDs, and journals that have no
+  // backup here. Surface any uncommitted such files before deleting the tree,
+  // and — for scripted `--yes` runs where nobody reads the warning — fail
+  // closed unless explicitly overridden.
+  const uncommitted = collectUncommittedTrellisData(cwd);
+  if (uncommitted.length > 0) {
+    console.warn(
+      chalk.red.bold(
+        `\n⚠ ${uncommitted.length} uncommitted file(s) under .trellis/ (spec/tasks/workspace) ` +
+          `will be permanently deleted with no backup:`,
+      ),
+    );
+    for (const p of uncommitted.slice(0, 20)) {
+      console.warn(chalk.red(`    ${p}`));
+    }
+    if (uncommitted.length > 20) {
+      console.warn(chalk.red(`    … and ${uncommitted.length - 20} more`));
+    }
+    console.warn(
+      chalk.yellow("Commit or stash them first if you want to keep them.\n"),
+    );
+  }
+
   if (options.dryRun) {
     console.log(chalk.gray("Dry run — no files were modified."));
     return;
+  }
+
+  if (uncommitted.length > 0 && options.yes && !dirtyUninstallBypassEnabled()) {
+    console.error(
+      chalk.red(
+        "Refusing to uninstall with --yes while .trellis/ has uncommitted user data " +
+          "(spec/tasks/workspace). Commit or stash it, re-run without --yes to confirm " +
+          "interactively, or set TRELLIS_ALLOW_DIRTY_UNINSTALL=1 to override.",
+      ),
+    );
+    process.exit(1);
   }
 
   if (!options.yes) {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1439,7 +1439,26 @@ function isFileSafeToReplace(
 /**
  * Classify migrations based on file state and user modifications
  */
-function classifyMigrations(
+/**
+ * Whether the manifest records any file under `dirRelativePath` — i.e. whether
+ * Trellis actually created this directory. Used to gate rename-dir migrations:
+ * a directory Trellis never wrote (e.g. a user's own `.windsurf/` editor
+ * config that merely shares a path with a retired Trellis platform dir) must
+ * not be auto-moved.
+ */
+export function dirHasManifestEntries(
+  dirRelativePath: string,
+  hashes: TemplateHashes,
+): boolean {
+  const prefix = dirRelativePath.endsWith("/")
+    ? dirRelativePath
+    : dirRelativePath + "/";
+  return Object.keys(hashes).some(
+    (key) => key === dirRelativePath || key.startsWith(prefix),
+  );
+}
+
+export function classifyMigrations(
   migrations: MigrationItem[],
   cwd: string,
   hashes: TemplateHashes,
@@ -1515,9 +1534,17 @@ function classifyMigrations(
           // Target has user modifications - conflict
           result.conflict.push(item);
         }
-      } else {
-        // Directory rename - always auto (includes user files)
+      } else if (dirHasManifestEntries(item.from, hashes)) {
+        // Trellis created this directory (the manifest tracks files under it),
+        // so the rename is ours to make.
         result.auto.push(item);
+      } else {
+        // Target absent and the source has no manifest record: this is very
+        // likely a user-owned directory that merely shares a path with a
+        // retired Trellis platform dir (e.g. a real `.windsurf/` editor
+        // config). Skipping avoids silently moving the user's data out from
+        // under their editor — even under --force, since skip never executes.
+        result.skip.push(item);
       }
     } else if (item.type === "delete") {
       if (isTemplateModified(cwd, item.from, hashes)) {
@@ -1592,7 +1619,9 @@ function printMigrationSummary(classified: ClassifiedMigrations): void {
   }
 
   if (classified.skip.length > 0) {
-    console.log(chalk.gray("  ○ Skipping (old file not found):"));
+    console.log(
+      chalk.gray("  ○ Skipping (not found, protected, or not Trellis-owned):"),
+    );
     for (const item of classified.skip.slice(0, 3)) {
       console.log(chalk.gray(`    ${item.from}`));
     }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1941,6 +1941,43 @@ function printMigrationResult(result: MigrationResult): void {
 }
 
 /**
+ * One-time 0.2.0 migration: rename `traces-*.md` → `journal-*.md` in every
+ * developer workspace directory.
+ *
+ * Never overwrites an existing `journal-N.md`: a newer session may already
+ * have created it, and `.trellis/workspace/` is excluded from the update
+ * backup (see `BACKUP_EXCLUDE_PATTERNS`), so clobbering it would be
+ * unrecoverable data loss. Conflicting `traces-N.md` files are left in place
+ * and reported instead.
+ */
+export function renameTracesToJournal(workspaceDir: string): {
+  renamed: number;
+  skipped: string[];
+} {
+  const skipped: string[] = [];
+  let renamed = 0;
+  if (!fs.existsSync(workspaceDir)) return { renamed, skipped };
+
+  for (const dev of fs.readdirSync(workspaceDir)) {
+    const devPath = path.join(workspaceDir, dev);
+    if (!fs.statSync(devPath).isDirectory()) continue;
+
+    for (const file of fs.readdirSync(devPath)) {
+      if (!(file.startsWith("traces-") && file.endsWith(".md"))) continue;
+      const oldPath = path.join(devPath, file);
+      const newPath = path.join(devPath, file.replace("traces-", "journal-"));
+      if (fs.existsSync(newPath)) {
+        skipped.push(oldPath);
+        continue;
+      }
+      fs.renameSync(oldPath, newPath);
+      renamed++;
+    }
+  }
+  return { renamed, skipped };
+}
+
+/**
  * Main update command
  */
 export async function update(options: UpdateOptions): Promise<void> {
@@ -2413,29 +2450,19 @@ export async function update(options: UpdateOptions): Promise<void> {
     // and variable file numbers (traces-1.md, traces-2.md, etc.), so we can't enumerate them
     // in the migration manifest. This is a one-time migration for the 0.2.0 naming redesign.
     const workspaceDir = path.join(cwd, PATHS.WORKSPACE);
-    if (fs.existsSync(workspaceDir)) {
-      let journalRenamed = 0;
-      const devDirs = fs.readdirSync(workspaceDir);
-      for (const dev of devDirs) {
-        const devPath = path.join(workspaceDir, dev);
-        if (!fs.statSync(devPath).isDirectory()) continue;
-
-        const files = fs.readdirSync(devPath);
-        for (const file of files) {
-          if (file.startsWith("traces-") && file.endsWith(".md")) {
-            const oldPath = path.join(devPath, file);
-            const newFile = file.replace("traces-", "journal-");
-            const newPath = path.join(devPath, newFile);
-            fs.renameSync(oldPath, newPath);
-            journalRenamed++;
-          }
-        }
-      }
-      if (journalRenamed > 0) {
-        console.log(
-          chalk.cyan(`Renamed ${journalRenamed} traces file(s) to journal`),
-        );
-      }
+    const { renamed: journalRenamed, skipped: journalSkipped } =
+      renameTracesToJournal(workspaceDir);
+    if (journalRenamed > 0) {
+      console.log(
+        chalk.cyan(`Renamed ${journalRenamed} traces file(s) to journal`),
+      );
+    }
+    for (const oldPath of journalSkipped) {
+      console.warn(
+        chalk.yellow(
+          `Kept ${path.relative(cwd, oldPath)}: its journal target already exists`,
+        ),
+      );
     }
   }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -100,8 +100,8 @@ interface ChangeAnalysis {
 type ConflictAction = "overwrite" | "skip" | "create-new";
 
 const CLAUDE_SETTINGS_PATH = ".claude/settings.json";
-const TRELLIS_BLOCK_START = "<!-- TRELLIS:START -->";
-const TRELLIS_BLOCK_END = "<!-- TRELLIS:END -->";
+export const TRELLIS_BLOCK_START = "<!-- TRELLIS:START -->";
+export const TRELLIS_BLOCK_END = "<!-- TRELLIS:END -->";
 const LEGACY_UNTRACKED_AGENTS_MD_BLOCK_HASHES = new Set<string>([
   // v0.5.0-beta.17 and earlier wrote AGENTS.md but did not hash-track it.
   // This hash is the pristine Trellis-managed block before the Subagents

--- a/packages/cli/src/templates/trellis/scripts/common/io.py
+++ b/packages/cli/src/templates/trellis/scripts/common/io.py
@@ -8,6 +8,8 @@ for JSON file operations across all Trellis scripts.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 
@@ -25,13 +27,28 @@ def read_json(path: Path) -> dict | None:
 def write_json(path: Path, data: dict) -> bool:
     """Write dict to JSON file with pretty formatting.
 
+    The write is atomic: content goes to a temp file in the same directory
+    and is then renamed over the target. A crash or Ctrl-C mid-write leaves
+    the existing file intact rather than truncated, so a corrupted task.json
+    can never make a task silently vanish from `task.py list`.
+
     Returns True on success, False on error.
     """
+    payload = json.dumps(data, indent=2, ensure_ascii=False)
     try:
-        path.write_text(
-            json.dumps(data, indent=2, ensure_ascii=False),
-            encoding="utf-8",
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
         )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
         return True
     except (OSError, IOError):
         return False

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -51,6 +51,7 @@ from .safe_commit import (
 from .task_utils import (
     archive_task_complete,
     find_task_by_name,
+    is_within_tasks_dir,
     resolve_task_dir,
     run_task_hooks,
 )
@@ -453,6 +454,17 @@ def cmd_archive(args: argparse.Namespace) -> int:
         from .tasks import iter_active_tasks
         for t in iter_active_tasks(tasks_dir):
             print(f"  - {t.dir_name}/", file=sys.stderr)
+        return 1
+
+    # Refuse to archive anything that isn't a real task directly under
+    # .trellis/tasks/. A mistyped name (e.g. "src") resolves to repo_root/src,
+    # which is a dir but not a task — without this guard archive would move the
+    # user's source directory out of the repo.
+    if not is_within_tasks_dir(task_dir, repo_root):
+        print(colored(
+            f"Error: refusing to archive '{task_name}': "
+            f"{task_dir} is not a task under {tasks_dir}",
+            Colors.RED), file=sys.stderr)
         return 1
 
     dir_name = task_dir.name

--- a/packages/cli/src/templates/trellis/scripts/common/task_utils.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_utils.py
@@ -69,6 +69,28 @@ def is_safe_task_path(task_path: str, repo_root: Path | None = None) -> bool:
     return True
 
 
+def is_within_tasks_dir(task_dir_abs: Path, repo_root: Path | None = None) -> bool:
+    """Check that a resolved task directory really is a task under the tasks dir.
+
+    A real task lives directly at ``.trellis/tasks/<name>``. This returns True
+    only when ``task_dir_abs`` is an immediate child of the tasks directory.
+
+    Guards archive: ``resolve_task_dir`` falls back to ``repo_root/<name>`` for
+    an unknown name, so a mistyped ``task.py archive src`` resolves to the real
+    ``src/`` source directory. Without this check archive would ``shutil.move``
+    it out of the repo. Also rejects the tasks dir itself and anything nested
+    under ``archive/`` (already-archived tasks).
+    """
+    if repo_root is None:
+        repo_root = get_repo_root()
+    try:
+        resolved = task_dir_abs.resolve()
+        tasks_resolved = get_tasks_dir(repo_root).resolve()
+    except (OSError, RuntimeError):
+        return False
+    return resolved.parent == tasks_resolved
+
+
 # =============================================================================
 # Task Lookup
 # =============================================================================

--- a/packages/cli/src/utils/atomic-write.ts
+++ b/packages/cli/src/utils/atomic-write.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Write a file atomically: stream into a temp file in the same directory,
+ * then rename it over the target. A crash, Ctrl-C, or ENOSPC mid-write
+ * leaves the original file intact (or absent) — never truncated or
+ * half-written. The temp file shares the target's directory so the rename
+ * stays on one filesystem and is therefore atomic.
+ *
+ * On failure the temp file is removed on a best-effort basis and the
+ * original error is re-thrown.
+ */
+export function writeFileAtomic(
+  filePath: string,
+  data: string | Uint8Array,
+): void {
+  const dir = path.dirname(filePath);
+  const tmp = path.join(dir, `.${path.basename(filePath)}.${process.pid}.tmp`);
+  try {
+    fs.writeFileSync(tmp, data);
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // best-effort cleanup; surface the original write error
+    }
+    throw err;
+  }
+}

--- a/packages/cli/src/utils/file-writer.ts
+++ b/packages/cli/src/utils/file-writer.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import chalk from "chalk";
 import inquirer from "inquirer";
 
+import { writeFileAtomic } from "./atomic-write.js";
 import { toPosix } from "./posix.js";
 
 export type WriteMode = "ask" | "force" | "skip" | "append";
@@ -95,7 +96,7 @@ function appendToFile(
   const newContent = existingContent.endsWith("\n")
     ? existingContent + content
     : existingContent + "\n" + content;
-  fs.writeFileSync(filePath, newContent);
+  writeFileAtomic(filePath, newContent);
   if (options?.executable) {
     fs.chmodSync(filePath, "755");
   }
@@ -120,7 +121,7 @@ export async function writeFile(
 
   if (!exists) {
     // File doesn't exist, write directly
-    fs.writeFileSync(filePath, content);
+    writeFileAtomic(filePath, content);
     if (options?.executable) {
       fs.chmodSync(filePath, "755");
     }
@@ -147,7 +148,7 @@ export async function writeFile(
       : globalWriteMode;
 
   if (mode === "force") {
-    fs.writeFileSync(filePath, content);
+    writeFileAtomic(filePath, content);
     if (options?.executable) {
       fs.chmodSync(filePath, "755");
     }
@@ -196,7 +197,7 @@ export async function writeFile(
   }
 
   if (action === "overwrite") {
-    fs.writeFileSync(filePath, content);
+    writeFileAtomic(filePath, content);
     if (options?.executable) {
       fs.chmodSync(filePath, "755");
     }
@@ -219,7 +220,7 @@ export async function writeFile(
 
   if (action === "overwrite-all") {
     globalWriteMode = "force";
-    fs.writeFileSync(filePath, content);
+    writeFileAtomic(filePath, content);
     if (options?.executable) {
       fs.chmodSync(filePath, "755");
     }

--- a/packages/cli/src/utils/registry-config.ts
+++ b/packages/cli/src/utils/registry-config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { DIR_NAMES } from "../constants/paths.js";
+import { writeFileAtomic } from "./atomic-write.js";
 import { toPosix } from "./posix.js";
 
 export interface SpecRegistryConfig {
@@ -162,7 +163,7 @@ export function writeSpecRegistryConfig(
         output.push(...specLines);
       }
     }
-    fs.writeFileSync(filePath, output.join("\n"), "utf-8");
+    writeFileAtomic(filePath, output.join("\n"));
     return;
   }
 
@@ -180,5 +181,5 @@ export function writeSpecRegistryConfig(
     "",
   ].join("\n");
 
-  fs.writeFileSync(filePath, content.trimEnd() + "\n" + section, "utf-8");
+  writeFileAtomic(filePath, content.trimEnd() + "\n" + section);
 }

--- a/packages/cli/src/utils/template-fetcher.ts
+++ b/packages/cli/src/utils/template-fetcher.ts
@@ -927,7 +927,12 @@ export async function downloadWithStrategy(
     } finally {
       // Best-effort cleanup; also settles giget's orphaned download promise
       // on timeout (giget has no AbortSignal, so removing the dir ENOENTs it).
-      await fs.promises.rm(tempDir, { recursive: true, force: true });
+      // A rejected rm (EBUSY/EPERM) must not replace the download outcome.
+      try {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
     }
     return true;
   }
@@ -959,8 +964,13 @@ export async function downloadWithStrategy(
       }
       throw error;
     } finally {
-      // Clean up temp directory
-      await fs.promises.rm(tempDir, { recursive: true, force: true });
+      // Clean up temp directory. A rejected rm (EBUSY/EPERM) must not
+      // replace the download outcome.
+      try {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
     }
     return true;
   }

--- a/packages/cli/src/utils/template-fetcher.ts
+++ b/packages/cli/src/utils/template-fetcher.ts
@@ -904,9 +904,32 @@ export async function downloadWithStrategy(
     return false;
   }
 
-  // overwrite: Delete existing directory first
+  // overwrite: Download to a temp dir first, then swap it in. Deleting
+  // destDir up-front and downloading in place would destroy the user's
+  // existing spec if the download fails (network timeout, etc.) — the
+  // operation they asked for never completed, yet their data is gone.
   if (strategy === "overwrite" && exists) {
-    await fs.promises.rm(destDir, { recursive: true });
+    const tempDir = path.join(os.tmpdir(), `trellis-template-${Date.now()}`);
+    try {
+      await withTimeout(
+        downloadTemplate(gigetSource, {
+          dir: tempDir,
+          preferOffline: true,
+        }),
+        TIMEOUTS.DOWNLOAD_MS,
+        "Template download",
+      );
+      // Download succeeded — only now is it safe to replace the old dir.
+      // copyMissing into a freshly removed dir copies everything, and works
+      // across filesystems (tempDir lives in os.tmpdir()).
+      await fs.promises.rm(destDir, { recursive: true, force: true });
+      await copyMissing(tempDir, destDir);
+    } finally {
+      // Best-effort cleanup; also settles giget's orphaned download promise
+      // on timeout (giget has no AbortSignal, so removing the dir ENOENTs it).
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+    return true;
   }
 
   // append: Download to temp dir, then merge missing files

--- a/packages/cli/src/utils/template-hash.ts
+++ b/packages/cli/src/utils/template-hash.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 
 import { DIR_NAMES, FILE_NAMES } from "../constants/paths.js";
 import type { TemplateHashes } from "../types/migration.js";
+import { writeFileAtomic } from "./atomic-write.js";
 import { toPosix } from "./posix.js";
 
 /** File name for storing template hashes */
@@ -113,7 +114,7 @@ export function saveHashes(cwd: string, hashes: TemplateHashes): void {
     __version: HASHES_SCHEMA_VERSION,
     hashes: normalizeHashKeys(hashes),
   };
-  fs.writeFileSync(hashesPath, JSON.stringify(payload, null, 2));
+  writeFileAtomic(hashesPath, JSON.stringify(payload, null, 2));
 }
 
 /**

--- a/packages/cli/test/commands/channel-guard.test.ts
+++ b/packages/cli/test/commands/channel-guard.test.ts
@@ -310,6 +310,30 @@ describe("scanLiveWorkers + enforceSpawnBudget (integration)", () => {
     expect(typeof live[0].state.idleSince).toBe("string");
   });
 
+  it("skips legacy channel dirs with pre-validation names instead of throwing", async () => {
+    await createChannel("c-ok", { by: "main" });
+    await appendEvent(
+      "c-ok",
+      { kind: "spawned", by: "main", as: "w1", provider: "claude" },
+      env.projectKey,
+    );
+    writeLivePid(env.channelsRoot, env.projectKey, "c-ok", "w1");
+
+    // A store from before name validation: a channel dir whose name fails
+    // SAFE_SEGMENT_RE. Without the skip, readReservationWorkers → channelDir
+    // throws and the whole scan dies.
+    const legacyDir = path.join(env.channelsRoot, env.projectKey, "bad name");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "events.jsonl"), "");
+
+    const live = scanLiveWorkers({
+      projectKey: env.projectKey,
+      isSupervisorProcess: verifySupervisor,
+    });
+    expect(live).toHaveLength(1);
+    expect(live[0].channel).toBe("c-ok");
+  });
+
   it("counts spawn reservations before spawned is durable", async () => {
     await createChannel("c1b", { by: "main" });
     writeReservation(env.channelsRoot, env.projectKey, "c1b", "reserved");

--- a/packages/cli/test/commands/channel-name-safety.test.ts
+++ b/packages/cli/test/commands/channel-name-safety.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertSafeName,
+  channelDir,
+} from "../../src/commands/channel/store/paths.js";
+
+// The CLI keeps its own copy of the channel path helpers, so the
+// path-traversal guard needs its own regression test here — a change to
+// the CLI copy alone must not silently drop the check.
+describe("cli channel name path-traversal guard", () => {
+  it("rejects traversal and separators", () => {
+    for (const bad of ["..", ".", "../x", "../../x", "a/b", "a\\b"]) {
+      expect(() => assertSafeName(bad)).toThrow(/Invalid channel name/);
+    }
+  });
+
+  it("accepts the names real channels use", () => {
+    for (const ok of ["a", "chat-only", "ch1", "legacy_thread", "a.b"]) {
+      expect(() => assertSafeName(ok)).not.toThrow();
+    }
+  });
+
+  it("channelDir refuses to resolve outside the store", () => {
+    expect(() => channelDir("../../escape")).toThrow(/Invalid channel name/);
+  });
+});

--- a/packages/cli/test/commands/init-uninstall-overdelete.integration.test.ts
+++ b/packages/cli/test/commands/init-uninstall-overdelete.integration.test.ts
@@ -163,6 +163,46 @@ describe("init + uninstall: manifest accuracy + homedir guard", () => {
     );
   });
 
+  // ----- R1.6: Trellis-written AGENTS.md with user content outside the block -----
+
+  it("#R1.6 uninstall strips only the Trellis block from a tracked AGENTS.md, preserving user content outside it", async () => {
+    // Trellis writes AGENTS.md (so it's manifest-tracked, unlike the
+    // skip-existing cases above). The user then adds their own instructions
+    // OUTSIDE the <!-- TRELLIS:START/END --> block — a supported layout that
+    // update.ts explicitly preserves. Uninstall must not unlink the whole
+    // file and take the user content with it.
+    await init({ yes: true, claude: true, force: true });
+    const agentsPath = path.join(tmpDir, "AGENTS.md");
+    // Sanity: Trellis tracked it and wrote the managed block.
+    expect(loadHashes(tmpDir)).toHaveProperty("AGENTS.md");
+    const written = fs.readFileSync(agentsPath, "utf-8");
+    expect(written).toContain("<!-- TRELLIS:START -->");
+
+    const userSection = "\n## My project rules\n\nAlways rebase.\n";
+    fs.writeFileSync(agentsPath, written + userSection);
+
+    await uninstall({ yes: true });
+
+    expect(fs.existsSync(agentsPath)).toBe(true);
+    const after = fs.readFileSync(agentsPath, "utf-8");
+    expect(after).not.toContain("<!-- TRELLIS:START -->");
+    expect(after).not.toContain("<!-- TRELLIS:END -->");
+    expect(after).toContain("## My project rules");
+    expect(after).toContain("Always rebase.");
+  });
+
+  it("#R1.7 uninstall still deletes a tracked AGENTS.md that is only the Trellis block", async () => {
+    // Normal case: user never edited AGENTS.md, so once the block is stripped
+    // nothing user-authored remains and the file is removed.
+    await init({ yes: true, claude: true, force: true });
+    const agentsPath = path.join(tmpDir, "AGENTS.md");
+    expect(fs.existsSync(agentsPath)).toBe(true);
+
+    await uninstall({ yes: true });
+
+    expect(fs.existsSync(agentsPath)).toBe(false);
+  });
+
   // ----- R3: poisoned-manifest self-heal -----
 
   it("#R3.1 update silently prunes orphan manifest entries", async () => {

--- a/packages/cli/test/commands/uninstall-dirty-guard.integration.test.ts
+++ b/packages/cli/test/commands/uninstall-dirty-guard.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for the uninstall uncommitted-data guard (audit 🔴-7).
+ *
+ * `trellis uninstall` deletes the whole .trellis/ tree — including
+ * user-authored specs, task PRDs, and journals — with no backup. When those
+ * hold uncommitted work, a scripted `--yes` run must fail closed rather than
+ * silently destroy them.
+ *
+ * Uses real git + real python (no child_process mock) because the guard
+ * shells out to `git status` and init shells out to `python3 --version`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import inquirer from "inquirer";
+
+vi.mock("figlet", () => ({
+  default: { textSync: vi.fn(() => "TRELLIS") },
+}));
+vi.mock("inquirer", () => ({
+  default: { prompt: vi.fn() },
+}));
+
+import { init } from "../../src/commands/init.js";
+import {
+  uninstall,
+  collectUncommittedTrellisData,
+} from "../../src/commands/uninstall.js";
+
+function has(cmd: string, args: string[]): boolean {
+  try {
+    execFileSync(cmd, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const canRun = has("git", ["--version"]) && has("python3", ["--version"]);
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
+}
+
+describe.skipIf(!canRun)("uninstall uncommitted-data guard", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "trellis-dirty-")),
+    );
+    git(tmpDir, "init", "-q", "-b", "main");
+    git(tmpDir, "config", "user.email", "t@example.com");
+    git(tmpDir, "config", "user.name", "Test");
+    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    vi.spyOn(console, "log").mockImplementation(noop);
+    vi.spyOn(console, "warn").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+    vi.mocked(inquirer.prompt).mockResolvedValue({ proceed: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    delete process.env.TRELLIS_ALLOW_DIRTY_UNINSTALL;
+    await init({ yes: true, claude: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.TRELLIS_ALLOW_DIRTY_UNINSTALL;
+  });
+
+  it("detects a newly added spec file once the tree is committed", () => {
+    // Commit the init'd tree first so git reports the new file individually
+    // (an entirely-untracked .trellis collapses to the dir name instead).
+    git(tmpDir, "add", "-A");
+    git(tmpDir, "commit", "-q", "-m", "trellis");
+
+    const specFile = path.join(tmpDir, ".trellis", "spec", "my-rules.md");
+    fs.mkdirSync(path.dirname(specFile), { recursive: true });
+    fs.writeFileSync(specFile, "my custom spec");
+
+    const dirty = collectUncommittedTrellisData(tmpDir);
+    expect(dirty.some((p) => p.includes("spec/my-rules.md"))).toBe(true);
+  });
+
+  it("reports nothing once the .trellis tree is committed", () => {
+    git(tmpDir, "add", "-A");
+    git(tmpDir, "commit", "-q", "-m", "trellis");
+    expect(collectUncommittedTrellisData(tmpDir)).toEqual([]);
+  });
+
+  it("refuses --yes uninstall while user data is uncommitted, leaving .trellis intact", async () => {
+    const specFile = path.join(tmpDir, ".trellis", "spec", "my-rules.md");
+    fs.mkdirSync(path.dirname(specFile), { recursive: true });
+    fs.writeFileSync(specFile, "unsaved work");
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code ?? 0})`);
+      }) as never);
+
+    await expect(uninstall({ yes: true })).rejects.toThrow("process.exit(1)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    // Nothing was deleted — the spec and the tree survive.
+    expect(fs.existsSync(specFile)).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".trellis"))).toBe(true);
+  });
+
+  it("TRELLIS_ALLOW_DIRTY_UNINSTALL=1 overrides the guard", async () => {
+    const specFile = path.join(tmpDir, ".trellis", "spec", "my-rules.md");
+    fs.mkdirSync(path.dirname(specFile), { recursive: true });
+    fs.writeFileSync(specFile, "unsaved work");
+    process.env.TRELLIS_ALLOW_DIRTY_UNINSTALL = "1";
+
+    await uninstall({ yes: true });
+
+    // Override honored — the tree is removed.
+    expect(fs.existsSync(path.join(tmpDir, ".trellis"))).toBe(false);
+  });
+
+  it("committed user data does not block --yes uninstall", async () => {
+    git(tmpDir, "add", "-A");
+    git(tmpDir, "commit", "-q", "-m", "trellis");
+
+    await uninstall({ yes: true });
+
+    expect(fs.existsSync(path.join(tmpDir, ".trellis"))).toBe(false);
+  });
+});

--- a/packages/cli/test/commands/update-internals.test.ts
+++ b/packages/cli/test/commands/update-internals.test.ts
@@ -341,3 +341,81 @@ describe("renameTracesToJournal", () => {
     });
   });
 });
+
+// =============================================================================
+// rename-dir ownership gate — 🔴-4: never auto-move a user-owned directory
+// =============================================================================
+
+import {
+  classifyMigrations,
+  dirHasManifestEntries,
+} from "../../src/commands/update.js";
+import type { MigrationItem } from "../../src/types/migration.js";
+
+describe("dirHasManifestEntries", () => {
+  it("is true when the manifest tracks a file under the dir", () => {
+    expect(
+      dirHasManifestEntries(".windsurf/workflows", {
+        ".windsurf/workflows/a.md": "hash",
+      }),
+    ).toBe(true);
+  });
+
+  it("is true on an exact key match", () => {
+    expect(dirHasManifestEntries("AGENTS.md", { "AGENTS.md": "h" })).toBe(true);
+  });
+
+  it("is false when nothing under the dir is tracked", () => {
+    expect(
+      dirHasManifestEntries(".windsurf/workflows", {
+        ".claude/settings.json": "h",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match a sibling dir that shares a prefix string", () => {
+    // ".devin" must not match ".devinX/..."
+    expect(
+      dirHasManifestEntries(".devin", { ".devinX/a.md": "h" }),
+    ).toBe(false);
+  });
+});
+
+describe("classifyMigrations rename-dir ownership gate", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-renamedir-"));
+    // A user-owned .windsurf/workflows that Trellis never created.
+    fs.mkdirSync(path.join(tmpDir, ".windsurf", "workflows"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".windsurf", "workflows", "user.md"),
+      "user workflow",
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const migration: MigrationItem[] = [
+    { type: "rename-dir", from: ".windsurf/workflows", to: ".devin/workflows" },
+  ];
+
+  it("skips (never auto-moves) an unowned source dir when the target is absent", () => {
+    const result = classifyMigrations(migration, tmpDir, {}, new Map());
+    expect(result.auto).toHaveLength(0);
+    expect(result.skip).toHaveLength(1);
+    expect(result.skip[0].from).toBe(".windsurf/workflows");
+  });
+
+  it("auto-migrates when Trellis owns the source dir (manifest has entries)", () => {
+    const hashes = { ".windsurf/workflows/user.md": "some-hash" };
+    const result = classifyMigrations(migration, tmpDir, hashes, new Map());
+    expect(result.skip).toHaveLength(0);
+    expect(result.auto).toHaveLength(1);
+    expect(result.auto[0].to).toBe(".devin/workflows");
+  });
+});

--- a/packages/cli/test/commands/update-internals.test.ts
+++ b/packages/cli/test/commands/update-internals.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import {
   cleanupEmptyDirs,
   loadUpdateSkipPaths,
+  renameTracesToJournal,
   shouldExcludeFromBackup,
   sortMigrationsForExecution,
 } from "../../src/commands/update.js";
@@ -278,5 +279,65 @@ describe("shouldExcludeFromBackup", () => {
     ".opencode\\node_modules\\zod\\index.js",
   ])("excludes Windows-style backslash path %s", (p) => {
     expect(shouldExcludeFromBackup(p)).toBe(true);
+  });
+});
+
+// =============================================================================
+// renameTracesToJournal — 0.2.0 traces→journal migration (data-safety)
+// =============================================================================
+
+describe("renameTracesToJournal", () => {
+  let tmpDir: string;
+  let ws: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-traces-"));
+    ws = path.join(tmpDir, "workspace");
+    fs.mkdirSync(path.join(ws, "alice"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renames traces-N.md to journal-N.md when no target exists", () => {
+    const dev = path.join(ws, "alice");
+    fs.writeFileSync(path.join(dev, "traces-1.md"), "trace one");
+
+    const { renamed, skipped } = renameTracesToJournal(ws);
+
+    expect(renamed).toBe(1);
+    expect(skipped).toEqual([]);
+    expect(fs.existsSync(path.join(dev, "traces-1.md"))).toBe(false);
+    expect(fs.readFileSync(path.join(dev, "journal-1.md"), "utf-8")).toBe(
+      "trace one",
+    );
+  });
+
+  it("never overwrites an existing journal target; keeps both and reports it", () => {
+    const dev = path.join(ws, "alice");
+    fs.writeFileSync(path.join(dev, "traces-1.md"), "old trace");
+    // A newer session already created journal-1.md with real history.
+    fs.writeFileSync(path.join(dev, "journal-1.md"), "REAL SESSION HISTORY");
+
+    const { renamed, skipped } = renameTracesToJournal(ws);
+
+    expect(renamed).toBe(0);
+    expect(skipped).toEqual([path.join(dev, "traces-1.md")]);
+    // Existing journal is untouched...
+    expect(fs.readFileSync(path.join(dev, "journal-1.md"), "utf-8")).toBe(
+      "REAL SESSION HISTORY",
+    );
+    // ...and the traces file is preserved, not destroyed.
+    expect(fs.readFileSync(path.join(dev, "traces-1.md"), "utf-8")).toBe(
+      "old trace",
+    );
+  });
+
+  it("returns zero counts when the workspace dir does not exist", () => {
+    expect(renameTracesToJournal(path.join(tmpDir, "nope"))).toEqual({
+      renamed: 0,
+      skipped: [],
+    });
   });
 });

--- a/packages/cli/test/scripts/task-archive.integration.test.ts
+++ b/packages/cli/test/scripts/task-archive.integration.test.ts
@@ -202,6 +202,36 @@ describe.skipIf(!hasPython())(
       30_000, // python startup + 100-file ops can be slow
     );
 
+    it("refuses to archive a mistyped name that resolves to a real source dir", () => {
+      makeTask(tmp, "real-task", "# real task\n");
+      // A user source directory that is NOT a task.
+      const srcDir = path.join(tmp, "src");
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(path.join(srcDir, "index.ts"), "export const x = 1;\n");
+      git(tmp, "add", "-A");
+      git(tmp, "commit", "-q", "-m", "initial");
+
+      // Typo: `archive src` instead of a task name. resolve_task_dir falls
+      // back to repo_root/src; without the guard this moves the whole source
+      // dir into .trellis/tasks/archive/.
+      const r = spawnSync(
+        "python3",
+        [".trellis/scripts/task.py", "archive", "src"],
+        { cwd: tmp, encoding: "utf-8" },
+      );
+
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain("refusing to archive");
+      // src/ untouched, still at its original location with its file.
+      expect(fs.existsSync(path.join(srcDir, "index.ts"))).toBe(true);
+      // No archive dir was created holding a moved src.
+      expect(
+        fs.existsSync(
+          path.join(tmp, ".trellis", "tasks", "archive"),
+        ),
+      ).toBe(false);
+    });
+
     it("fails when archive auto-commit cannot record tracked source deletes", () => {
       makeTask(tmp, "tracked", "# tracked task\n");
       git(tmp, "add", "-A");

--- a/packages/cli/test/utils/atomic-write.test.ts
+++ b/packages/cli/test/utils/atomic-write.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeFileAtomic } from "../../src/utils/atomic-write.js";
+
+describe("writeFileAtomic", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-atomic-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes new content", () => {
+    const f = path.join(dir, "a.json");
+    writeFileAtomic(f, '{"x":1}');
+    expect(fs.readFileSync(f, "utf-8")).toBe('{"x":1}');
+  });
+
+  it("overwrites and leaves no temp file behind", () => {
+    const f = path.join(dir, "a.json");
+    writeFileAtomic(f, "old");
+    writeFileAtomic(f, "new");
+    expect(fs.readFileSync(f, "utf-8")).toBe("new");
+    expect(fs.readdirSync(dir)).toEqual(["a.json"]);
+  });
+
+  it("preserves the original file when the write fails", () => {
+    const f = path.join(dir, "keep.json");
+    writeFileAtomic(f, "original");
+    // A directory in place of the temp target's parent is not the failure we
+    // model; instead force a rename failure by pointing at an unwritable dir.
+    const roDir = path.join(dir, "ro");
+    fs.mkdirSync(roDir);
+    const target = path.join(roDir, "x.json");
+    writeFileAtomic(target, "first");
+    fs.chmodSync(roDir, 0o500); // read+execute only, no write
+    try {
+      expect(() => writeFileAtomic(target, "second")).toThrow();
+      // Original survives; no half-written temp left in the dir.
+      expect(fs.readFileSync(target, "utf-8")).toBe("first");
+      expect(fs.readdirSync(roDir)).toEqual(["x.json"]);
+    } finally {
+      fs.chmodSync(roDir, 0o700);
+    }
+  });
+});

--- a/packages/cli/test/utils/template-fetcher-cleanup.test.ts
+++ b/packages/cli/test/utils/template-fetcher-cleanup.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests: temp-dir cleanup in `downloadWithStrategy` is
+ * best-effort — a rejected `fs.promises.rm` (EBUSY/EPERM on Windows) must
+ * not replace the download outcome (success return or download error).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadWithStrategy } from "../../src/utils/template-fetcher.js";
+
+vi.mock("giget", () => ({
+  downloadTemplate: vi.fn(async (_src: string, opts: { dir: string }) => {
+    fs.mkdirSync(opts.dir, { recursive: true });
+    fs.writeFileSync(path.join(opts.dir, "file.md"), "new content");
+    return { dir: opts.dir, source: "mock" };
+  }),
+}));
+
+describe("downloadWithStrategy temp-dir cleanup", () => {
+  let tmpDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-fetch-clean-"));
+    destDir = path.join(tmpDir, "dest");
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, "old.md"), "old content");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function failTempDirCleanup(): void {
+    const realRm = fs.promises.rm.bind(fs.promises);
+    vi.spyOn(fs.promises, "rm").mockImplementation(async (p, opts) => {
+      if (String(p).includes("trellis-template-")) {
+        throw Object.assign(new Error("EBUSY: resource busy"), {
+          code: "EBUSY",
+        });
+      }
+      return realRm(p as fs.PathLike, opts);
+    });
+  }
+
+  it("overwrite: a failed temp cleanup does not mask the successful download", async () => {
+    failTempDirCleanup();
+    await expect(
+      downloadWithStrategy("some/template", destDir, "overwrite"),
+    ).resolves.toBe(true);
+    // The swap itself still happened.
+    expect(fs.readFileSync(path.join(destDir, "file.md"), "utf-8")).toBe(
+      "new content",
+    );
+    expect(fs.existsSync(path.join(destDir, "old.md"))).toBe(false);
+  });
+
+  it("append: a failed temp cleanup does not mask the successful download", async () => {
+    failTempDirCleanup();
+    await expect(
+      downloadWithStrategy("some/template", destDir, "append"),
+    ).resolves.toBe(true);
+    // append keeps existing files and adds missing ones.
+    expect(fs.readFileSync(path.join(destDir, "old.md"), "utf-8")).toBe(
+      "old content",
+    );
+    expect(fs.readFileSync(path.join(destDir, "file.md"), "utf-8")).toBe(
+      "new content",
+    );
+  });
+});

--- a/packages/cli/test/utils/template-fetcher-overwrite.test.ts
+++ b/packages/cli/test/utils/template-fetcher-overwrite.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Control giget's downloadTemplate per-test: it either writes template files
+// into the requested dir (success) or throws (download failure).
+const downloadTemplateMock = vi.fn();
+vi.mock("giget", () => ({
+  downloadTemplate: (source: string, opts: { dir: string }) =>
+    downloadTemplateMock(source, opts),
+}));
+
+import { downloadWithStrategy } from "../../src/utils/template-fetcher.js";
+
+describe("downloadWithStrategy overwrite: temp-first swap", () => {
+  let cwd: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-overwrite-"));
+    destDir = path.join(cwd, ".trellis", "spec");
+    fs.mkdirSync(destDir, { recursive: true });
+    // Pre-existing user-authored spec.
+    fs.writeFileSync(path.join(destDir, "user.md"), "MY OWN SPEC");
+    downloadTemplateMock.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("replaces the dir when the download succeeds", async () => {
+    downloadTemplateMock.mockImplementation(async (_src, opts) => {
+      fs.mkdirSync(opts.dir, { recursive: true });
+      fs.writeFileSync(path.join(opts.dir, "template.md"), "FROM TEMPLATE");
+    });
+
+    const result = await downloadWithStrategy(
+      "some/path",
+      destDir,
+      "overwrite",
+    );
+
+    expect(result).toBe(true);
+    expect(fs.readFileSync(path.join(destDir, "template.md"), "utf-8")).toBe(
+      "FROM TEMPLATE",
+    );
+    // Overwrite replaces: the old user file is gone (that is the asked-for op).
+    expect(fs.existsSync(path.join(destDir, "user.md"))).toBe(false);
+  });
+
+  it("preserves the existing dir when the download fails", async () => {
+    downloadTemplateMock.mockRejectedValue(
+      new Error("Template download timed out"),
+    );
+
+    await expect(
+      downloadWithStrategy("some/path", destDir, "overwrite"),
+    ).rejects.toThrow(/timed out/);
+
+    // The user's spec must survive a failed overwrite — the operation they
+    // asked for never completed.
+    expect(fs.existsSync(destDir)).toBe(true);
+    expect(fs.readFileSync(path.join(destDir, "user.md"), "utf-8")).toBe(
+      "MY OWN SPEC",
+    );
+    // No stray temp dir left in os.tmpdir() for this run is not asserted here
+    // (shared dir), but destDir must contain only the original file.
+    expect(fs.readdirSync(destDir)).toEqual(["user.md"]);
+  });
+});

--- a/packages/core/src/channel/internal/store/paths.ts
+++ b/packages/core/src/channel/internal/store/paths.ts
@@ -46,13 +46,23 @@ const BUCKET_MARKER = ".bucket";
 const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
 
 /**
+ * Whether a channel/worker name is usable as a filesystem segment.
+ * Discovery scans use this to skip directories created before name
+ * validation existed (spaces, CJK, ...) — they can never be valid
+ * channels, and `assertSafeName` throwing mid-scan would kill the scan.
+ */
+export function isSafeName(name: string): boolean {
+  return name !== "." && name !== ".." && SAFE_SEGMENT_RE.test(name);
+}
+
+/**
  * Reject names that would escape their bucket when joined into a path.
  * A channel/worker name becomes a filesystem segment; without this guard
  * a name like `../../x` lets `path.join` resolve outside the store and a
  * later `fs.rmSync(recursive)` deletes arbitrary directories.
  */
 export function assertSafeName(name: string, kind = "channel"): void {
-  if (name === "." || name === ".." || !SAFE_SEGMENT_RE.test(name)) {
+  if (!isSafeName(name)) {
     throw new Error(
       `Invalid ${kind} name: ${JSON.stringify(name)}. ` +
         `Names may only contain letters, digits, '.', '_' and '-'.`,
@@ -207,6 +217,10 @@ export function listChannelNamesInProject(project: string): string[] {
   }
   for (const entry of entries) {
     if (entry.startsWith(".")) continue;
+    // Pre-validation legacy dirs (spaces, CJK, ...) can never be valid
+    // channels; returning them would make the watcher's channelDir/
+    // eventsPath calls throw and kill cross-channel discovery.
+    if (!isSafeName(entry)) continue;
     const channelEvents = path.join(dir, entry, "events.jsonl");
     if (fs.existsSync(channelEvents)) out.push(entry);
   }

--- a/packages/core/src/channel/internal/store/paths.ts
+++ b/packages/core/src/channel/internal/store/paths.ts
@@ -42,10 +42,29 @@ export function projectDir(project: string = currentProjectKey()): string {
 
 const BUCKET_MARKER = ".bucket";
 
+/** Characters allowed in a channel or worker name used as a path segment. */
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Reject names that would escape their bucket when joined into a path.
+ * A channel/worker name becomes a filesystem segment; without this guard
+ * a name like `../../x` lets `path.join` resolve outside the store and a
+ * later `fs.rmSync(recursive)` deletes arbitrary directories.
+ */
+export function assertSafeName(name: string, kind = "channel"): void {
+  if (name === "." || name === ".." || !SAFE_SEGMENT_RE.test(name)) {
+    throw new Error(
+      `Invalid ${kind} name: ${JSON.stringify(name)}. ` +
+        `Names may only contain letters, digits, '.', '_' and '-'.`,
+    );
+  }
+}
+
 export function channelDir(
   name: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(name);
   return path.join(projectDir(project), name);
 }
 
@@ -76,6 +95,7 @@ export function workerFile(
   suffix: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(worker, "worker");
   return path.join(channelDir(name, project), `${worker}.${suffix}`);
 }
 
@@ -84,6 +104,7 @@ export function workerLockPath(
   worker: string,
   project: string = currentProjectKey(),
 ): string {
+  assertSafeName(worker, "worker");
   return path.join(channelDir(name, project), `${worker}.spawnlock`);
 }
 

--- a/packages/core/test/channel/name-safety.test.ts
+++ b/packages/core/test/channel/name-safety.test.ts
@@ -7,6 +7,9 @@ import { createChannel } from "../../src/channel/index.js";
 import {
   assertSafeName,
   channelDir,
+  isSafeName,
+  listChannelNamesInProject,
+  projectDir,
 } from "../../src/channel/internal/store/paths.js";
 import { setupChannelTmp, type TmpEnv } from "./setup.js";
 
@@ -37,6 +40,22 @@ describe("channel name path-traversal guard", () => {
 
   it("channelDir throws instead of resolving outside the store", () => {
     expect(() => channelDir("../../escape")).toThrow(/Invalid channel name/);
+  });
+
+  it("listChannelNamesInProject skips legacy dirs with pre-validation names", async () => {
+    await createChannel({ channel: "good-one", by: "main" });
+
+    // A dir created before name validation existed. Returning it would make
+    // the watcher's channelDir/eventsPath calls throw mid-discovery.
+    const bucket = projectDir();
+    const legacyDir = path.join(bucket, "坏 名字");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "events.jsonl"), "");
+
+    const names = listChannelNamesInProject(path.basename(bucket));
+    expect(names).toContain("good-one");
+    expect(names).not.toContain("坏 名字");
+    for (const name of names) expect(isSafeName(name)).toBe(true);
   });
 
   it("createChannel --force cannot delete a directory outside the store", async () => {

--- a/packages/core/test/channel/name-safety.test.ts
+++ b/packages/core/test/channel/name-safety.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createChannel } from "../../src/channel/index.js";
+import {
+  assertSafeName,
+  channelDir,
+} from "../../src/channel/internal/store/paths.js";
+import { setupChannelTmp, type TmpEnv } from "./setup.js";
+
+describe("channel name path-traversal guard", () => {
+  let env: TmpEnv;
+  beforeEach(() => {
+    env = setupChannelTmp();
+    vi.spyOn(process, "cwd").mockReturnValue(env.projectDir);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    env.cleanup();
+  });
+
+  const traversal = ["..", ".", "../x", "../../x", "a/b", "a\\b", "x/../y"];
+
+  it("assertSafeName rejects traversal and separators", () => {
+    for (const bad of traversal) {
+      expect(() => assertSafeName(bad)).toThrow(/Invalid channel name/);
+    }
+  });
+
+  it("assertSafeName accepts the names real channels use", () => {
+    for (const ok of ["a", "chat-only", "ch1", "legacy_thread", "a.b", "R"]) {
+      expect(() => assertSafeName(ok)).not.toThrow();
+    }
+  });
+
+  it("channelDir throws instead of resolving outside the store", () => {
+    expect(() => channelDir("../../escape")).toThrow(/Invalid channel name/);
+  });
+
+  it("createChannel --force cannot delete a directory outside the store", async () => {
+    // A user directory that lives outside the channel store, reachable via `..`.
+    const victim = path.join(env.tmpDir, "victim");
+    fs.mkdirSync(victim, { recursive: true });
+    const marker = path.join(victim, "keep.txt");
+    fs.writeFileSync(marker, "important");
+
+    // Without the guard, `../../victim` would let path.join resolve out of
+    // the store and force-wipe delete it. The guard throws before any path
+    // resolution, so the external directory is never reached.
+    await expect(
+      createChannel({ channel: "../../victim", by: "main", force: true }),
+    ).rejects.toThrow(/Invalid channel name/);
+
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(fs.readFileSync(marker, "utf-8")).toBe("important");
+  });
+});


### PR DESCRIPTION
Fixes all **8 blocker (🔴) findings** from the 2026-07-10 deep code audit — cases where a normal execution path could irreversibly delete or move a user's repository data. Each fix ships with a regression test (most fail without the fix).

## Blockers fixed

| Commit | Finding | Fix |
|---|---|---|
| `4899d5a` | 🔴-2 / 🔴-8 path traversal | Whitelist channel/worker names at the `channelDir` chokepoint — one guard covers the `create`/`rm`/`run` delete entry points. `create '../../x' --force` and `rm '../../x'` no longer `rmSync` outside the store. |
| `c285bd3` | Root cause: non-atomic writes | Add `writeFileAtomic` (temp + rename) and route the attribution manifest, shared file writer, and registry config through it; make Python `write_json` atomic via `os.replace`. Closes the crash-window truncation family (V4/V8/V15/V18/V32 + config.yaml). |
| `5066b18` | 🔴-1 uninstall deletes AGENTS.md | Give AGENTS.md a StructuredFileSpec that strips only the `<!-- TRELLIS:START/END -->` block; delete the file only when nothing user-authored remains. |
| `f3bffb0` | 🔴-3 archive moves `src/` | `task.py archive` refuses any directory that isn't a real task directly under `.trellis/tasks/` (a mistyped `archive src` no longer `shutil.move`s the source tree). |
| `d7fe3a0` | 🔴-6 overwrite deletes-first | The `overwrite` template strategy downloads to a temp dir and only swaps it in on success; a failed download leaves the existing spec untouched. |
| `0c2e276` | 🔴-5 traces→journal clobber | The `traces-*.md → journal-*.md` migration skips (never overwrites) an existing `journal-N.md`; `workspace/` is excluded from the backup, so an overwrite was unrecoverable. |
| `76e44a9` | 🔴-7 `rm -rf .trellis` | Uninstall surfaces uncommitted `spec/tasks/workspace` data and, for scripted `--yes`, fails closed unless `TRELLIS_ALLOW_DIRTY_UNINSTALL=1`. Disclosure now names specs/PRDs/journals/memory. |
| `524c936` | 🔴-4 rename-dir moves `.windsurf/` | rename-dir auto-migrates only when the manifest tracks files under the source dir; an unowned dir (e.g. a real Windsurf editor config) is skipped, safe even under `--force`. |

## Two root causes addressed

- **Non-atomic writes** — 177/184 write points truncated in place. The atomic helper + Python `os.replace` close the whole crash-window family in one place.
- **Path handling** — channel names and archive/rename-dir targets flowed into `path.join`/`shutil.move` without an ownership or containment check.

## Testing

- `packages/core`: 301 tests pass. `packages/cli`: 1350 tests pass.
- New regression tests: channel name-safety (core + cli), `writeFileAtomic`, AGENTS.md strip-vs-delete, `task.py archive` guard, overwrite temp-first, `renameTracesToJournal`, uninstall dirty-guard (real git), rename-dir ownership gate.
- Path-traversal deletes and the overwrite/uninstall data-loss cases were reproduced in a sandbox to confirm the guards hold.

## Not in this PR (second batch)

Concurrency / torn-line 🟠 findings (V19 task.json locking, V20 lock TOCTOU, V21/V26 torn trailing line) need file locking / seq reconciliation — a larger design change, intentionally deferred. The 🟡/⚪ findings were not adversarially verified in the audit and need per-item review before action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger channel/worker name validation with safer reservation/scanning and hardened task archiving (rejects mistyped targets outside the Trellis tasks directory).
  * `uninstall` now scrubs only Trellis-managed `AGENTS.md` blocks and adds a dirty `.trellis` data guard (fails closed with `--yes` unless overridden).
  * `update` migrates `traces-*` to `journal-*` without overwriting and tightens `rename-dir` ownership gating.
* **Bug Fixes**
  * Improved durability via atomic temp-file writes and safer template overwrite/swap cleanup.
* **Documentation**
  * Expanded Filesystem Safety guidance and command specs (channel/uninstall/update).
* **Tests**
  * Added unit/integration coverage for the new guards and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->