### PR TITLE
docs(mem): sync Pi session settings guidance

### DIFF
--- a/packages/cli/src/templates/common/bundled-skills/trellis-session-insight/SKILL.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-session-insight/SKILL.md
@@ -11,7 +11,7 @@ It is intentionally a **capability skill, not a workflow**. There is no fixed ou
 
 ## What `trellis mem` is
 
-A local CLI that indexes the user's past Claude Code, Codex, and Pi Agent conversation logs (the JSONL files each platform stores under `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.pi/agent/sessions/`) and lets you list, search, slice by Trellis task boundaries, and dump cleaned dialogue from them. OpenCode logs are not yet indexable (provider adapter pending) — when an OpenCode session is the obvious target, surface that limitation rather than guessing.
+A local CLI that indexes the user's past Claude Code, Codex, and Pi Agent conversation logs and lets you list, search, slice by Trellis task boundaries, and dump cleaned dialogue from them. Claude and Codex use `~/.claude/projects/` and `~/.codex/sessions/`. Pi uses its default or environment-configured session root, global `~/.pi/agent/settings.json`, and the scoped project's `.pi/settings.json`; relative `sessionDir` values resolve from the settings file directory. Project-local Pi settings require project-scoped lookup through the current cwd or `--cwd`. OpenCode logs are not yet indexable (provider adapter pending) — when an OpenCode session is the obvious target, surface that limitation rather than guessing.
 
 Nothing in `mem` is uploaded. All reads are local.
 


### PR DESCRIPTION
## Summary

- update marketplace mem-recall for Pi project-local sessionDir discovery
- synchronize the local Alma mem-recall copy byte-for-byte
- update bundled trellis-session-insight with the same project-scoped lookup behavior
- correct Pi phase-slicing guidance

## Verification

- marketplace and local mem-recall copies are byte-identical
- bundled platform template test: 64 passed
- full pnpm build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported conversation log sources for `trellis mem`, including Claude Code, Codex, and Pi Agent.
  * Documented Pi Agent session directory configuration and path resolution behavior.
  * Clarified that OpenCode logs are not currently indexable and should be surfaced as a limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->