### PR TITLE
feat(mem): support project-local Pi session directories

### DIFF
--- a/.trellis/spec/cli/backend/commands-mem.md
+++ b/.trellis/spec/cli/backend/commands-mem.md
@@ -207,9 +207,11 @@ export function collectPiTurnsAndEvents(s: MemSessionInfo): {
 
 - **Roots**: inspect the default root under
   `~/.pi/agent/sessions/--<encoded-cwd>--/`, `PI_CODING_AGENT_DIR`,
-  `PI_CODING_AGENT_SESSION_DIR`, and `settings.json.sessionDir` where visible
-  to the current Trellis process. Custom session dirs contain direct `.jsonl`
-  files and must be filtered by the header `cwd`.
+  `PI_CODING_AGENT_SESSION_DIR`, global `~/.pi/agent/settings.json`, and the
+  scoped project's `.pi/settings.json`. Resolve relative `sessionDir` values
+  from the directory containing their settings file, matching Pi's settings
+  contract. Custom session dirs contain direct `.jsonl` files and must be
+  filtered by the header `cwd`.
 - **Metadata**: the first row must be a `type: "session"` header. Emit
   `platform: "pi"`, `id`, `cwd`, `created`, `updated`, `filePath`, and optional
   `title` from the latest `session_info.name`. Do not use the first user

--- a/packages/core/src/mem/adapters/pi.ts
+++ b/packages/core/src/mem/adapters/pi.ts
@@ -150,7 +150,7 @@ function candidateFiles(f: MemFilter): string[] {
     }
   };
 
-  for (const root of piSessionRoots()) {
+  for (const root of piSessionRoots(f.cwd)) {
     if (f.cwd && path.resolve(root) === path.resolve(defaultRoot)) {
       pushJsonlFiles(piProjectDirFromCwd(f.cwd));
     } else {

--- a/packages/core/src/mem/internal/paths.ts
+++ b/packages/core/src/mem/internal/paths.ts
@@ -29,15 +29,16 @@ export const PI_SESSIONS = expandHome(
     path.join(PI_AGENT_DIR, "sessions"),
 );
 
-function readPiSettingsSessionDir(): string | undefined {
-  const settingsFile = path.join(PI_AGENT_DIR, "settings.json");
+function readPiSettingsSessionDir(settingsFile: string): string | undefined {
   try {
     const raw: unknown = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
     const sessionDir = (raw as { sessionDir?: unknown }).sessionDir;
-    return typeof sessionDir === "string" && sessionDir.trim()
-      ? expandHome(sessionDir)
-      : undefined;
+    if (typeof sessionDir !== "string" || !sessionDir.trim()) return undefined;
+    const expanded = expandHome(sessionDir);
+    return path.isAbsolute(expanded)
+      ? expanded
+      : path.resolve(path.dirname(settingsFile), expanded);
   } catch {
     return undefined;
   }
@@ -58,11 +59,19 @@ export function piProjectDirFromCwd(cwd: string): string {
   return path.join(path.join(PI_AGENT_DIR, "sessions"), safePath);
 }
 
-/** Discover Pi session roots visible from the current process. */
-export function piSessionRoots(): string[] {
+/** Discover Pi session roots visible from the current process and project. */
+export function piSessionRoots(cwd?: string): string[] {
   const roots = [path.join(PI_AGENT_DIR, "sessions"), PI_SESSIONS];
-  const settingsSessionDir = readPiSettingsSessionDir();
-  if (settingsSessionDir) roots.push(settingsSessionDir);
+  const globalSettingsDir = readPiSettingsSessionDir(
+    path.join(PI_AGENT_DIR, "settings.json"),
+  );
+  if (globalSettingsDir) roots.push(globalSettingsDir);
+  if (cwd) {
+    const projectSettingsDir = readPiSettingsSessionDir(
+      path.join(path.resolve(cwd), ".pi", "settings.json"),
+    );
+    if (projectSettingsDir) roots.push(projectSettingsDir);
+  }
 
   const seen = new Set<string>();
   const out: string[] = [];

--- a/packages/core/test/mem/adapters.test.ts
+++ b/packages/core/test/mem/adapters.test.ts
@@ -694,6 +694,7 @@ describe("piListSessions / piExtractDialogue", () => {
   afterEach(() => {
     rimraf(nodePath.join(fakeHome, ".pi"));
     rimraf(nodePath.join(fakeHome, ".pi-custom-sessions"));
+    rimraf(nodePath.join(fakeHome, "pi-project-settings"));
   });
 
   it("returns no sessions when the Pi sessions root doesn't exist", () => {
@@ -736,14 +737,19 @@ describe("piListSessions / piExtractDialogue", () => {
     expect(found?.title).toBe("Pi memory task");
   });
 
-  it("lists sessions from settings-configured custom session roots", () => {
-    const customRoot = nodePath.join(fakeHome, ".pi-custom-sessions");
+  it("resolves relative global sessionDir from the Pi agent directory", () => {
+    const customRoot = nodePath.join(
+      fakeHome,
+      ".pi",
+      "agent",
+      "custom-sessions",
+    );
     const customFile = nodePath.join(
       customRoot,
       `2026-06-18_${sessionId}.jsonl`,
     );
     writeJson(nodePath.join(fakeHome, ".pi", "agent", "settings.json"), {
-      sessionDir: customRoot,
+      sessionDir: "custom-sessions",
     });
     writeJsonl(customFile, [
       {
@@ -763,6 +769,39 @@ describe("piListSessions / piExtractDialogue", () => {
     ]);
 
     const found = piListSessions(mkFilter({ cwd: projectCwd })).find(
+      (s) => s.id === sessionId,
+    );
+    expect(found?.filePath).toBe(customFile);
+  });
+
+  it("lists sessions from project-local Pi settings", () => {
+    const localCwd = nodePath.join(fakeHome, "pi-project-settings");
+    const customRoot = nodePath.join(localCwd, ".pi", "custom-sessions");
+    const customFile = nodePath.join(
+      customRoot,
+      `2026-06-18_${sessionId}.jsonl`,
+    );
+    writeJson(nodePath.join(localCwd, ".pi", "settings.json"), {
+      sessionDir: "custom-sessions",
+    });
+    writeJsonl(customFile, [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-18T10:00:00.000Z",
+        cwd: localCwd,
+      },
+      {
+        type: "message",
+        id: "u1",
+        parentId: null,
+        timestamp: "2026-06-18T10:00:01.000Z",
+        message: { role: "user", content: "project-local root" },
+      },
+    ]);
+
+    const found = piListSessions(mkFilter({ cwd: localCwd })).find(
       (s) => s.id === sessionId,
     );
     expect(found?.filePath).toBe(customFile);


### PR DESCRIPTION
## Summary

- discover Pi session roots from project-local `.pi/settings.json`
- resolve relative `sessionDir` values from the settings file directory
- document and test global and project-scoped Pi settings behavior

## Verification

- `pnpm --filter @mindfold-ai/trellis-core test -- test/mem/adapters.test.ts`
- `pnpm --filter @mindfold-ai/trellis-core lint`
- `pnpm --filter @mindfold-ai/trellis-core typecheck`
- `pnpm --filter @mindfold-ai/trellis-core test`
- `pnpm test:integration -- test/cli/mem.test.ts test/cli/templates.test.ts`
- `pnpm build`
- built CLI smoke test against real local Pi sessions: list, search, context, and extract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of Pi session history across default, global, and project-specific settings.
  * Correctly resolves relative session directory paths based on their settings location.
  * Filters custom session files to match the active working directory.
* **Documentation**
  * Updated CLI and backend specifications to clarify supported Pi session locations and path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->