### PR TITLE
chore: run full test suite in pre-commit, hardened against git-env leaks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,17 @@
 pnpm lint-staged
+
+# Keep the marketplace submodule initialized — several tests diff templates
+# against its mirrored content (e.g. workflows/native/workflow.md), and a
+# missing/stale checkout lets drift slip past this hook (only caught in CI).
+git submodule update --init marketplace
+
+# Git sets GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_COMMON_DIR for the hook's
+# own process so it can operate on the commit-in-progress. Some integration
+# tests (e.g. task-archive.integration.test.ts) shell out to `git` inside
+# their own tmp fixture repos; without unsetting these first, those nested
+# git calls inherit this repo's real coordinates instead of the fixture's,
+# and can corrupt the real repo/worktree metadata. Verified: this happened
+# and required manually repairing every worktree's core.worktree/core.bare.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+
+pnpm test


### PR DESCRIPTION
## Summary
- `pre-commit` only ran `lint-staged` (eslint/prettier on staged `.ts` files) — no test execution locally. Combined with a common local setup where the `marketplace` submodule isn't initialized, PR #433's marketplace/workflows mirror drift (the CI failure fixed in #435) went undetected through every local check and only surfaced when CI ran with a full submodule checkout.
- Initializes the `marketplace` submodule before testing, since several tests diff templates against its mirrored content and a missing checkout would otherwise fail every commit regardless of relevance.
- Unsets `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR`/`GIT_OBJECT_DIRECTORY` before running tests.

## Why the env unset is load-bearing, not defensive boilerplate
Git sets `GIT_DIR`/`GIT_INDEX_FILE` for the hook's own process so it can operate on the commit-in-progress. Some git-integration tests (`test/scripts/task-archive.integration.test.ts`, `test/scripts/add-session.integration.test.ts`) shell out to `git` inside their own tmp fixture repos. Without unsetting these first, those nested `git` calls inherit this repo's real coordinates instead of the fixture's — **verified this actually happened**: running the full suite through this hook without the unset corrupted the shared bare repo's worktree metadata (every linked worktree started failing `git status` with "fatal: this operation must be run in a work tree"), injected a stray `git config user.email/name` into the shared config, deleted a local branch ref, and created a bogus branch. No commits/objects were lost and nothing reached the remote, but every worktree needed manual repair (`core.worktree`/`core.bare` per-worktree config overrides).

## Test plan
- [x] Reproduced the corruption once (disposable worktree) to confirm root cause, repaired all affected worktrees.
- [x] Re-tested with the env-unset fix in a fresh disposable worktree: a real `git commit` through the hardened hook ran all 1366 tests clean.
- [x] Confirmed every other worktree sharing the bare repo was untouched before/after the real commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-commit checks to run staged-file linting.
  * Added automatic marketplace submodule initialization.
  * Improved test execution reliability during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->