### PR TITLE
fix(update): preserve reintroduced templates

### DIFF
--- a/.trellis/spec/cli/backend/commands-update.md
+++ b/.trellis/spec/cli/backend/commands-update.md
@@ -144,7 +144,7 @@ Opt-in to apply file migrations (renames/deletes/dir renames). Without it: migra
 1. `commands/update.ts:executeMigrations` runs on the classified plan.
 2. The hardcoded 0.2.0 `traces-*.md → journal-*.md` rename runs via `commands/update.ts:renameTracesToJournal(workspaceDir)` (workspace/<dev>/ pattern walk; cannot live in the manifest because the path includes a variable developer slug). It never overwrites: if the `journal-*.md` target already exists, that file is left as-is and reported back in a `skipped` list instead of being renamed over — `.trellis/workspace/` is outside the backup snapshot, so an overwrite there would be unrecoverable. See [Filesystem Safety § 3](./filesystem-safety.md).
 
-`safe-file-delete` migrations are independent of `--migrate` — they always run when their hash gate passes (see Apply Phase). Rationale in `migrations.md`.
+`safe-file-delete` migrations are independent of `--migrate` — they always run when their hash gate passes (see Apply Phase). A historical deletion is ignored when its path is present in the current template snapshot: current template ownership takes precedence if a later release intentionally restores a retired path. Rationale in `migrations.md`.
 
 ### Tag flag (`--tag <beta|rc|latest>`)
 
@@ -214,7 +214,7 @@ Order of operations in `commands/update.ts:update` (after the `Proceed?` confirm
 
 2. **Migrations** (only if `--migrate`) — `commands/update.ts:executeMigrations` runs `auto` items first (sorted by depth), then `confirm` items via `commands/update.ts:promptMigrationAction` (or `--force` / `--skip-all` short-circuits). Default action for prompts is `backup-rename`: leaves `<new-path>.backup` of the user's modified content alongside the rename, so users can diff inline without digging through the snapshot. Hash tracking is updated via `utils/template-hash.ts:renameHash` / `removeHash`. Empty source dirs are pruned by `commands/update.ts:cleanupEmptyDirs` (gated by `configurators/index.ts:isManagedPath` + `isManagedRootDir` — never deletes managed roots themselves, never crosses into unmanaged paths). After regular migrations, the hardcoded `traces-*.md → journal-*.md` workspace walk (`commands/update.ts:renameTracesToJournal`) runs; files whose journal target already exists are skipped (not overwritten) and printed as a yellow "Kept ... its journal target already exists" warning.
 
-3. **`safe-file-delete`** — `commands/update.ts:executeSafeFileDeletes` deletes files in the `delete` action bucket (hash matched, not protected, not in `update.skip` unless bypassed), removes their hash entries, and prunes empty parent directories. `migrations.md` covers the full classification matrix.
+3. **`safe-file-delete`** — `commands/update.ts:executeSafeFileDeletes` deletes files in the `delete` action bucket (hash matched, not protected, not in `update.skip` unless bypassed), removes their hash entries, and prunes empty parent directories. `commands/update.ts:collectSafeFileDeletes` first excludes paths owned by the current template snapshot so historical cleanup cannot conflict with a reintroduced template. `migrations.md` covers the full classification matrix.
 
 4. **New file writes** — straight `mkdir -p` + `writeFileSync`. `.sh` and `.py` get `chmod 755`.
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -317,11 +317,13 @@ interface SafeFileDeleteClassified {
  * - File exists
  * - Content hash matches allowed_hashes
  * - Path is not protected or in update.skip
+ * - Path is not owned by the current template set
  */
 function collectSafeFileDeletes(
   migrations: MigrationItem[],
   cwd: string,
   skipPaths: string[],
+  currentTemplatePaths: ReadonlySet<string>,
   /**
    * Bypass `update.skip` for safe-file-delete. Enable this for breaking releases
    * where honoring skip would leave the project half-migrated (old files at
@@ -331,7 +333,11 @@ function collectSafeFileDeletes(
    */
   bypassUpdateSkip = false,
 ): SafeFileDeleteClassified[] {
-  const safeDeletes = migrations.filter((m) => m.type === "safe-file-delete");
+  // Historical migrations are loaded forever, so current template ownership
+  // must win when a later release intentionally restores a retired path.
+  const safeDeletes = migrations.filter(
+    (m) => m.type === "safe-file-delete" && !currentTemplatePaths.has(m.from),
+  );
   const results: SafeFileDeleteClassified[] = [];
 
   for (const item of safeDeletes) {
@@ -2172,6 +2178,7 @@ export async function update(options: UpdateOptions): Promise<void> {
     allMigrations,
     cwd,
     skipPaths,
+    new Set(templates.keys()),
     breakingBypass,
   );
   const hasSafeDeletes =

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -246,6 +246,17 @@ describe("update() integration", () => {
     expect(entries.filter((e) => e.startsWith(".backup-")).length).toBe(0);
   });
 
+  it("#1b current OpenCode templates are not classified as deprecated", async () => {
+    const startPath = ".opencode/commands/trellis/start.md";
+    await init({ yes: true, force: true, opencode: true });
+    expect(fs.existsSync(projectFile(startPath))).toBe(true);
+
+    await update({ dryRun: true });
+
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).not.toContain(`${startPath} (modified, skipped)`);
+  });
+
   it("[issue-zcode-codex-upgrade] zcode private skills do not trigger legacy Codex backfill", async () => {
     await init({ yes: true, force: true, zcode: true });
 


### PR DESCRIPTION
## Summary

- exclude current template paths from historical `safe-file-delete` cleanup
- add an OpenCode regression test for the restored `start.md` command
- document current-template precedence in the update contract

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (core: 303 passed; CLI: 1354 passed)
- built CLI smoke: upgrade an OpenCode project initialized by 0.6.3, add `start.md`, then confirm a second update is clean with no deprecated warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented update operations from treating reintroduced template files as deprecated or deleting them.
  * Ensured current template files retain ownership when paths previously marked for safe deletion are restored.
  * Added coverage for OpenCode template files during update dry runs.

* **Documentation**
  * Clarified safe-file-delete behavior and precedence during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->