### PR TITLE
docs: correct Codex inline-default rationale (issue #434)

### DIFF
--- a/.claude/hooks/inject-workflow-state.py
+++ b/.claude/hooks/inject-workflow-state.py
@@ -220,12 +220,15 @@ def _codex_mode_banner(config: dict) -> str:
     """Emit a `<codex-mode>` banner for the additionalContext payload.
 
     Reads `codex.dispatch_mode` from .trellis/config.yaml; defaults to
-    `inline` when missing or invalid because Codex sub-agents run with
-    `fork_turns="none"` isolation and can't inherit the parent session's
-    task context. The banner makes the active mode explicit to Codex AI
-    per turn, complementing the workflow-state body which is per-status.
-    Mode tells AI which dispatch protocol to follow; workflow-state tells
-    AI what step it's at.
+    `inline` when missing or invalid. Trellis defaults Codex dispatch to
+    `inline` to avoid relying on inherited parent transcripts — Codex
+    sub-agents may use fresh, full, or bounded conversation history
+    (`fork_turns`), and fresh-history agents still receive their explicit
+    delegated task and inherited session configuration; this is a Trellis
+    policy choice, not a Codex limitation. The banner makes the active
+    mode explicit to Codex AI per turn, complementing the workflow-state
+    body which is per-status. Mode tells AI which dispatch protocol to
+    follow; workflow-state tells AI what step it's at.
     """
     mode = "inline"
     if isinstance(config, dict):
@@ -252,11 +255,13 @@ def resolve_breadcrumb_key(
 ) -> str:
     """Pick the breadcrumb tag key based on Codex dispatch_mode.
 
-    Codex defaults to ``inline`` because sub-agents run with ``fork_turns="none"``
-    isolation and can't inherit the parent session's task context. Users can
-    opt into ``codex.dispatch_mode: sub-agent`` in ``.trellis/config.yaml``
-    to use the parallel ``<status>-inline`` tag → ``<status>`` flip. Invalid
-    or missing values fall back to inline.
+    Codex defaults to ``inline`` as a Trellis policy choice to avoid relying
+    on inherited parent transcripts, not because Codex sub-agents are
+    technically unable to receive context (``fork_turns`` is caller-controlled
+    and fresh-history agents still get their explicit task + session config).
+    Users can opt into ``codex.dispatch_mode: sub-agent`` in
+    ``.trellis/config.yaml`` to use the parallel ``<status>-inline`` tag →
+    ``<status>`` flip. Invalid or missing values fall back to inline.
 
     Non-codex platforms return the plain status unchanged.
     """

--- a/.codex/hooks/inject-workflow-state.py
+++ b/.codex/hooks/inject-workflow-state.py
@@ -220,12 +220,15 @@ def _codex_mode_banner(config: dict) -> str:
     """Emit a `<codex-mode>` banner for the additionalContext payload.
 
     Reads `codex.dispatch_mode` from .trellis/config.yaml; defaults to
-    `inline` when missing or invalid because Codex sub-agents run with
-    `fork_turns="none"` isolation and can't inherit the parent session's
-    task context. The banner makes the active mode explicit to Codex AI
-    per turn, complementing the workflow-state body which is per-status.
-    Mode tells AI which dispatch protocol to follow; workflow-state tells
-    AI what step it's at.
+    `inline` when missing or invalid. Trellis defaults Codex dispatch to
+    `inline` to avoid relying on inherited parent transcripts — Codex
+    sub-agents may use fresh, full, or bounded conversation history
+    (`fork_turns`), and fresh-history agents still receive their explicit
+    delegated task and inherited session configuration; this is a Trellis
+    policy choice, not a Codex limitation. The banner makes the active
+    mode explicit to Codex AI per turn, complementing the workflow-state
+    body which is per-status. Mode tells AI which dispatch protocol to
+    follow; workflow-state tells AI what step it's at.
     """
     mode = "inline"
     if isinstance(config, dict):
@@ -252,11 +255,13 @@ def resolve_breadcrumb_key(
 ) -> str:
     """Pick the breadcrumb tag key based on Codex dispatch_mode.
 
-    Codex defaults to ``inline`` because sub-agents run with ``fork_turns="none"``
-    isolation and can't inherit the parent session's task context. Users can
-    opt into ``codex.dispatch_mode: sub-agent`` in ``.trellis/config.yaml``
-    to use the parallel ``<status>-inline`` tag → ``<status>`` flip. Invalid
-    or missing values fall back to inline.
+    Codex defaults to ``inline`` as a Trellis policy choice to avoid relying
+    on inherited parent transcripts, not because Codex sub-agents are
+    technically unable to receive context (``fork_turns`` is caller-controlled
+    and fresh-history agents still get their explicit task + session config).
+    Users can opt into ``codex.dispatch_mode: sub-agent`` in
+    ``.trellis/config.yaml`` to use the parallel ``<status>-inline`` tag →
+    ``<status>`` flip. Invalid or missing values fall back to inline.
 
     Non-codex platforms return the plain status unchanged.
     """

--- a/.trellis/config.yaml
+++ b/.trellis/config.yaml
@@ -108,11 +108,12 @@ channel:
 # Codex (dispatch behavior)
 #-------------------------------------------------------------------------------
 # Codex-only knob; other platforms ignore it. Default ("inline") makes the
-# main Codex agent edit code directly because Codex sub-agents run with
-# `fork_turns="none"` isolation and can't inherit the parent session's
-# task context. Set to "sub-agent" to opt into the legacy dispatch model
-# (main agent spawns trellis-implement / trellis-check / trellis-research
-# sub-agents).
+# main Codex agent edit code directly. This is a Trellis policy choice to
+# avoid relying on inherited parent transcripts, not a Codex limitation —
+# `fork_turns` is caller-controlled, and fresh-history sub-agents still
+# receive their explicit delegated task and inherited session config. Set
+# to "sub-agent" to opt into the legacy dispatch model (main agent spawns
+# trellis-implement / trellis-check / trellis-research sub-agents).
 #
 # codex:
 #   dispatch_mode: inline  # or "sub-agent" to dispatch trellis-* sub-agents

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -232,12 +232,15 @@ def _codex_mode_banner(config: dict) -> str:
     """Emit a `<codex-mode>` banner for the additionalContext payload.
 
     Reads `codex.dispatch_mode` from .trellis/config.yaml; defaults to
-    `inline` when missing or invalid because Codex sub-agents run with
-    `fork_turns="none"` isolation and can't inherit the parent session's
-    task context. The banner makes the active mode explicit to Codex AI
-    per turn, complementing the workflow-state body which is per-status.
-    Mode tells AI which dispatch protocol to follow; workflow-state tells
-    AI what step it's at.
+    `inline` when missing or invalid. Trellis defaults Codex dispatch to
+    `inline` to avoid relying on inherited parent transcripts — Codex
+    sub-agents may use fresh, full, or bounded conversation history
+    (`fork_turns`), and fresh-history agents still receive their explicit
+    delegated task and inherited session configuration; this is a Trellis
+    policy choice, not a Codex limitation. The banner makes the active
+    mode explicit to Codex AI per turn, complementing the workflow-state
+    body which is per-status. Mode tells AI which dispatch protocol to
+    follow; workflow-state tells AI what step it's at.
     """
     mode = "inline"
     if isinstance(config, dict):
@@ -264,11 +267,13 @@ def resolve_breadcrumb_key(
 ) -> str:
     """Pick the breadcrumb tag key based on Codex dispatch_mode.
 
-    Codex defaults to ``inline`` because sub-agents run with ``fork_turns="none"``
-    isolation and can't inherit the parent session's task context. Users can
-    opt into ``codex.dispatch_mode: sub-agent`` in ``.trellis/config.yaml``
-    to use the parallel ``<status>-inline`` tag → ``<status>`` flip. Invalid
-    or missing values fall back to inline.
+    Codex defaults to ``inline`` as a Trellis policy choice to avoid relying
+    on inherited parent transcripts, not because Codex sub-agents are
+    technically unable to receive context (``fork_turns`` is caller-controlled
+    and fresh-history agents still get their explicit task + session config).
+    Users can opt into ``codex.dispatch_mode: sub-agent`` in
+    ``.trellis/config.yaml`` to use the parallel ``<status>-inline`` tag →
+    ``<status>`` flip. Invalid or missing values fall back to inline.
 
     Non-codex platforms return the plain status unchanged.
     """

--- a/packages/cli/src/templates/trellis/config.yaml
+++ b/packages/cli/src/templates/trellis/config.yaml
@@ -100,11 +100,12 @@ channel:
 # Codex (dispatch behavior)
 #-------------------------------------------------------------------------------
 # Codex-only knob; other platforms ignore it. Default ("inline") makes the
-# main Codex agent edit code directly because Codex sub-agents run with
-# `fork_turns="none"` isolation and can't inherit the parent session's
-# task context. Set to "sub-agent" to opt into the legacy dispatch model
-# (main agent spawns trellis-implement / trellis-check / trellis-research
-# sub-agents).
+# main Codex agent edit code directly. This is a Trellis policy choice to
+# avoid relying on inherited parent transcripts, not a Codex limitation —
+# `fork_turns` is caller-controlled, and fresh-history sub-agents still
+# receive their explicit delegated task and inherited session config. Set
+# to "sub-agent" to opt into the legacy dispatch model (main agent spawns
+# trellis-implement / trellis-check / trellis-research sub-agents).
 #
 # codex:
 #   dispatch_mode: inline  # or "sub-agent" to dispatch trellis-* sub-agents


### PR DESCRIPTION
Closes #434.

## Bug
`_codex_mode_banner` and `resolve_breadcrumb_key` in `inject-workflow-state.py`, plus the `codex.dispatch_mode` comment in `config.yaml`, claimed Codex sub-agents technically cannot inherit parent session context because they run with `fork_turns="none"` isolation. Per Codex's own implementation (cited with source line numbers in the issue), that's inaccurate:

- `fork_turns` is caller-controlled and defaults to `all`, not `none`.
- Even a fresh-history (`fork_turns="none"`) sub-agent still receives its explicit delegated task message and inherited session configuration (base/developer instructions, model settings, cwd, approval policy, sandbox config).

## Fix
Reworded all three comments to state the real reason plainly, using close to the issue's own suggested wording: Trellis defaults Codex dispatch to `inline` as its own policy choice — to avoid relying on inherited parent transcripts — not because Codex is technically unable to pass context.

**No behavior change.** `dispatch_mode` still defaults to `inline`. This is a documentation/comment correction only.

(Separately looked into whether the `inline` default itself is still the right call given the underlying #240/#241 self-wait incident it was originally meant to guard against was later fixed structurally — by disabling `multi_agent`/`multi_agent_v2` tool availability in the Codex sub-agent role files, independent of `dispatch_mode`. That's a bigger, real-Codex-verification-gated question worth its own investigation; keeping this PR scoped to the wording fix per #434.)

## Test plan
- [x] Full test suite: 1388 passed, 0 failed.
- [x] typecheck / lint clean, `git diff --check` clean.
- [x] Applied to the shared template source and both local dogfood copies without touching their unrelated pre-existing drift, and to `.trellis/config.yaml` without touching its repo-specific customizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Codex dispatch-mode guidance and terminology.
  * Documented the distinction between inline and sub-agent workflows, including context handling and caller-controlled settings.
  * Updated workflow-state and configuration comments consistently across included templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->