### PR TITLE
fix(omp): 将会话上下文注入 Bash tool 环境

### DIFF
--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -40,7 +40,7 @@ function buildContextKey(platformName: string, kind: string, value: string): str
    return safeValue ? `${platformName}_${safeValue}` : `${platformName}_${hashValue(value)}`;
 }
 
-function deriveContextKey(ctx?: { sessionManager?: { getSessionId?: () => string; getSessionFile?: () => string } }): string | null {
+function deriveContextKey(ctx?: { sessionManager?: { getSessionId?: () => string | undefined; getSessionFile?: () => string | undefined } }): string | null {
    const sessionId = ctx?.sessionManager?.getSessionId?.();
    if (sessionId) {
       return buildContextKey("omp", "session", sessionId);
@@ -336,7 +336,7 @@ export default function(pi: ExtensionAPI): void {
    let lastCompactionTs = 0;
    let lastInjectionTs = 0;
 
-   const rememberContextKey = (ctx?: { sessionManager?: { getSessionId?: () => string; getSessionFile?: () => string } }): string | null => {
+   const rememberContextKey = (ctx?: { sessionManager?: { getSessionId?: () => string | undefined; getSessionFile?: () => string | undefined } }): string | null => {
       const key = deriveContextKey(ctx);
       if (!key) return null;
       return key;
@@ -439,12 +439,27 @@ export default function(pi: ExtensionAPI): void {
          messages: [
             ...event.messages,
             {
-               role: "custom",
+               role: "custom" as const,
                customType: "trellis-workflow-state",
                content: cached.workflowMsg,
+               display: false,
                timestamp: Date.now(),
             },
          ],
+      };
+   });
+
+   // OMP passes Bash event.input through to the tool execution parameters, so
+   // inject the session key through the shell-agnostic env field. An explicit
+   // per-call value wins over the derived key.
+   pi.on("tool_call", (event, ctx) => {
+      if (event.toolName !== "bash") return;
+      const contextKey = rememberContextKey(ctx);
+      if (!contextKey) return;
+      const input = event.input as { env?: Record<string, string> };
+      input.env = {
+         TRELLIS_CONTEXT_ID: contextKey,
+         ...input.env,
       };
    });
 
@@ -453,10 +468,9 @@ export default function(pi: ExtensionAPI): void {
          projectRoot = findProjectRoot(ctx.cwd);
       }
       // Resolve projectRoot on first input if session_start missed it
-      if (!projectRoot) return { action: "continue" };
+      if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
       // Pre-warm the cache so before_agent_start and context can use it
       turnCache.get(projectRoot, contextKey);
-      return { action: "continue" };
    });
 }

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import vm from "node:vm";
+import ts from "typescript";
 import {
   getAllAgents,
   getExtensionTemplate,
@@ -10,6 +13,47 @@ import { collectOmpTemplates } from "../../src/configurators/omp.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const templateDir = path.resolve(__dirname, "../../src/templates/omp");
+
+type OmpEventHandler = (event: unknown, ctx?: unknown) => unknown;
+type OmpExtension = (pi: {
+  on: (event: string, handler: OmpEventHandler) => void;
+}) => void;
+
+function loadOmpExtension(): OmpExtension {
+  const compiled = ts.transpileModule(getExtensionTemplate(), {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const require = createRequire(import.meta.url);
+  const moduleObject: { exports: { default?: OmpExtension } } = { exports: {} };
+  const sandboxProcess = Object.create(process) as NodeJS.Process;
+  const sandboxEnv = { ...process.env };
+  delete sandboxEnv.TRELLIS_CONTEXT_ID;
+  Object.defineProperty(sandboxProcess, "env", { value: sandboxEnv });
+  const sandbox = vm.createContext({
+    Buffer,
+    console,
+    exports: moduleObject.exports,
+    module: moduleObject,
+    process: sandboxProcess,
+    require,
+  });
+  vm.runInContext(compiled, sandbox);
+  const extension = moduleObject.exports.default;
+  if (!extension) throw new Error("OMP extension template has no default export");
+  return extension;
+}
+
+function captureOmpHandlers(): Map<string, OmpEventHandler> {
+  const handlers = new Map<string, OmpEventHandler>();
+  loadOmpExtension()({
+    on: (event, handler) => handlers.set(event, handler),
+  });
+  return handlers;
+}
 
 describe("omp templates", () => {
   it("provides the three Trellis sub-agent definitions", () => {
@@ -62,6 +106,55 @@ describe("omp templates", () => {
       "No identity: use single-session fallback only when there is exactly one session file.",
     );
     expect(extension).not.toContain("currentContextKey");
+  });
+
+  it("injects the derived context key into the original Bash params", () => {
+    const handler = captureOmpHandlers().get("tool_call");
+    if (!handler) throw new Error("OMP extension did not register tool_call");
+    const params: { command: string; env?: Record<string, string> } = {
+      command: "python3 ./.trellis/scripts/task.py current",
+      env: { EXISTING: "kept" },
+    };
+
+    handler(
+      { type: "tool_call", toolName: "bash", toolCallId: "call-1", input: params },
+      { sessionManager: { getSessionId: () => "session/a" } },
+    );
+
+    expect(params.env?.TRELLIS_CONTEXT_ID).toBe("omp_session_a");
+    expect(params.env?.EXISTING).toBe("kept");
+  });
+
+  it("preserves an explicit Bash env override and leaves inline assignments untouched", () => {
+    const handler = captureOmpHandlers().get("tool_call");
+    if (!handler) throw new Error("OMP extension did not register tool_call");
+    const command =
+      "TRELLIS_CONTEXT_ID=inline python3 ./.trellis/scripts/task.py current";
+    const params: { command: string; env?: Record<string, string> } = {
+      command,
+      env: { TRELLIS_CONTEXT_ID: "explicit" },
+    };
+
+    handler(
+      { type: "tool_call", toolName: "bash", toolCallId: "call-2", input: params },
+      { sessionManager: { getSessionId: () => "session/b" } },
+    );
+
+    expect(params.command).toBe(command);
+    expect(params.env?.TRELLIS_CONTEXT_ID).toBe("explicit");
+  });
+
+  it("does not mutate non-Bash tool params", () => {
+    const handler = captureOmpHandlers().get("tool_call");
+    if (!handler) throw new Error("OMP extension did not register tool_call");
+    const params: Record<string, unknown> = { path: "README.md" };
+
+    handler(
+      { type: "tool_call", toolName: "read", toolCallId: "call-3", input: params },
+      { sessionManager: { getSessionId: () => "session/c" } },
+    );
+
+    expect(params).toEqual({ path: "README.md" });
   });
 
   it("extension template contains session context injection markers", () => {


### PR DESCRIPTION
## 概述

修复 Oh My Pi extension 没有把当前 OMP session context key 传给 Bash tool 的问题。

修复前，OMP 会话内执行 `task.py start/current` 看不到 `TRELLIS_CONTEXT_ID`，active-task pointer 进入 degraded mode；修复后，Bash 子进程会继承 `omp_<session-id>`，并正常读写 `.trellis/.runtime/sessions/<context-key>.json`。

Fixes #423

## 根因

OMP extension 已经能从 `ctx.sessionManager.getSessionId()` 派生正确的 context key，但这个值只传给 extension 自己启动的 `get_context.py`。

AI 发起的 Bash tool 没有对应的 `tool_call` bridge，所以 `task.py` 子进程无法解析当前 session identity。

## 改动

### 1. 通过 Bash input 的 `env` 注入 context key

新增 OMP `tool_call` handler：

- 只处理 `bash`；
- 从当前 extension context 派生 `omp_<session-id>`；
- 修改后续真实执行使用的原始 Bash params 对象；
- 使用 `event.input.env` 传递 `TRELLIS_CONTEXT_ID`；
- 保留调用方已有的其他环境变量；
- 调用方显式提供的 `env.TRELLIS_CONTEXT_ID` 优先，不会被覆盖；
- 不写 `process.env`，避免 process-global 值跨 session 泄漏。

选择 `env` 字段而不是照搬 Pi extension 的 `export ...; <command>` 前缀，是因为 OMP Bash schema 原生支持 `env?: Record<string, string>`。这样不依赖 POSIX / PowerShell / cmd 方言，不需要 shell quoting，也不改写用户命令文本。

### 2. 增加真实 handler 行为测试

测试不再只断言模板里存在某个字符串，而是：

1. 编译并加载生成的 extension；
2. 捕获 extension 注册的 `tool_call` handler；
3. 触发伪造 Bash event；
4. 断言 wrapper 后续会执行的原始 params 对象被实际修改。

覆盖：

- 派生 context key 注入；
- 已有 env 字段保留；
- 显式 `TRELLIS_CONTEXT_ID` 保留；
- 命令内显式赋值不被改写；
- 非 Bash tool 不被修改。

### 3. 对齐 OMP 16.4.8 extension 类型契约

在对生成物执行独立 `tsc` 时，同时发现并修正了几处现有类型不匹配：

- `getSessionFile()` 允许返回 `undefined`；
- 注入的 custom message 补齐必需的 `display: false`；
- `input` handler 不再返回 OMP `InputEventResult` 不支持的 `action` 字段。

这些调整不改变现有运行时流程，只让生成的 extension 能通过 OMP 16.4.8 发布类型的完整检查。

## 验证

### 自动测试

```text
pnpm exec vitest run test/templates/omp.test.ts
✓ 13 tests passed

pnpm typecheck
✓ passed

pnpm exec eslint test/templates/omp.test.ts
✓ passed
```

另外把生成的 `index.ts` 作为独立 TypeScript 文件，对 `@oh-my-pi/pi-coding-agent` 16.4.8 的发布声明执行 `tsc --noEmit`：通过。

### OMP 真机 E2E

环境：Trellis 0.6.7 + OMP 16.4.8，均从全新 OMP session 执行 Bash tool。

修复前：

```text
python3 -c 'import os; print(repr(os.getenv("TRELLIS_CONTEXT_ID")))'
None
```

```text
python3 ./.trellis/scripts/task.py start <task-dir>
ℹ Session identity not available; active-task pointer not persisted this session (degraded mode).
```

将本 PR 生成的 extension 安装到项目 `.omp/extensions/trellis/index.ts` 后，正常启动全新 OMP session，不手工传 env：

```text
python3 -c 'import os; print(repr(os.getenv("TRELLIS_CONTEXT_ID")))'
'omp_019f5c82-c770-7000-8bc2-98e935153d20'
```

```text
python3 ./.trellis/scripts/task.py start <task-dir>
✓ Current task set to: .trellis/tasks/<task-dir>
Source: session:omp_<session-id>
```

并确认生成了：

```text
.trellis/.runtime/sessions/omp_<session-id>.json
```

## 边界

本 PR 只修复 OMP 主会话到 Bash tool 的 session identity bridge。OMP in-process sub-agent 如何继承主会话 active-task context 是独立问题，不在本 PR 范围内。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session and context handling when session identity information is unavailable.
  * Preserved workflow state more reliably after context compaction.
  * Bash tool executions now receive the appropriate context identifier when available.
  * Existing context identifiers provided explicitly are preserved.
  * Non-Bash tool executions remain unchanged.
* **Improvements**
  * Streamlined per-turn context preparation for more consistent input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->