### PR TITLE
fix(configurators): quote YAML frontmatter descriptions to survive embedded colons

### DIFF
--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -297,7 +297,11 @@ export function wrapWithCommandFrontmatter(
       `Missing command description for "${baseName}". Add it to COMMAND_DESCRIPTIONS in shared.ts.`,
     );
   }
-  return `---\nname: ${name}\ndescription: ${description}\n---\n\n${content}`;
+  // JSON.stringify produces a double-quoted YAML scalar, which is safe even
+  // when the description contains a colon (an unquoted plain scalar cannot
+  // contain ": " — some parsers reject it outright, e.g. Trae CLI's SlashCommand
+  // schema; others silently truncate at the second colon).
+  return `---\nname: ${name}\ndescription: ${JSON.stringify(description)}\n---\n\n${content}`;
 }
 
 /**
@@ -325,9 +329,12 @@ export function wrapWithOmpFrontmatter(name: string, content: string): string {
   // Strip leading H1 + blank line from template body
   const body = content.replace(/^# [^\n]+\n\n/, "");
   const hint = COMMAND_ARGUMENT_HINTS[baseName];
+  // JSON.stringify produces a double-quoted YAML scalar, safe even when the
+  // description contains a colon (see wrapWithCommandFrontmatter).
+  const quotedDescription = JSON.stringify(description);
   const frontmatter = hint
-    ? `---\ndescription: ${description}\nargument-hint: ${hint}\n---`
-    : `---\ndescription: ${description}\n---`;
+    ? `---\ndescription: ${quotedDescription}\nargument-hint: ${JSON.stringify(hint)}\n---`
+    : `---\ndescription: ${quotedDescription}\n---`;
   return `${frontmatter}\n\n${body}`;
 }
 

--- a/packages/cli/test/configurators/shared.test.ts
+++ b/packages/cli/test/configurators/shared.test.ts
@@ -591,7 +591,7 @@ describe("wrapWithOmpFrontmatter", () => {
     const content = "# Finish Work\n\nWrap up the current session.";
     const result = wrapWithOmpFrontmatter("finish-work", content);
     expect(result).toMatch(
-      /^---\ndescription: .+\nargument-hint: \[task-name\]\n---\n\n/,
+      /^---\ndescription: .+\nargument-hint: "\[task-name\]"\n---\n\n/,
     );
     expect(result).not.toContain("# Finish Work");
     expect(result).toContain("Wrap up the current session.");


### PR DESCRIPTION
## Summary
- `wrapWithCommandFrontmatter` / `wrapWithOmpFrontmatter` (used by Trae, Qoder, and OMP command generation) interpolated the command description as an unquoted YAML plain scalar.
- `COMMAND_DESCRIPTIONS['finish-work']` contains a colon-space (`Wrap up the current session: quality gate, ...`), which is invalid inside an unquoted YAML plain scalar — some parsers (Trae CLI's slash-command loader) reject the whole file outright.
- Real user report from 柏亮 (Trae CLI user): "这个地方多了个冒号，导致这个command用不了" (screenshot showed the generated `.trae/commands/trellis-finish-work.md`, unusable).

## Fix
`JSON.stringify()` the description (and OMP's `argument-hint`) to produce a double-quoted YAML scalar, which is always safe regardless of embedded colons/quotes.

## Verification
```
$ python3 -c "import yaml; yaml.safe_load('description: Wrap up the current session: quality gate, ...')"
yaml.scanner.ScannerError: mapping values are not allowed here

$ python3 -c "import yaml; yaml.safe_load('description: \"Wrap up the current session: quality gate, ...\"')"
# parses cleanly
```
Also confirmed against a real generated `.trae/commands/trellis-finish-work.md` via `trellis init --trae`.

## Test plan
- [x] Updated `wrapWithOmpFrontmatter` test regex for the now-quoted `argument-hint` value.
- [x] Full test suite: 1366 passed, 0 failed.
- [x] `typecheck` / `lint` / `git diff --check` clean.

## Not included
A second, unrelated Trae issue was reported alongside this one: the `SessionStart` hook fails with "hook returned invalid session start JSON output" in Trae CLI. Deferred — could not confirm Trae CLI's exact expected SessionStart JSON schema (docs.trae.ai is a client-rendered SPA not accessible from this environment), and it's non-blocking: the `UserPromptSubmit` hook already delivers the same context successfully as a fallback (confirmed in the user's own screenshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output metadata formatting by safely quoting descriptions and argument hints.
  * Prevented special characters and bracketed values from being misinterpreted in YAML frontmatter.

* **Tests**
  * Updated validation to confirm argument hints are emitted as properly quoted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->