### PR TITLE
feat(codex): enable native subagent dispatch

### DIFF
--- a/.trellis/config.yaml
+++ b/.trellis/config.yaml
@@ -107,13 +107,14 @@ channel:
 #-------------------------------------------------------------------------------
 # Codex (dispatch behavior)
 #-------------------------------------------------------------------------------
-# Codex-only knob; other platforms ignore it. Default ("inline") makes the
-# main Codex agent edit code directly. This is a Trellis policy choice to
-# avoid relying on inherited parent transcripts, not a Codex limitation —
-# `fork_turns` is caller-controlled, and fresh-history sub-agents still
-# receive their explicit delegated task and inherited session config. Set
-# to "sub-agent" to opt into the legacy dispatch model (main agent spawns
-# trellis-implement / trellis-check / trellis-research sub-agents).
+# Codex-only knob; other platforms ignore it. Default ("auto") dispatches
+# trellis-implement / trellis-check / trellis-research sub-agents. This does
+# not rely on inherited parent transcripts: `fork_turns` remains
+# caller-controlled, while Codex's native SubagentStart hook injects task
+# context when trusted and child-side loading remains the fallback when it is
+# unavailable. Set to "inline" only to keep implementation and checks in the
+# main session. "sub-agent" remains a backwards-compatible alias for "auto".
+# Invalid explicit values safely use inline mode.
 #
 # codex:
-#   dispatch_mode: inline  # or "sub-agent" to dispatch trellis-* sub-agents
+#   dispatch_mode: auto  # or "inline"; legacy alias: "sub-agent"

--- a/.trellis/scripts/common/active_task.py
+++ b/.trellis/scripts/common/active_task.py
@@ -396,15 +396,18 @@ def _lookup_cursor_shell_ticket_context_key() -> str | None:
 def resolve_context_key(
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
+    *,
+    allow_environment_context: bool = True,
 ) -> str | None:
     """Resolve a stable session/window context key, if one is available.
 
     `TRELLIS_CONTEXT_ID` is an explicit context-key override used by CLI
     scripts and subprocesses. It does not store the task itself.
     """
-    override = _string_value(os.environ.get("TRELLIS_CONTEXT_ID"))
-    if override:
-        return _sanitize_key(override) or _hash_value(override)
+    if allow_environment_context:
+        override = _string_value(os.environ.get("TRELLIS_CONTEXT_ID"))
+        if override:
+            return _sanitize_key(override) or _hash_value(override)
 
     data = _as_dict(platform_input)
     platform_name = _detect_platform(data, platform) if data or platform else None
@@ -422,11 +425,12 @@ def resolve_context_key(
         if transcript_path:
             return _context_key(platform_name or "session", "transcript", transcript_path)
 
-    env_context_key = _lookup_env_context_key(platform_name)
-    if env_context_key:
-        return env_context_key
+    if allow_environment_context:
+        env_context_key = _lookup_env_context_key(platform_name)
+        if env_context_key:
+            return env_context_key
 
-    if platform_name in (None, "session", "cursor"):
+    if allow_environment_context and platform_name in (None, "session", "cursor"):
         return _lookup_cursor_shell_ticket_context_key()
     return None
 
@@ -485,17 +489,24 @@ def resolve_active_task(
     repo_root: Path,
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
+    *,
+    allow_single_session_fallback: bool = True,
+    allow_environment_context: bool = True,
 ) -> ActiveTask:
     """Resolve the active task from session runtime state only.
 
     A stale session task is returned as stale. Missing context identity or a
     missing/empty session context falls back to single-session inference: if
     exactly one session file exists in the runtime, return its task with
-    source_type="session-fallback" — covers class-2 platform sub-agents (codex,
-    copilot, gemini, qoder) that don't inherit the parent's session id. ≥2
+    source_type="session-fallback" — covers pull-based platform sub-agents
+    (copilot, gemini, qoder) that don't inherit the parent's session id. ≥2
     files or 0 files yield ActiveTask(None) — refuses to guess across windows.
     """
-    context_key = resolve_context_key(platform_input, platform)
+    context_key = resolve_context_key(
+        platform_input,
+        platform,
+        allow_environment_context=allow_environment_context,
+    )
     if context_key:
         context = _read_json(_context_path(repo_root, context_key)) or {}
         task_ref = _string_value(context.get("current_task"))
@@ -503,9 +514,10 @@ def resolve_active_task(
         if active:
             return active
 
-    fallback = _resolve_single_session_fallback(repo_root)
-    if fallback is not None:
-        return fallback
+    if allow_single_session_fallback:
+        fallback = _resolve_single_session_fallback(repo_root)
+        if fallback is not None:
+            return fallback
 
     return ActiveTask(None, "none", context_key)
 

--- a/.trellis/scripts/common/config.py
+++ b/.trellis/scripts/common/config.py
@@ -167,7 +167,7 @@ def _next_content_line(lines: list[str], start: int) -> tuple[int, str]:
 DEFAULT_SESSION_COMMIT_MESSAGE = "chore: record journal"
 DEFAULT_MAX_JOURNAL_LINES = 2000
 DEFAULT_SESSION_AUTO_COMMIT = True
-DEFAULT_CODEX_DISPATCH_MODE = "inline"
+DEFAULT_CODEX_DISPATCH_MODE = "auto"
 
 CONFIG_FILE = "config.yaml"
 
@@ -247,8 +247,14 @@ def get_session_auto_commit(repo_root: Path | None = None) -> bool:
 def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
     """Return Codex dispatch mode.
 
-    Default is ``inline``. ``sub-agent`` is an explicit opt-in because Codex
-    sub-agents do not inherit the parent session context.
+    Default is ``auto``, which dispatches Trellis sub-agents and uses native
+    context injection with a child-side fallback. ``inline`` is an explicit
+    opt-out. ``sub-agent`` remains a backwards-compatible alias for ``auto``.
+
+    Invalid explicit configuration falls back to ``inline`` rather than
+    unexpectedly dispatching a sub-agent. This CLI-facing parser is the only
+    place that emits a warning for invalid values; hook readers fail safely
+    without producing per-turn warning noise.
     """
     config = _load_config(repo_root)
     codex = config.get("codex")
@@ -256,20 +262,22 @@ def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
         return DEFAULT_CODEX_DISPATCH_MODE
     if not isinstance(codex, dict):
         print(
-            f"[WARN] invalid codex config: {codex!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+            f"[WARN] invalid codex config: {codex!r}; using inline",
             file=sys.stderr,
         )
-        return DEFAULT_CODEX_DISPATCH_MODE
+        return "inline"
 
     raw = codex.get("dispatch_mode", DEFAULT_CODEX_DISPATCH_MODE)
     mode = str(raw).strip().lower()
-    if mode in ("inline", "sub-agent"):
+    if mode in ("auto", "inline"):
         return mode
+    if mode == "sub-agent":
+        return "auto"
     print(
-        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using inline",
         file=sys.stderr,
     )
-    return DEFAULT_CODEX_DISPATCH_MODE
+    return "inline"
 
 
 def get_hooks(event: str, repo_root: Path | None = None) -> list[str]:

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -116,7 +116,7 @@ def _repo_relative_path(path: Path, repo_root: Path) -> str:
 # Config directories of platforms that consume implement.jsonl / check.jsonl.
 # Keep in sync with src/types/ai-tools.ts AI_TOOLS entries — these are the
 # platforms listed in workflow.md's "agent-capable" Skill Routing block.
-# Codex is checked separately because default inline mode does not consume
+# Codex is checked separately because explicit inline mode does not consume
 # JSONL. Kilo / Antigravity / Devin are NOT in this list either: they load
 # specs through skills instead of JSONL.
 _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
@@ -149,14 +149,15 @@ def _has_subagent_platform(repo_root: Path) -> bool:
     """Return True if any sub-agent-capable platform is configured.
 
     Detected by probing well-known config directories at the repo root. Codex
-    only counts when ``codex.dispatch_mode`` explicitly opts into
-    ``sub-agent``; inline mode loads context through skills, not JSONL.
+    counts by default through ``codex.dispatch_mode: auto`` (including the
+    legacy ``sub-agent`` alias); explicit inline mode loads context through
+    skills, not JSONL.
     """
     for config_dir in _SUBAGENT_CONFIG_DIRS:
         if (repo_root / config_dir).is_dir():
             return True
     if (repo_root / _CODEX_CONFIG_DIR).is_dir():
-        return get_codex_dispatch_mode(repo_root) == "sub-agent"
+        return get_codex_dispatch_mode(repo_root) == "auto"
     return False
 
 

--- a/.trellis/scripts/common/workflow_phase.py
+++ b/.trellis/scripts/common/workflow_phase.py
@@ -144,27 +144,31 @@ def _platform_matches(platform: str, block_names: list[str]) -> bool:
 def resolve_effective_platform(platform: str, config: dict) -> str:
     """Map ``codex`` to a dispatch-mode-namespaced virtual platform name.
 
-    When ``--platform codex`` is passed, return ``"codex-inline"`` (default)
-    or ``"codex-sub-agent"`` based on ``.trellis/config.yaml`` ``codex.dispatch_mode``.
+    When ``--platform codex`` is passed, return ``"codex-sub-agent"`` by
+    default or ``"codex-inline"`` when explicitly configured in
+    ``.trellis/config.yaml``. ``sub-agent`` remains an alias for ``auto``.
     ``filter_platform`` then surfaces blocks whose marker lists include the
     namespaced name (e.g. ``[codex-sub-agent, ...]`` or ``[codex-inline, Kilo,
     Antigravity, Devin]``).
 
-    Default is ``inline`` because Codex sub-agents run with ``fork_turns="none"``
-    isolation and can't inherit the parent session's task context — inline
-    keeps the main agent in charge so context isn't lost. Invalid / missing
-    values also fall back to inline.
+    Native Codex context injection supports the ``auto`` default. Invalid
+    explicit values fall back to ``inline`` safely; this renderer deliberately
+    does not warn because it can run in normal CLI output flows.
 
     Other platforms are returned unchanged.
     """
     if platform == "codex":
-        mode = "inline"
+        mode = "auto"
         codex_cfg = config.get("codex") if isinstance(config, dict) else None
         if isinstance(codex_cfg, dict):
-            cfg_mode = codex_cfg.get("dispatch_mode")
-            if cfg_mode in ("inline", "sub-agent"):
-                mode = cfg_mode
-        return f"codex-{mode}"
+            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+            if cfg_mode == "inline":
+                mode = "inline"
+            elif cfg_mode in ("auto", "sub-agent"):
+                mode = "auto"
+            else:
+                mode = "inline"
+        return "codex-sub-agent" if mode == "auto" else "codex-inline"
     return platform
 
 

--- a/.trellis/scripts/common/workflow_phase.py
+++ b/.trellis/scripts/common/workflow_phase.py
@@ -160,14 +160,17 @@ def resolve_effective_platform(platform: str, config: dict) -> str:
     if platform == "codex":
         mode = "auto"
         codex_cfg = config.get("codex") if isinstance(config, dict) else None
-        if isinstance(codex_cfg, dict):
-            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
-            if cfg_mode == "inline":
+        if codex_cfg is not None:
+            if not isinstance(codex_cfg, dict):
                 mode = "inline"
-            elif cfg_mode in ("auto", "sub-agent"):
-                mode = "auto"
             else:
-                mode = "inline"
+                cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+                if cfg_mode == "inline":
+                    mode = "inline"
+                elif cfg_mode in ("auto", "sub-agent"):
+                    mode = "auto"
+                else:
+                    mode = "inline"
         return "codex-sub-agent" if mode == "auto" else "codex-inline"
     return platform
 

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -934,18 +934,19 @@ Trellis sub-agents (implement / check / research) need task context (`prd.md` + 
 
 | Class                          | Mechanism                                                                                                                                                                                                      | Platforms                                                     |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Class-1** — Hook-inject      | Python hook (or JS plugin) under `.{platform}/hooks/` fires on the sub-agent spawn tool and rewrites the tool's prompt input                                                                                   | Claude Code, Cursor, OpenCode, Kiro, CodeBuddy, Factory Droid, ZCode |
-| **Class-2** — Pull-based       | Platform's hook can't reliably mutate sub-agent prompts; Trellis injects a "Required: Load Trellis Context First" prelude into each sub-agent definition file so the sub-agent reads context itself at startup | Codex, Gemini CLI, Qoder, Copilot, Reasonix, Trae IDE  |
+| **Class-1** — Hook-inject      | Native hook or plugin fires at sub-agent start and injects context before the child runs, either by rewriting the spawn prompt or adding developer context                                                        | Claude Code, Cursor, OpenCode, Kiro, CodeBuddy, Codex, Factory Droid, ZCode |
+| **Class-2** — Pull-based       | Platform lacks a Trellis-supported native sub-agent context injection hook; Trellis injects a "Required: Load Trellis Context First" prelude into each definition so the sub-agent reads context at startup     | Gemini CLI, Qoder, Copilot, Reasonix, Trae IDE  |
 | **Class-3** — Extension-backed | Platform exposes hook-equivalent events and custom tools through a project-local TypeScript extension; Trellis owns the sub-agent tool and the context injection path                                          | Pi Agent, Oh My Pi                                           |
 
-### Class-1 — Hook-inject (7 platforms)
+### Class-1 — Hook-inject (8 platforms)
 
-Platform's PreToolUse-equivalent hook can fire on the sub-agent spawn tool AND modify the tool's prompt input. Trellis's `inject-subagent-context.py` (or OpenCode's plugin) reads `prd.md` + the JSONL-referenced spec files and rewrites the sub-agent's initial prompt.
+Platform's native sub-agent-start hook delivers context before the child runs. Most platforms rewrite the spawn prompt; Codex emits developer context through `SubagentStart`. Trellis's `inject-subagent-context.py` (or OpenCode's plugin) reads `prd.md` + the JSONL-referenced spec files for that delivery.
 
 | Platform      | Hook event                            | Mechanism                               |
 | ------------- | ------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Claude Code   | `PreToolUse` + matcher `Task`/`Agent` | `updatedInput.prompt`                   |
 | CodeBuddy     | `PreToolUse` + matcher `Task`         | `modifiedInput.prompt` (same as Claude) |
+| Codex         | `SubagentStart` + exact Trellis-role matcher | `hookSpecificOutput.additionalContext`; child-side pull fallback |
 | Cursor        | `preToolUse` + matcher `Task          | Subagent`                               | `updated_input.prompt` (Cursor staff marked Task prompt mutation fixed on 2026-04-07; current Cursor may emit native sub-agent calls as tool name `Subagent`, and native Task args may encode custom agents as `subagent_type.custom.name`) |
 | Factory Droid | `PreToolUse` + matcher `Task`         | `updatedInput.prompt`                   |
 | Kiro          | per-agent `agentSpawn` hook           | direct stdout context                   |
@@ -984,15 +985,14 @@ import { isTrellisSubagent } from "../lib/trellis-context.js"
 
 `getActiveTask()` in `lib/trellis-context.js` itself includes the single-session fallback so any caller (`workflow-state` breadcrumb, `session-start` task status) sees the same resolved task as the prompt injector. The fallback only activates when the explicit context-key lookup misses, so multi-window setups remain isolated.
 
-### Class-2 — Pull-based (6 platforms)
+### Class-2 — Pull-based (5 platforms)
 
-Platform's hook either doesn't expose a sub-agent spawn event or can't modify the prompt. Sub-agents must Read context themselves at startup. Trellis injects a "Required: Load Trellis Context First" prelude into each sub-agent definition file.
+Platform's hook either does not expose a sub-agent-start event or cannot inject Trellis context. Sub-agents must read context themselves at startup. Trellis injects a "Required: Load Trellis Context First" prelude into each sub-agent definition file.
 
-| Platform | Why hook-inject is unavailable |
+| Platform | Why native context injection is unavailable |
 |---|---|
 | Gemini CLI | `BeforeTool` fires but [#18128](https://github.com/google-gemini/gemini-cli/issues/18128) hides chain-of-thought; reliability margin too thin |
 | Qoder | No `Task` tool concept; `SubagentStart` input has no `prompt` field; Context Isolation |
-| Codex | `PreToolUse` only fires for Bash; `CollabAgentSpawn` hook unimplemented ([#15486](https://github.com/openai/codex/issues/15486)) |
 | Copilot | `preToolUse` doesn't enforce on subagents ([#2392](https://github.com/github/copilot-cli/issues/2392), [#2540](https://github.com/github/copilot-cli/issues/2540)) |
 | Reasonix | Sub-agent skills run with `runAs: subagent`; no prompt-mutation hook exists, so workflow dispatch must carry the active task and the sub-agent skill reads task artifacts itself. |
 | Trae IDE | `SessionStart` / `UserPromptSubmit` hooks cover main-session context, but no Trellis-supported sub-agent prompt mutation surface exists; generated `.trae/agents/*.md` files receive the pull-based prelude. |

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -460,6 +460,92 @@ Same root reason as `cli_adapter.py`: Python scripts run at user-project runtime
 > - `detect_platform` checks `.codex/` existence (not `.agents/skills/`)
 > - **CRITICAL**: Template copy (`src/templates/trellis/scripts/`) must be byte-identical to live copy (`.trellis/scripts/`)
 
+### Scenario: Codex Native `SubagentStart` Context Delivery
+
+#### 1. Scope / Trigger
+
+Trigger: Codex has a native sub-agent start hook. Trellis must send only the
+dispatched role's task context to a child without letting a stale environment
+override the parent session or letting a missing parent borrow another window's
+task.
+
+#### 2. Signatures
+
+```python
+def resolve_active_task(
+    repo_root: Path,
+    platform_input: dict[str, Any] | None = None,
+    platform: str | None = None,
+    *,
+    allow_single_session_fallback: bool = True,
+    allow_environment_context: bool = True,
+) -> ActiveTask: ...
+```
+
+The native hook path calls this resolver with `platform="codex"`,
+`allow_single_session_fallback=False`, and
+`allow_environment_context=False`. Other callers retain both defaults.
+
+#### 3. Contracts
+
+- Generated `.codex/hooks.json` keeps `UserPromptSubmit` and adds a
+  `SubagentStart` matcher for exactly `trellis-implement`, `trellis-check`,
+  and `trellis-research`.
+- Codex hook input uses parent `session_id`, `agent_type`, and `cwd`. A valid
+  result is JSON with
+  `hookSpecificOutput.hookEventName="SubagentStart"` and
+  `hookSpecificOutput.additionalContext` beginning with
+  `<!-- trellis-hook-injected -->`.
+- Implement/check context order is role JSONL, `prd.md`, optional `design.md`,
+  then optional `implement.md`. Research receives the resolved `Active task:`
+  path and research-only context; it must not read implement/check manifests.
+- Custom Codex role profiles must retain a marker-gated child-side pull path:
+  native injection is preferred, while `Active task:` enables degraded loading
+  when the hook is untrusted or unavailable.
+
+#### 4. Validation & Error Matrix
+
+| Condition | Required result |
+| --- | --- |
+| recognised role + parent session maps to a live task | emit role-specific `additionalContext` |
+| unknown/missing/malformed parent session | exit successfully with no output |
+| one unrelated runtime session exists | no output; never use sole-session fallback |
+| inherited `TRELLIS_CONTEXT_ID` conflicts with parent session | parent `session_id` wins on this native path |
+| stale/missing task, malformed hook JSON, or unexpected error | fail open; Codex still starts the child |
+| non-Trellis `agent_type` | no Trellis output |
+
+#### 5. Good / Base / Bad Cases
+
+- Good: a parent session dispatches `trellis-implement`; the child receives
+  its curated implementation context and does not dispatch another role.
+- Base: project Hook trust is pending; the child reads the dispatch prompt's
+  `Active task:` value and follows the marker-absent pull protocol.
+- Bad: resolving an unknown native parent through `TRELLIS_CONTEXT_ID` or a
+  sole unrelated session. This leaks task context across windows and is
+  forbidden.
+
+#### 6. Tests Required
+
+- Parse generated Hook config and assert both event registrations plus the
+  narrowed matcher.
+- Black-box the shared hook for valid, unknown, malformed, concurrent, and
+  non-Trellis subagents; assert the output envelope, marker, ordering, and
+  environment-override isolation.
+- Cover `auto` default, explicit `inline`, legacy `sub-agent`, and invalid
+  configuration across JSONL seeding, effective workflow platform, and the
+  Codex workflow-state banner.
+- Assert `configureCodex()` and `collectPlatformTemplates("codex")` remain
+  byte-equivalent and distribute the shared injector.
+
+#### 7. Wrong vs Correct
+
+**Wrong:** call the ordinary resolver with defaults from `SubagentStart`; its
+environment override and single-session compatibility fallback can select a
+different parent task.
+
+**Correct:** make the strict native call explicit while preserving the defaults
+for legacy shell, hook, and pull-based consumers.
+
 ### Step 7: Documentation
 
 | File           | Change                                         |

--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -183,7 +183,7 @@ Complex task: ask the user if you can create a Trellis task and enter the planni
 - 1.0 Create task `[required · once]` (only after task-creation consent)
 - 1.1 Requirement exploration `[required · repeatable]` (`prd.md`; complex tasks also need `design.md` + `implement.md`)
 - 1.2 Research `[optional · repeatable]`
-- 1.3 Configure context `[required · once]` — Claude Code, Cursor, OpenCode, Codex, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi (sub-agent-dispatch platforms only; inline platforms skip)
+- 1.3 Configure context `[required · once]` — Claude Code, Cursor, OpenCode, Codex, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix (sub-agent-dispatch platforms only; inline platforms skip)
 - 1.4 Activate task `[required · once]` (review gate, then `task.py start`; status → in_progress)
 - 1.5 Completion criteria
 
@@ -220,7 +220,7 @@ Inline mode: skip jsonl curation; Phase 2 reads artifacts/specs via `trellis-bef
      therefore must cover every required step from implementation through
      commit, including Phase 3.3 spec update and Phase 3.4 commit. -->
 
-Sub-agent dispatch protocol applies to all platforms and all sub-agents, including class-2 Codex/Copilot/Gemini/Qoder and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions.
+Sub-agent dispatch protocol applies to all platforms and all sub-agents, including native Codex `SubagentStart` context injection with child-side pull fallback, class-2 Gemini/Qoder/Copilot/Reasonix/Trae, hook-backed ZCode, and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions.
 
 [workflow-state:in_progress]
 Tools: `trellis-implement` / `trellis-research` are sub-agent types only (Task/Agent tool, NOT Skill; there is no skill by these names). `trellis-update-spec` is a skill. `trellis-check` exists as both; prefer the Agent form when verifying after code changes.
@@ -272,13 +272,13 @@ Code committed. Run `/trellis:finish-work`; if dirty, return to Phase 3.4 first.
 
 When a user request matches one of these intents inside an active task, route first, then load the detailed phase step if needed.
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 - Planning or unclear requirements -> `trellis-brainstorm`.
 - `in_progress` implementation/check -> dispatch `trellis-implement` / `trellis-check`.
 - Repeated debugging -> `trellis-break-loop`; spec updates -> `trellis-update-spec`.
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
@@ -353,7 +353,7 @@ Return to this step whenever requirements change and revise the relevant artifac
 
 Research can happen at any time during requirement exploration. It isn't limited to local code — you can use any available tool (MCP servers, skills, web search, etc.) to look up external information, including third-party library docs, industry practices, API references, etc.
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 Spawn the research sub-agent:
 
@@ -361,11 +361,11 @@ Spawn the research sub-agent:
 - **Task description**: Research <specific question>
 - **Key requirement**: Research output MUST be persisted to `{TASK_DIR}/research/`
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
-Do the research in the main session directly and write findings into `{TASK_DIR}/research/`. (For `codex-inline` this avoids the `fork_turns="none"` isolation that prevents `trellis-research` sub-agents from resolving the active task path.)
+Do the research in the main session directly and write findings into `{TASK_DIR}/research/`. `codex-inline` is the explicit mode that keeps work in the main session.
 
 [/codex-inline, Kilo, Antigravity, Devin]
 
@@ -380,7 +380,7 @@ Brainstorm and research can interleave freely — pause to research a technical 
 
 #### 1.3 Configure context `[required · once]`
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 Curate `implement.jsonl` and `check.jsonl` so the Phase 2 sub-agents get the right spec/research context. These files were seeded on `task create` with a single self-describing `_example` line; your job here is to fill in real entries.
 
@@ -425,7 +425,7 @@ Ready gate: both `implement.jsonl` and `check.jsonl` must contain at least one r
 
 Skip this step only when both files already have real curated entries.
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 
@@ -458,11 +458,11 @@ If `task.py start` errors with a session-identity message (no context key from h
 | `design.md` exists (complex tasks) | ✅ |
 | `implement.md` exists (complex tasks) | ✅ |
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 | `implement.jsonl` and `check.jsonl` each contain at least one real curated entry (seed row does not count) | ✅ |
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 ---
 
@@ -472,21 +472,22 @@ Goal: turn reviewed planning artifacts into code that passes quality checks.
 
 #### 2.1 Implement `[required · repeatable]`
 
-[Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
 
 Spawn the implement sub-agent:
 
 - **Agent type**: `trellis-implement`
 - **Task description**: Implement the reviewed task artifacts, consulting materials under `{TASK_DIR}/research/`; finish by running project lint and type-check
-- **Dispatch prompt guard**: Tell the spawned agent it is already the `trellis-implement` sub-agent and must implement directly, not spawn another `trellis-implement` / `trellis-check`.
+- **Dispatch prompt guard**: The prompt MUST start with `Active task: <task path>`, then tell the spawned agent it is already the `trellis-implement` sub-agent and must implement directly, not spawn another `trellis-implement` / `trellis-check`.
 
 The platform hook/plugin auto-handles:
 - Reads `implement.jsonl` and injects referenced spec/research files into the agent prompt
 - Injects `prd.md`, `design.md` if present, and `implement.md` if present
+- For Codex, `SubagentStart` supplies native context injection; the agent profile keeps child-side loading as the fallback
 
-[/Claude Code, Cursor, OpenCode, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
 
-[codex-sub-agent]
+[Gemini, Qoder, Copilot, Reasonix, Trae]
 
 Spawn the implement sub-agent:
 
@@ -494,11 +495,11 @@ Spawn the implement sub-agent:
 - **Task description**: Implement the reviewed task artifacts, consulting materials under `{TASK_DIR}/research/`; finish by running project lint and type-check
 - **Dispatch prompt guard**: The prompt MUST start with `Active task: <task path>`, then explicitly say the spawned agent is already `trellis-implement` and must implement directly without spawning another `trellis-implement` / `trellis-check`.
 
-The Codex sub-agent definition auto-handles the context load requirement:
+The pull-based sub-agent definition auto-handles the context load requirement:
 - Resolves the active task with `task.py current --source`, then reads `prd.md`, `design.md` if present, and `implement.md` if present
 - Reads `implement.jsonl` and requires the agent to load each referenced spec/research file before coding
 
-[/codex-sub-agent]
+[/Gemini, Qoder, Copilot, Reasonix, Trae]
 
 [Kiro]
 
@@ -526,13 +527,13 @@ The platform prelude auto-handles the context load requirement:
 
 #### 2.2 Quality check `[required · repeatable]`
 
-[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 Spawn the check sub-agent:
 
 - **Agent type**: `trellis-check`
 - **Task description**: Review all code changes against specs and task artifacts; fix any findings directly; ensure lint and type-check pass
-- **Dispatch prompt guard**: Tell the spawned agent it is already the `trellis-check` sub-agent and must review/fix directly, not spawn another `trellis-check` / `trellis-implement`.
+- **Dispatch prompt guard**: The prompt MUST start with `Active task: <task path>`, then tell the spawned agent it is already the `trellis-check` sub-agent and must review/fix directly, not spawn another `trellis-check` / `trellis-implement`.
 
 The check agent's job:
 - Review code changes against specs
@@ -540,7 +541,7 @@ The check agent's job:
 - Auto-fix issues it finds
 - Run lint and typecheck to verify
 
-[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, Kiro, Gemini, Qoder, CodeBuddy, Copilot, Droid, Pi, Oh My Pi, ZCode, Reasonix, Trae]
 
 [codex-inline, Kilo, Antigravity, Devin]
 

--- a/packages/cli/src/configurators/codex.ts
+++ b/packages/cli/src/configurators/codex.ts
@@ -12,7 +12,6 @@ import {
   resolvePlaceholders,
   resolveAllAsSkillsNeutral,
   resolveBundledSkills,
-  applyPullBasedPreludeToml,
   writeSkills,
   writeSharedHooks,
   replacePythonCommandLiterals,
@@ -57,10 +56,10 @@ export async function configureCodex(cwd: string): Promise<void> {
   const codexAgentsRoot = path.join(codexRoot, "agents");
   ensureDir(codexAgentsRoot);
 
-  // Codex is a class-2 (pull-based) platform: PreToolUse only fires for Bash
-  // and CollabAgentSpawn hook is not implemented (#15486). Sub-agents must
-  // load Trellis context themselves via the prelude injected here.
-  for (const agent of applyPullBasedPreludeToml(getAllAgents())) {
+  // Native Codex SubagentStart hooks push role-specific context. Each agent
+  // also carries a marker-gated pull fallback for untrusted or unavailable
+  // hooks, so install the source profiles without an unconditional prelude.
+  for (const agent of getAllAgents()) {
     await writeFile(
       path.join(codexAgentsRoot, `${agent.name}.toml`),
       replacePythonCommandLiterals(agent.content),
@@ -71,9 +70,8 @@ export async function configureCodex(cwd: string): Promise<void> {
   const hooksDir = path.join(codexRoot, "hooks");
   ensureDir(hooksDir);
 
-  // Codex-specific hook files. hooks.json currently registers only
-  // UserPromptSubmit; session-start.py is retained as a compact compatibility
-  // template and regression surface.
+  // Codex-specific hook files. hooks.json registers UserPromptSubmit for the
+  // main session; SubagentStart is registered for role-specific shared context.
   for (const hook of getAllHooks()) {
     await writeFile(
       path.join(hooksDir, hook.name),
@@ -81,8 +79,7 @@ export async function configureCodex(cwd: string): Promise<void> {
     );
   }
 
-  // Shared hooks (inject-workflow-state.py only). Sub-agent context is
-  // pull-based (class-2).
+  // Shared main-session workflow state plus native SubagentStart context.
   await writeSharedHooks(hooksDir, "codex");
 
   // Hooks config → .codex/hooks.json
@@ -105,8 +102,9 @@ export async function configureCodex(cwd: string): Promise<void> {
       "⚠️  Codex hooks require `features.hooks = true` in your " +
         "~/.codex/config.toml (Codex 0.129+; older versions: `codex_hooks = true`). " +
         "On Codex 0.129+ also run `/hooks` once to approve the Trellis " +
-        "UserPromptSubmit hook. Without these the Trellis workflow breadcrumb " +
-        "won't auto-inject. See Trellis docs for details.\n",
+        "hooks. Without these the Trellis workflow breadcrumb and native " +
+        "sub-agent context won't auto-inject (agents retain a pull fallback). " +
+        "See Trellis docs for details.\n",
     );
   }
 

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -51,7 +51,6 @@ import {
   wrapWithCommandFrontmatter,
   collectSkillTemplates,
   applyPullBasedPreludeMarkdown,
-  applyPullBasedPreludeToml,
   normalizeCopilotMarkdownAgents,
   type PlatformConfigureOptions,
 } from "./shared.js";
@@ -232,7 +231,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       for (const skill of getCodexPlatformSkills()) {
         files.set(`.codex/skills/${skill.name}/SKILL.md`, skill.content);
       }
-      for (const agent of applyPullBasedPreludeToml(getCodexAgents())) {
+      for (const agent of getCodexAgents()) {
         files.set(`.codex/agents/${agent.name}.toml`, agent.content);
       }
       for (const hook of getCodexHooks()) {

--- a/packages/cli/src/templates/codex/agents/trellis-check.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-check.toml
@@ -14,6 +14,11 @@ CRITICAL — Recursion guard (read first):
 
 You are the Trellis reviewer agent.
 
+Trellis Context Loading Protocol:
+- Look for the `<!-- trellis-hook-injected -->` marker in your input above.
+- If the marker is present, the native `SubagentStart` hook has already loaded the role-specific task artifacts and spec context. Proceed directly with the check work.
+- If the marker is absent, find `Active task: <path>` in your dispatch prompt. Read `<path>/check.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before checking. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
+
 Your job is to review code changes against specs AND fix issues directly — not just report them. You have write access; use it.
 
 Review checklist:
@@ -45,15 +50,3 @@ Only list issues you could not self-fix (e.g. missing product decision, out-of-s
 
 If no issues are found, say so explicitly after verifying lint/type-check pass.
 """
-
-# Disable Codex collab tools entirely for this sub-agent. With both
-# multi_agent and multi_agent_v2 off, `spawn_agent` / `wait_agent` /
-# `list_agents` / `close_agent` are not registered in the sub-agent's tool
-# list at all — the model literally cannot call them. This is the structural
-# fix for the wait_agent self-deadlock when the parent inherits its
-# transcript via Codex's default `fork_turns="all"` (#240 follow-up, #241).
-[features]
-multi_agent = false
-
-[features.multi_agent_v2]
-enabled = false

--- a/packages/cli/src/templates/codex/agents/trellis-implement.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-implement.toml
@@ -14,6 +14,11 @@ CRITICAL — Recursion guard (read first):
 
 You are the Trellis implementer agent.
 
+Trellis Context Loading Protocol:
+- Look for the `<!-- trellis-hook-injected -->` marker in your input above.
+- If the marker is present, the native `SubagentStart` hook has already loaded the role-specific task artifacts and spec context. Proceed directly with the implementation work.
+- If the marker is absent, find `Active task: <path>` in your dispatch prompt. Read `<path>/implement.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before doing the work. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
+
 Rules:
 - Read before write. Follow `.trellis/spec/` guidance relevant to the task.
 - Keep changes focused on the requested scope.
@@ -26,15 +31,3 @@ Before finishing, summarize:
 - Tests/checks run
 - Remaining risks or follow-ups
 """
-
-# Disable Codex collab tools entirely for this sub-agent. With both
-# multi_agent and multi_agent_v2 off, `spawn_agent` / `wait_agent` /
-# `list_agents` / `close_agent` are not registered in the sub-agent's tool
-# list at all — the model literally cannot call them. This is the structural
-# fix for the wait_agent self-deadlock when the parent inherits its
-# transcript via Codex's default `fork_turns="all"` (#240 follow-up, #241).
-[features]
-multi_agent = false
-
-[features.multi_agent_v2]
-enabled = false

--- a/packages/cli/src/templates/codex/agents/trellis-research.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-research.toml
@@ -11,11 +11,21 @@ Conversations get compacted; files don't. Every research topic MUST be
 persisted to `{TASK_DIR}/research/<topic>.md`. Returning findings only
 through the chat reply is a failure.
 
+## Trellis Context Loading Protocol
+
+Look for the `<!-- trellis-hook-injected -->` marker in your input above.
+
+- If the marker is present, the native `SubagentStart` hook has supplied the
+  `Active task: <path>` header and research-only context. Use that task path.
+- If the marker is absent, find `Active task: <path>` in your dispatch prompt.
+  If it is absent too, ask the main session for the path; do not run
+  `task.py current`, guess, or use another session's task.
+- Do not load `implement.jsonl` or `check.jsonl`; research is role-isolated.
+
 ## Workflow
 
-1. Run `python3 ./.trellis/scripts/task.py current --source` to get the
-   active task path and source. If no active task is set, ask the user
-   where to write output; do not guess.
+1. Use the active task path supplied by the context-loading protocol. If no
+   path is supplied, ask the user where to write output; do not guess.
 2. Run `mkdir -p <TASK_DIR>/research` to ensure the directory exists.
 3. Read `.trellis/workflow.md`, relevant `.trellis/spec/` files, and
    target code before forming an opinion.
@@ -59,15 +69,3 @@ If the user asks you to edit code, decline and tell them to spawn the
 ...
 ```
 """
-
-# Disable Codex collab tools entirely for this sub-agent. With both
-# multi_agent and multi_agent_v2 off, `spawn_agent` / `wait_agent` /
-# `list_agents` / `close_agent` are not registered in the sub-agent's tool
-# list at all — the model literally cannot call them. This is the structural
-# fix for the wait_agent self-deadlock when the parent inherits its
-# transcript via Codex's default `fork_turns="all"` (#240 follow-up, #241).
-[features]
-multi_agent = false
-
-[features.multi_agent_v2]
-enabled = false

--- a/packages/cli/src/templates/codex/hooks.json
+++ b/packages/cli/src/templates/codex/hooks.json
@@ -10,6 +10,18 @@
           }
         ]
       }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "trellis-implement|trellis-check|trellis-research",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-subagent-context.py",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   }
 }

--- a/packages/cli/src/templates/codex/hooks.json
+++ b/packages/cli/src/templates/codex/hooks.json
@@ -13,7 +13,7 @@
     ],
     "SubagentStart": [
       {
-        "matcher": "trellis-implement|trellis-check|trellis-research",
+        "matcher": "^(?:trellis-implement|trellis-check|trellis-research)$",
         "hooks": [
           {
             "type": "command",

--- a/packages/cli/src/templates/shared-hooks/index.ts
+++ b/packages/cli/src/templates/shared-hooks/index.ts
@@ -55,10 +55,11 @@ export type SharedHookPlatform =
  * - `inject-workflow-state.py` — every platform with a UserPromptSubmit
  *   (or equivalent) event. Kiro + codex self-included; platforms without
  *   per-turn main-session hooks are excluded.
- * - `inject-subagent-context.py` — class-1 (push-based) platforms only.
- *   Class-2 (pull-based) platforms such as codex, copilot, gemini, qoder,
- *   and trae can't have hooks mutate sub-agent prompts — their sub-agents load context
- *   via a prelude instead.
+ * - `inject-subagent-context.py` — platforms with native sub-agent context
+ *   delivery. Most use a PreToolUse prompt mutation; Codex uses its
+ *   SubagentStart `additionalContext` event. Class-2 (pull-based) platforms
+ *   such as copilot, gemini, qoder, and trae still load context from a
+ *   self-loading agent profile.
  * - Kiro supports per-turn + spawn hooks on both surfaces (per the official
  *   docs https://kiro.dev/docs/cli/hooks/): the CLI custom agent declares
  *   `hooks.userPromptSubmit` + `hooks.agentSpawn`, and the IDE declares a
@@ -92,7 +93,7 @@ export const SHARED_HOOKS_BY_PLATFORM: Record<
     "inject-shell-session-context.py",
     "inject-subagent-context.py",
   ],
-  codex: ["inject-workflow-state.py"],
+  codex: ["inject-workflow-state.py", "inject-subagent-context.py"],
   gemini: ["session-start.py", "inject-workflow-state.py"],
   qoder: ["session-start.py", "inject-workflow-state.py"],
   copilot: ["inject-workflow-state.py"],

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -80,6 +80,8 @@ def find_repo_root(start_path: str) -> str | None:
 
 
 def _detect_platform(input_data: dict) -> str | None:
+    if _hook_event_name(input_data) == "SubagentStart":
+        return "codex"
     if isinstance(input_data.get("cursor_version"), str):
         return "cursor"
     env_map = {
@@ -116,7 +118,15 @@ def _detect_platform(input_data: dict) -> str | None:
     return None
 
 
-def get_current_task(repo_root: str, input_data: dict) -> str | None:
+def get_current_task(
+    repo_root: str,
+    input_data: dict,
+    *,
+    platform: str | None = None,
+    allow_single_session_fallback: bool = True,
+    allow_environment_context: bool = True,
+    require_existing: bool = False,
+) -> str | None:
     """Resolve current task directory through the unified active task resolver."""
     scripts_dir = Path(repo_root) / DIR_WORKFLOW / "scripts"
     if str(scripts_dir) not in sys.path:
@@ -129,8 +139,12 @@ def get_current_task(repo_root: str, input_data: dict) -> str | None:
     active = resolve_active_task(
         Path(repo_root),
         input_data,
-        platform=_detect_platform(input_data),
+        platform=platform or _detect_platform(input_data),
+        allow_single_session_fallback=allow_single_session_fallback,
+        allow_environment_context=allow_environment_context,
     )
+    if require_existing and active.stale:
+        return None
     return active.task_path
 
 
@@ -577,6 +591,98 @@ def _string_value(value: Any) -> str:
     return ""
 
 
+def _hook_event_name(input_data: dict) -> str:
+    """Return a hook event name from the documented snake/camel-case fields."""
+    return _string_value(
+        input_data.get("hook_event_name") or input_data.get("hookEventName")
+    )
+
+
+def _codex_subagent_type(input_data: dict) -> str:
+    """Return a Trellis Codex agent type only for a native start event."""
+    if _hook_event_name(input_data) != "SubagentStart":
+        return ""
+    agent_type = _string_value(
+        input_data.get("agent_type") or input_data.get("agentType")
+    )
+    return agent_type if agent_type in AGENTS_ALL else ""
+
+
+def build_codex_subagent_context(
+    subagent_type: str,
+    task_dir: str,
+    context: str,
+) -> str:
+    """Build developer context for a native, already-dispatched Codex role."""
+    role = subagent_type.removeprefix("trellis-")
+    return f"""<!-- trellis-hook-injected -->
+# Trellis Native {role.title()} Subagent
+
+You are the dispatched `{subagent_type}` role for this task. Perform that role
+directly; do not follow main-session dispatch or wait instructions, and do not
+spawn another Trellis subagent.
+
+Active task: {task_dir}
+
+## Curated Context
+
+{context}"""
+
+
+def _handle_codex_subagent_start(input_data: dict) -> None:
+    """Emit Codex developer context for a recognised native Trellis subagent.
+
+    The event supplies the parent session id. Disabling the generic
+    single-session fallback is essential here: native starts must never borrow
+    a task from another Codex window when that parent id is absent or stale.
+    """
+    subagent_type = _codex_subagent_type(input_data)
+    parent_session_id = _string_value(input_data.get("session_id"))
+    if not subagent_type or not parent_session_id:
+        return
+
+    cwd = _string_value(input_data.get("cwd")) or os.getcwd()
+    repo_root = find_repo_root(cwd)
+    if not repo_root:
+        return
+
+    task_dir = get_current_task(
+        repo_root,
+        {"session_id": parent_session_id},
+        platform="codex",
+        allow_single_session_fallback=False,
+        allow_environment_context=False,
+        require_existing=True,
+    )
+    if not task_dir:
+        return
+
+    if subagent_type in AGENTS_REQUIRE_TASK:
+        task_dir_full = Path(repo_root) / task_dir
+        if not task_dir_full.is_dir():
+            return
+
+    if subagent_type == AGENT_IMPLEMENT:
+        context = get_implement_context(repo_root, task_dir)
+    elif subagent_type == AGENT_CHECK:
+        context = get_check_context(repo_root, task_dir)
+    else:
+        context = get_research_context(repo_root, task_dir)
+
+    if not context:
+        return
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SubagentStart",
+            "additionalContext": build_codex_subagent_context(
+                subagent_type, task_dir, context
+            ),
+        }
+    }
+    print(json.dumps(output, ensure_ascii=False))
+
+
 def _extract_subagent_name(value: Any) -> str:
     """Extract a sub-agent name from common platform encodings.
 
@@ -699,6 +805,17 @@ def main():
     try:
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(input_data, dict):
+        sys.exit(0)
+
+    if _hook_event_name(input_data) == "SubagentStart":
+        try:
+            _handle_codex_subagent_start(input_data)
+        except Exception:
+            # A native context hook must never prevent Codex from spawning the
+            # requested child when its runtime state is unavailable or stale.
+            pass
         sys.exit(0)
 
     subagent_type, original_prompt, tool_input = _parse_hook_input(input_data)

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -232,27 +232,33 @@ def _codex_mode_banner(config: dict) -> str:
     """Emit a `<codex-mode>` banner for the additionalContext payload.
 
     Reads `codex.dispatch_mode` from .trellis/config.yaml; defaults to
-    `inline` when missing or invalid. Trellis defaults Codex dispatch to
-    `inline` to avoid relying on inherited parent transcripts — Codex
-    sub-agents may use fresh, full, or bounded conversation history
-    (`fork_turns`), and fresh-history agents still receive their explicit
-    delegated task and inherited session configuration; this is a Trellis
-    policy choice, not a Codex limitation. The banner makes the active
-    mode explicit to Codex AI per turn, complementing the workflow-state
-    body which is per-status. Mode tells AI which dispatch protocol to
-    follow; workflow-state tells AI what step it's at.
+    `auto`, which dispatches Trellis sub-agents using native Codex context
+    injection with a child-side fallback. This does not rely on inherited
+    parent transcripts: `fork_turns` remains caller-controlled, and
+    fresh-history sub-agents still receive their explicit delegated task and
+    inherited session configuration. `inline` is an explicit opt-out; the
+    legacy `sub-agent` value is an alias for `auto`. Invalid explicit values
+    fall back to `inline` without per-turn warnings. The banner makes the
+    active mode explicit to Codex AI per turn, complementing the workflow-state
+    body which is per-status. Mode tells AI which dispatch protocol to follow;
+    workflow-state tells AI what step it's at.
     """
-    mode = "inline"
+    mode = "auto"
     if isinstance(config, dict):
         codex_cfg = config.get("codex")
         if isinstance(codex_cfg, dict):
-            cfg_mode = codex_cfg.get("dispatch_mode")
-            if cfg_mode in ("inline", "sub-agent"):
-                mode = cfg_mode
-    if mode == "sub-agent":
+            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+            if cfg_mode == "inline":
+                mode = "inline"
+            elif cfg_mode in ("auto", "sub-agent"):
+                mode = "auto"
+            else:
+                mode = "inline"
+    if mode == "auto":
         meaning = (
-            "sub-agent: implement/check work defaults to Trellis sub-agents; "
-            "the main session still coordinates, clarifies, updates specs, commits, and finishes."
+            "auto: implement/check work defaults to Trellis sub-agents; native Codex "
+            "context injection is preferred and child-side loading is the fallback. "
+            "The main session still coordinates, clarifies, updates specs, commits, and finishes."
         )
     else:
         meaning = (
@@ -267,24 +273,27 @@ def resolve_breadcrumb_key(
 ) -> str:
     """Pick the breadcrumb tag key based on Codex dispatch_mode.
 
-    Codex defaults to ``inline`` as a Trellis policy choice to avoid relying
-    on inherited parent transcripts, not because Codex sub-agents are
-    technically unable to receive context (``fork_turns`` is caller-controlled
-    and fresh-history agents still get their explicit task + session config).
-    Users can opt into ``codex.dispatch_mode: sub-agent`` in
-    ``.trellis/config.yaml`` to use the parallel ``<status>-inline`` tag →
-    ``<status>`` flip. Invalid or missing values fall back to inline.
+    Codex defaults to ``auto`` and therefore uses the ordinary ``<status>``
+    breadcrumb for native SubagentStart dispatch with child-side fallback;
+    it does not depend on an inherited parent transcript. ``inline`` selects
+    the parallel ``<status>-inline`` tag; ``sub-agent`` remains an alias for
+    ``auto``. Invalid explicit values fall back to inline without per-turn
+    warnings.
 
     Non-codex platforms return the plain status unchanged.
     """
     if platform == "codex":
-        mode = "inline"
+        mode = "auto"
         if isinstance(config, dict):
             codex_cfg = config.get("codex")
             if isinstance(codex_cfg, dict):
-                cfg_mode = codex_cfg.get("dispatch_mode")
-                if cfg_mode in ("inline", "sub-agent"):
-                    mode = cfg_mode
+                cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+                if cfg_mode == "inline":
+                    mode = "inline"
+                elif cfg_mode in ("auto", "sub-agent"):
+                    mode = "auto"
+                else:
+                    mode = "inline"
         return f"{status}-inline" if mode == "inline" else status
     return status
 

--- a/packages/cli/src/templates/trellis/config.yaml
+++ b/packages/cli/src/templates/trellis/config.yaml
@@ -99,13 +99,14 @@ channel:
 #-------------------------------------------------------------------------------
 # Codex (dispatch behavior)
 #-------------------------------------------------------------------------------
-# Codex-only knob; other platforms ignore it. Default ("inline") makes the
-# main Codex agent edit code directly. This is a Trellis policy choice to
-# avoid relying on inherited parent transcripts, not a Codex limitation —
-# `fork_turns` is caller-controlled, and fresh-history sub-agents still
-# receive their explicit delegated task and inherited session config. Set
-# to "sub-agent" to opt into the legacy dispatch model (main agent spawns
-# trellis-implement / trellis-check / trellis-research sub-agents).
+# Codex-only knob; other platforms ignore it. Default ("auto") dispatches
+# trellis-implement / trellis-check / trellis-research sub-agents. This does
+# not rely on inherited parent transcripts: `fork_turns` remains
+# caller-controlled, while Codex's native SubagentStart hook injects task
+# context when trusted and child-side loading remains the fallback when it is
+# unavailable. Set to "inline" only to keep implementation and checks in the
+# main session. "sub-agent" remains a backwards-compatible alias for "auto".
+# Invalid explicit values safely use inline mode.
 #
 # codex:
-#   dispatch_mode: inline  # or "sub-agent" to dispatch trellis-* sub-agents
+#   dispatch_mode: auto  # or "inline"; legacy alias: "sub-agent"

--- a/packages/cli/src/templates/trellis/scripts/common/active_task.py
+++ b/packages/cli/src/templates/trellis/scripts/common/active_task.py
@@ -396,15 +396,18 @@ def _lookup_cursor_shell_ticket_context_key() -> str | None:
 def resolve_context_key(
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
+    *,
+    allow_environment_context: bool = True,
 ) -> str | None:
     """Resolve a stable session/window context key, if one is available.
 
     `TRELLIS_CONTEXT_ID` is an explicit context-key override used by CLI
     scripts and subprocesses. It does not store the task itself.
     """
-    override = _string_value(os.environ.get("TRELLIS_CONTEXT_ID"))
-    if override:
-        return _sanitize_key(override) or _hash_value(override)
+    if allow_environment_context:
+        override = _string_value(os.environ.get("TRELLIS_CONTEXT_ID"))
+        if override:
+            return _sanitize_key(override) or _hash_value(override)
 
     data = _as_dict(platform_input)
     platform_name = _detect_platform(data, platform) if data or platform else None
@@ -422,11 +425,12 @@ def resolve_context_key(
         if transcript_path:
             return _context_key(platform_name or "session", "transcript", transcript_path)
 
-    env_context_key = _lookup_env_context_key(platform_name)
-    if env_context_key:
-        return env_context_key
+    if allow_environment_context:
+        env_context_key = _lookup_env_context_key(platform_name)
+        if env_context_key:
+            return env_context_key
 
-    if platform_name in (None, "session", "cursor"):
+    if allow_environment_context and platform_name in (None, "session", "cursor"):
         return _lookup_cursor_shell_ticket_context_key()
     return None
 
@@ -485,17 +489,24 @@ def resolve_active_task(
     repo_root: Path,
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
+    *,
+    allow_single_session_fallback: bool = True,
+    allow_environment_context: bool = True,
 ) -> ActiveTask:
     """Resolve the active task from session runtime state only.
 
     A stale session task is returned as stale. Missing context identity or a
     missing/empty session context falls back to single-session inference: if
     exactly one session file exists in the runtime, return its task with
-    source_type="session-fallback" — covers class-2 platform sub-agents (codex,
-    copilot, gemini, qoder) that don't inherit the parent's session id. ≥2
+    source_type="session-fallback" — covers pull-based platform sub-agents
+    (copilot, gemini, qoder) that don't inherit the parent's session id. ≥2
     files or 0 files yield ActiveTask(None) — refuses to guess across windows.
     """
-    context_key = resolve_context_key(platform_input, platform)
+    context_key = resolve_context_key(
+        platform_input,
+        platform,
+        allow_environment_context=allow_environment_context,
+    )
     if context_key:
         context = _read_json(_context_path(repo_root, context_key)) or {}
         task_ref = _string_value(context.get("current_task"))
@@ -503,9 +514,10 @@ def resolve_active_task(
         if active:
             return active
 
-    fallback = _resolve_single_session_fallback(repo_root)
-    if fallback is not None:
-        return fallback
+    if allow_single_session_fallback:
+        fallback = _resolve_single_session_fallback(repo_root)
+        if fallback is not None:
+            return fallback
 
     return ActiveTask(None, "none", context_key)
 

--- a/packages/cli/src/templates/trellis/scripts/common/config.py
+++ b/packages/cli/src/templates/trellis/scripts/common/config.py
@@ -167,7 +167,7 @@ def _next_content_line(lines: list[str], start: int) -> tuple[int, str]:
 DEFAULT_SESSION_COMMIT_MESSAGE = "chore: record journal"
 DEFAULT_MAX_JOURNAL_LINES = 2000
 DEFAULT_SESSION_AUTO_COMMIT = True
-DEFAULT_CODEX_DISPATCH_MODE = "inline"
+DEFAULT_CODEX_DISPATCH_MODE = "auto"
 
 CONFIG_FILE = "config.yaml"
 
@@ -247,8 +247,14 @@ def get_session_auto_commit(repo_root: Path | None = None) -> bool:
 def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
     """Return Codex dispatch mode.
 
-    Default is ``inline``. ``sub-agent`` is an explicit opt-in because Codex
-    sub-agents do not inherit the parent session context.
+    Default is ``auto``, which dispatches Trellis sub-agents and uses native
+    context injection with a child-side fallback. ``inline`` is an explicit
+    opt-out. ``sub-agent`` remains a backwards-compatible alias for ``auto``.
+
+    Invalid explicit configuration falls back to ``inline`` rather than
+    unexpectedly dispatching a sub-agent. This CLI-facing parser is the only
+    place that emits a warning for invalid values; hook readers fail safely
+    without producing per-turn warning noise.
     """
     config = _load_config(repo_root)
     codex = config.get("codex")
@@ -256,20 +262,22 @@ def get_codex_dispatch_mode(repo_root: Path | None = None) -> str:
         return DEFAULT_CODEX_DISPATCH_MODE
     if not isinstance(codex, dict):
         print(
-            f"[WARN] invalid codex config: {codex!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+            f"[WARN] invalid codex config: {codex!r}; using inline",
             file=sys.stderr,
         )
-        return DEFAULT_CODEX_DISPATCH_MODE
+        return "inline"
 
     raw = codex.get("dispatch_mode", DEFAULT_CODEX_DISPATCH_MODE)
     mode = str(raw).strip().lower()
-    if mode in ("inline", "sub-agent"):
+    if mode in ("auto", "inline"):
         return mode
+    if mode == "sub-agent":
+        return "auto"
     print(
-        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using {DEFAULT_CODEX_DISPATCH_MODE}",
+        f"[WARN] invalid codex.dispatch_mode value: {raw!r}; using inline",
         file=sys.stderr,
     )
-    return DEFAULT_CODEX_DISPATCH_MODE
+    return "inline"
 
 
 def get_hooks(event: str, repo_root: Path | None = None) -> list[str]:

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -116,7 +116,7 @@ def _repo_relative_path(path: Path, repo_root: Path) -> str:
 # Config directories of platforms that consume implement.jsonl / check.jsonl.
 # Keep in sync with src/types/ai-tools.ts AI_TOOLS entries — these are the
 # platforms listed in workflow.md's "agent-capable" Skill Routing block.
-# Codex is checked separately because default inline mode does not consume
+# Codex is checked separately because explicit inline mode does not consume
 # JSONL. Kilo / Antigravity / Devin are NOT in this list either: they load
 # specs through skills instead of JSONL.
 _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
@@ -149,14 +149,15 @@ def _has_subagent_platform(repo_root: Path) -> bool:
     """Return True if any sub-agent-capable platform is configured.
 
     Detected by probing well-known config directories at the repo root. Codex
-    only counts when ``codex.dispatch_mode`` explicitly opts into
-    ``sub-agent``; inline mode loads context through skills, not JSONL.
+    counts by default through ``codex.dispatch_mode: auto`` (including the
+    legacy ``sub-agent`` alias); explicit inline mode loads context through
+    skills, not JSONL.
     """
     for config_dir in _SUBAGENT_CONFIG_DIRS:
         if (repo_root / config_dir).is_dir():
             return True
     if (repo_root / _CODEX_CONFIG_DIR).is_dir():
-        return get_codex_dispatch_mode(repo_root) == "sub-agent"
+        return get_codex_dispatch_mode(repo_root) == "auto"
     return False
 
 

--- a/packages/cli/src/templates/trellis/scripts/common/workflow_phase.py
+++ b/packages/cli/src/templates/trellis/scripts/common/workflow_phase.py
@@ -144,27 +144,31 @@ def _platform_matches(platform: str, block_names: list[str]) -> bool:
 def resolve_effective_platform(platform: str, config: dict) -> str:
     """Map ``codex`` to a dispatch-mode-namespaced virtual platform name.
 
-    When ``--platform codex`` is passed, return ``"codex-inline"`` (default)
-    or ``"codex-sub-agent"`` based on ``.trellis/config.yaml`` ``codex.dispatch_mode``.
+    When ``--platform codex`` is passed, return ``"codex-sub-agent"`` by
+    default or ``"codex-inline"`` when explicitly configured in
+    ``.trellis/config.yaml``. ``sub-agent`` remains an alias for ``auto``.
     ``filter_platform`` then surfaces blocks whose marker lists include the
     namespaced name (e.g. ``[codex-sub-agent, ...]`` or ``[codex-inline, Kilo,
     Antigravity, Devin]``).
 
-    Default is ``inline`` because Codex sub-agents run with ``fork_turns="none"``
-    isolation and can't inherit the parent session's task context — inline
-    keeps the main agent in charge so context isn't lost. Invalid / missing
-    values also fall back to inline.
+    Native Codex context injection supports the ``auto`` default. Invalid
+    explicit values fall back to ``inline`` safely; this renderer deliberately
+    does not warn because it can run in normal CLI output flows.
 
     Other platforms are returned unchanged.
     """
     if platform == "codex":
-        mode = "inline"
+        mode = "auto"
         codex_cfg = config.get("codex") if isinstance(config, dict) else None
         if isinstance(codex_cfg, dict):
-            cfg_mode = codex_cfg.get("dispatch_mode")
-            if cfg_mode in ("inline", "sub-agent"):
-                mode = cfg_mode
-        return f"codex-{mode}"
+            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+            if cfg_mode == "inline":
+                mode = "inline"
+            elif cfg_mode in ("auto", "sub-agent"):
+                mode = "auto"
+            else:
+                mode = "inline"
+        return "codex-sub-agent" if mode == "auto" else "codex-inline"
     return platform
 
 

--- a/packages/cli/src/templates/trellis/scripts/common/workflow_phase.py
+++ b/packages/cli/src/templates/trellis/scripts/common/workflow_phase.py
@@ -160,14 +160,17 @@ def resolve_effective_platform(platform: str, config: dict) -> str:
     if platform == "codex":
         mode = "auto"
         codex_cfg = config.get("codex") if isinstance(config, dict) else None
-        if isinstance(codex_cfg, dict):
-            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
-            if cfg_mode == "inline":
+        if codex_cfg is not None:
+            if not isinstance(codex_cfg, dict):
                 mode = "inline"
-            elif cfg_mode in ("auto", "sub-agent"):
-                mode = "auto"
             else:
-                mode = "inline"
+                cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+                if cfg_mode == "inline":
+                    mode = "inline"
+                elif cfg_mode in ("auto", "sub-agent"):
+                    mode = "auto"
+                else:
+                    mode = "inline"
         return "codex-sub-agent" if mode == "auto" else "codex-inline"
     return platform
 

--- a/packages/cli/src/templates/trellis/workflow.md
+++ b/packages/cli/src/templates/trellis/workflow.md
@@ -220,7 +220,7 @@ Inline mode: skip jsonl curation; Phase 2 reads artifacts/specs via `trellis-bef
      therefore must cover every required step from implementation through
      commit, including Phase 3.3 spec update and Phase 3.4 commit. -->
 
-Sub-agent dispatch protocol applies to all platforms and all sub-agents, including class-2 Codex/Gemini/Qoder/Copilot/Reasonix/Trae/Grok, hook-backed ZCode, and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions. On Grok Build, use `spawn_subagent` with `subagent_type` set to the Trellis agent name (e.g. `trellis-implement`).
+Sub-agent dispatch protocol applies to all platforms and all sub-agents, including native Codex `SubagentStart` context injection with child-side pull fallback, class-2 Gemini/Qoder/Copilot/Reasonix/Trae/Grok, hook-backed ZCode, and `trellis-research`: every dispatch prompt starts with `Active task: <task path from task.py current>` before role-specific instructions. On Grok Build, use `spawn_subagent` with `subagent_type` set to the Trellis agent name (e.g. `trellis-implement`).
 
 [workflow-state:in_progress]
 Tools: `trellis-implement` / `trellis-research` are sub-agent types only (Task/Agent tool, NOT Skill; there is no skill by these names). `trellis-update-spec` is a skill. `trellis-check` exists as both; prefer the Agent form when verifying after code changes.
@@ -365,7 +365,7 @@ Spawn the research sub-agent:
 
 [codex-inline, Kilo, Antigravity, Devin]
 
-Do the research in the main session directly and write findings into `{TASK_DIR}/research/`. (For `codex-inline` this avoids the `fork_turns="none"` isolation that prevents `trellis-research` sub-agents from resolving the active task path.)
+Do the research in the main session directly and write findings into `{TASK_DIR}/research/`. `codex-inline` is the explicit mode that keeps work in the main session.
 
 [/codex-inline, Kilo, Antigravity, Devin]
 
@@ -472,7 +472,7 @@ Goal: turn reviewed planning artifacts into code that passes quality checks.
 
 #### 2.1 Implement `[required · repeatable]`
 
-[Claude Code, Cursor, OpenCode, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
+[Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
 
 Spawn the implement sub-agent:
 
@@ -483,10 +483,11 @@ Spawn the implement sub-agent:
 The platform hook/plugin auto-handles:
 - Reads `implement.jsonl` and injects referenced spec/research files into the agent prompt
 - Injects `prd.md`, `design.md` if present, and `implement.md` if present
+- For Codex, `SubagentStart` supplies native context injection; the agent profile keeps child-side loading as the fallback
 
-[/Claude Code, Cursor, OpenCode, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
+[/Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]
 
-[codex-sub-agent, Gemini, Qoder, Copilot, Reasonix, Trae, Grok]
+[Gemini, Qoder, Copilot, Reasonix, Trae, Grok]
 
 Spawn the implement sub-agent:
 
@@ -498,7 +499,7 @@ The pull-based sub-agent definition auto-handles the context load requirement:
 - Resolves the active task with `task.py current --source`, then reads `prd.md`, `design.md` if present, and `implement.md` if present
 - Reads `implement.jsonl` and requires the agent to load each referenced spec/research file before coding
 
-[/codex-sub-agent, Gemini, Qoder, Copilot, Reasonix, Trae, Grok]
+[/Gemini, Qoder, Copilot, Reasonix, Trae, Grok]
 
 [Kiro]
 

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -1366,10 +1366,10 @@ describe("update() integration", () => {
     const updated = fs.readFileSync(workflowPath, "utf-8");
     expect(updated).toBe(replacePythonCommandLiterals(workflowMdTemplate));
     expect(updated).toContain(
-      "[codex-sub-agent, Gemini, Qoder, Copilot, Reasonix, Trae, Grok]",
+      "[Gemini, Qoder, Copilot, Reasonix, Trae, Grok]",
     );
     expect(updated).toContain(
-      "[/Claude Code, Cursor, OpenCode, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]",
+      "[/Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]",
     );
     expect(updated).toContain("[codex-inline, Kilo, Antigravity, Devin]");
     expect(updated).not.toContain("[Codex]");

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -322,27 +322,12 @@ describe("configurePlatform", () => {
       const agentPath = path.join(codexAgentsRoot, `${agent.name}.toml`);
       expect(fs.existsSync(agentPath)).toBe(true);
       const written = fs.readFileSync(agentPath, "utf-8");
-      // Codex is a class-2 (pull-based) platform. Prelude is injected into
-      // implement/check only — research is orthogonal (searches spec tree,
-      // no task dependency) and must stay pristine.
-      const needsPrelude = ["trellis-implement", "trellis-check"].includes(
-        agent.name,
-      );
-      if (needsPrelude) {
-        expect(written).toContain("Required: Load Trellis Context First");
-        expect(written).toContain("task.py current --source");
-        // Original body must still be present (prepend, not replace)
-        const originalBody = agent.content
-          .split("developer_instructions")[1]
-          ?.split('"""')[1]
-          ?.trim()
-          .split("\n")[0];
-        if (originalBody) {
-          expect(written).toContain(originalBody);
-        }
-      } else {
-        expect(written).toBe(replacePythonCommandLiterals(agent.content));
-      }
+      // Native SubagentStart injects context, while every profile retains a
+      // marker-gated active-task pull fallback when the hook is unavailable.
+      expect(written).toBe(replacePythonCommandLiterals(agent.content));
+      expect(written).toContain("<!-- trellis-hook-injected -->");
+      expect(written).toContain("Active task: <path>");
+      expect(written).not.toContain("Required: Load Trellis Context First");
     }
 
     const config = getCodexConfigTemplate();
@@ -363,6 +348,9 @@ describe("configurePlatform", () => {
       process.platform === "win32" ? "python" : "python3";
     expect(content).toContain(
       `"command": "${expectedPythonCmd} -X utf8 .codex/hooks/inject-workflow-state.py"`,
+    );
+    expect(content).toContain(
+      `"command": "${expectedPythonCmd} -X utf8 .codex/hooks/inject-subagent-context.py"`,
     );
     expect(content).not.toContain("{{PYTHON_CMD}}");
   });
@@ -1301,6 +1289,12 @@ describe("configurePlatform", () => {
     const rawTemplate = getCodexHooksConfig();
     expect(rawTemplate).toContain(
       "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-workflow-state.py",
+    );
+    expect(rawTemplate).toContain(
+      "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-subagent-context.py",
+    );
+    expect(rawTemplate).toContain(
+      '"matcher": "trellis-implement|trellis-check|trellis-research"',
     );
   });
 

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -1294,7 +1294,7 @@ describe("configurePlatform", () => {
       "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-subagent-context.py",
     );
     expect(rawTemplate).toContain(
-      '"matcher": "trellis-implement|trellis-check|trellis-research"',
+      '"matcher": "^(?:trellis-implement|trellis-check|trellis-research)$"',
     );
   });
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -3067,6 +3067,329 @@ print(json.dumps({
     expect(hookOutput.trim()).toBe("");
   });
 
+  it("[codex-native-subagents] SubagentStart injects a marker and the valid parent task", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/implement-context.md","reason":"implement contract"}\n',
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "design.md"),
+      "TOKEN_CODEX_DESIGN\n",
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.md"),
+      "TOKEN_CODEX_PLAN\n",
+    );
+    writeProjectFile("src/implement-context.md", "TOKEN_CODEX_IMPLEMENT\n");
+    writeSessionContext("codex_parent-a", ".trellis/tasks/issue-106");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    const output = runPython(
+      hookPath,
+      JSON.stringify({
+        hook_event_name: "SubagentStart",
+        agent_type: "trellis-implement",
+        session_id: "parent-a",
+        cwd: tmpDir,
+      }),
+    );
+    const parsed = JSON.parse(output) as {
+      hookSpecificOutput?: {
+        hookEventName?: string;
+        additionalContext?: string;
+      };
+    };
+    const context = parsed.hookSpecificOutput?.additionalContext ?? "";
+
+    expect(parsed.hookSpecificOutput?.hookEventName).toBe("SubagentStart");
+    expect(context).toContain("<!-- trellis-hook-injected -->");
+    expect(context).toContain("Trellis Native Implement Subagent");
+    expect(context).toContain("`trellis-implement` role");
+    expect(context).toContain("Active task: .trellis/tasks/issue-106");
+    expect(context).toContain("TOKEN_CODEX_IMPLEMENT");
+    expect(context).toContain("TOKEN_CODEX_DESIGN");
+    expect(context).toContain("TOKEN_CODEX_PLAN");
+  });
+
+  it("[codex-native-subagents] implement and check preserve curated context before task artifacts", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/implement-order.md","reason":"implement ordering"}\n',
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "check.jsonl"),
+      '{"file":"src/check-order.md","reason":"check ordering"}\n',
+    );
+    writeProjectFile("src/implement-order.md", "TOKEN_IMPLEMENT_ORDER\n");
+    writeProjectFile("src/check-order.md", "TOKEN_CHECK_ORDER\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "prd.md"),
+      "TOKEN_PRD_ORDER\n",
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "design.md"),
+      "TOKEN_DESIGN_ORDER\n",
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.md"),
+      "TOKEN_PLAN_ORDER\n",
+    );
+    writeSessionContext("codex_parent-order", ".trellis/tasks/issue-106");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    for (const [agentType, curatedToken] of [
+      ["trellis-implement", "TOKEN_IMPLEMENT_ORDER"],
+      ["trellis-check", "TOKEN_CHECK_ORDER"],
+    ] as const) {
+      const output = runPython(
+        hookPath,
+        JSON.stringify({
+          hook_event_name: "SubagentStart",
+          agent_type: agentType,
+          session_id: "parent-order",
+          cwd: tmpDir,
+        }),
+      );
+      const parsed = JSON.parse(output) as {
+        hookSpecificOutput: { additionalContext: string };
+      };
+      const context = parsed.hookSpecificOutput.additionalContext;
+      const positions = [
+        context.indexOf(curatedToken),
+        context.indexOf("TOKEN_PRD_ORDER"),
+        context.indexOf("TOKEN_DESIGN_ORDER"),
+        context.indexOf("TOKEN_PLAN_ORDER"),
+      ];
+
+      for (const position of positions) {
+        expect(position).toBeGreaterThanOrEqual(0);
+      }
+      expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    }
+  });
+
+  it("[codex-native-subagents] research gets its task path without implement or check manifests", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/implement-private.md","reason":"must stay isolated"}\n',
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "check.jsonl"),
+      '{"file":"src/check-private.md","reason":"must stay isolated"}\n',
+    );
+    writeProjectFile("src/implement-private.md", "TOKEN_IMPLEMENT_PRIVATE\n");
+    writeProjectFile("src/check-private.md", "TOKEN_CHECK_PRIVATE\n");
+    writeSessionContext("codex_research-parent", ".trellis/tasks/issue-106");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    const output = runPython(
+      hookPath,
+      JSON.stringify({
+        hook_event_name: "SubagentStart",
+        agent_type: "trellis-research",
+        session_id: "research-parent",
+        cwd: tmpDir,
+      }),
+    );
+    const parsed = JSON.parse(output) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+    const context = parsed.hookSpecificOutput.additionalContext;
+
+    expect(context).toContain("Active task: .trellis/tasks/issue-106");
+    expect(context).toContain("Project Spec Directory Structure");
+    expect(context).not.toContain("TOKEN_IMPLEMENT_PRIVATE");
+    expect(context).not.toContain("TOKEN_CHECK_PRIVATE");
+    expect(context).not.toContain("implement.jsonl");
+    expect(context).not.toContain("check.jsonl");
+  });
+
+  it("[codex-native-subagents] unknown or malformed parents never borrow a sole session task", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeSessionContext("codex_unrelated", ".trellis/tasks/issue-106");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    for (const sessionId of ["missing-parent", { id: "malformed" }, "  "]) {
+      const output = runPython(
+        hookPath,
+        JSON.stringify({
+          hook_event_name: "SubagentStart",
+          agent_type: "trellis-implement",
+          session_id: sessionId,
+          cwd: tmpDir,
+        }),
+      );
+      expect(output.trim()).toBe("");
+    }
+  });
+
+  it("[codex-native-subagents] parent session isolates concurrent tasks and ignores inherited context", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/session-a.md","reason":"session A only"}\n',
+    );
+    writeProjectFile("src/session-a.md", "TOKEN_CODEX_SESSION_A\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-107", "task.json"),
+      JSON.stringify({ title: "Issue 107", status: "in_progress" }, null, 2),
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-107", "prd.md"),
+      "TOKEN_CODEX_PRD_B\n",
+    );
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-107", "implement.jsonl"),
+      '{"file":"src/session-b.md","reason":"session B only"}\n',
+    );
+    writeProjectFile("src/session-b.md", "TOKEN_CODEX_SESSION_B\n");
+    writeSessionContext("codex_parent-a", ".trellis/tasks/issue-106");
+    writeSessionContext("codex_parent-b", ".trellis/tasks/issue-107");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    const outputFor = (sessionId: string, env: NodeJS.ProcessEnv = {}) => {
+      const output = runPython(
+        hookPath,
+        JSON.stringify({
+          hook_event_name: "SubagentStart",
+          agent_type: "trellis-implement",
+          session_id: sessionId,
+          cwd: tmpDir,
+        }),
+        env,
+      );
+      return (
+        JSON.parse(output) as {
+          hookSpecificOutput: { additionalContext: string };
+        }
+      ).hookSpecificOutput.additionalContext;
+    };
+
+    const sessionA = outputFor("parent-a");
+    const sessionB = outputFor("parent-b");
+    const parentWins = outputFor("parent-a", {
+      TRELLIS_CONTEXT_ID: "codex_parent-b",
+    });
+
+    expect(sessionA).toContain("TOKEN_CODEX_SESSION_A");
+    expect(sessionA).not.toContain("TOKEN_CODEX_SESSION_B");
+    expect(sessionB).toContain("TOKEN_CODEX_SESSION_B");
+    expect(sessionB).not.toContain("TOKEN_CODEX_SESSION_A");
+    expect(parentWins).toContain("TOKEN_CODEX_SESSION_A");
+    expect(parentWins).not.toContain("TOKEN_CODEX_SESSION_B");
+  });
+
+  it("[codex-native-subagents] non-Trellis SubagentStart agents stay silent", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeSessionContext("codex_parent-a", ".trellis/tasks/issue-106");
+    const injectSubagentContextScript = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    const hookPath = path.join(
+      ".codex",
+      "hooks",
+      "inject-subagent-context.py",
+    );
+    writeProjectFile(
+      hookPath,
+      expectTemplateContent(
+        injectSubagentContextScript,
+        "codex inject-subagent-context hook",
+      ),
+    );
+
+    const output = runPython(
+      hookPath,
+      JSON.stringify({
+        hook_event_name: "SubagentStart",
+        agent_type: "general-purpose-reviewer",
+        session_id: "parent-a",
+        cwd: tmpDir,
+      }),
+    );
+
+    expect(output.trim()).toBe("");
+  });
+
   it("[session-current-task] Cursor hook uses conversation_id when transcript_path is null", () => {
     setupTaskRepo();
     writeLegacyCurrentTask(".trellis/tasks/issue-106");
@@ -3759,7 +4082,7 @@ print(json.dumps({
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
     expect(ctx).not.toContain("<sub-agent-notice>");
-    expect(ctx).toContain("<codex-mode>inline:");
+    expect(ctx).toContain("<codex-mode>auto:");
     expect(ctx.indexOf("</codex-mode>")).toBeLessThan(
       ctx.indexOf("<workflow-state>"),
     );
@@ -3968,6 +4291,7 @@ print(json.dumps({
   it("[issue-373] task.py create does NOT seed jsonl for Codex inline mode", () => {
     setupTaskRepo();
     fs.mkdirSync(path.join(tmpDir, ".codex"), { recursive: true });
+    writeConfigYaml("codex:\n  dispatch_mode: inline\n");
     const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
     execSync(
       `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "codex inline task" --slug codex-inline-task --assignee test-dev`,
@@ -4215,17 +4539,11 @@ print(len(entries))
     }
   });
 
-  it("[issue-241-followup] codex sub-agent toml files disable collab tools at protocol level", () => {
-    // 0.5.6 added prompt-layer guidance (`fork_turns="none"`) to AGENTS.md but
-    // it didn't reach Ca11back's reproduction in #241 — the sub-agent still
-    // inherited the parent transcript and called wait_agent on parent's
-    // spawn records. Structural fix: each Codex sub-agent role file disables
-    // multi_agent / multi_agent_v2 features so spawn_agent / wait_agent /
-    // list_agents / close_agent simply don't exist in the sub-agent's tool
-    // list. Codex agent role files support full ConfigToml override layers
-    // (codex-rs/core/src/config/agent_roles.rs:217-225) — `[features]` table
-    // included. No prompt-layer prose needed — if the tool doesn't exist, the
-    // model can't call it.
+  it("[issue-241-followup] Codex role profiles keep recursion guards without disabling native subagents", () => {
+    // Native Codex subagents are bounded by their documented depth limit and
+    // the profiles' direct-execution guidance. The legacy per-profile feature
+    // override blocked native Trellis subagent dispatch entirely, so it must
+    // not reappear.
     const templateRoot = path.join(
       path.dirname(fileURLToPath(import.meta.url)),
       "..",
@@ -4243,14 +4561,16 @@ print(len(entries))
         path.join(templateRoot, relativePath),
         "utf-8",
       );
-      expect(
-        content,
-        `${relativePath} should disable [features].multi_agent`,
-      ).toMatch(/\[features\][\s\S]*?multi_agent\s*=\s*false/);
-      expect(
-        content,
-        `${relativePath} should disable [features.multi_agent_v2]`,
-      ).toMatch(/\[features\.multi_agent_v2\][\s\S]*?enabled\s*=\s*false/);
+      const roleGuard = relativePath.endsWith("trellis-research.toml")
+        ? "research is role-isolated"
+        : "MUST NOT spawn another";
+      expect(content, `${relativePath} should retain a role guard`).toContain(
+        roleGuard,
+      );
+      expect(content).not.toMatch(/multi_agent\s*=\s*false/);
+      expect(content).not.toMatch(
+        /\[features\.multi_agent_v2\][\s\S]*?enabled\s*=\s*false/,
+      );
     }
   });
 
@@ -4491,17 +4811,13 @@ print(len(entries))
     expect(output).not.toContain("before-dev takes under a minute");
   });
 
-  it("[workflow-v2] step 2.1 for codex (sub-agent mode) describes self-loaded agent context, not hook injection", () => {
+  it("[workflow-v2] step 2.1 for Codex describes native hook injection with child-side fallback", () => {
     writeTrellisScripts();
     writeProjectFile(path.join(".trellis", ".developer"), "name=test\n");
     writeProjectFile(
       path.join(".trellis", "workflow.md"),
       templateWorkflowMd(),
     );
-    // Codex defaults to inline since 0.5.9; opt into sub-agent dispatch
-    // explicitly so the [codex-sub-agent] block surfaces.
-    writeConfigYaml("codex:\n  dispatch_mode: sub-agent\n");
-
     const contextScript = path.join(
       tmpDir,
       ".trellis",
@@ -4513,13 +4829,13 @@ print(len(entries))
       { cwd: tmpDir, encoding: "utf-8" },
     );
 
+    expect(output).toContain("The platform hook/plugin auto-handles");
     expect(output).toContain(
+      "For Codex, `SubagentStart` supplies native context injection",
+    );
+    expect(output).not.toContain(
       "The pull-based sub-agent definition auto-handles",
     );
-    expect(output).toContain(
-      "Resolves the active task with `task.py current --source`",
-    );
-    expect(output).not.toContain("The platform hook/plugin auto-handles");
     expect(output).not.toContain("Load the `trellis-before-dev` skill");
   });
 
@@ -4768,7 +5084,7 @@ print(len(entries))
     writeProjectFile(path.join(".trellis", "config.yaml"), content);
   }
 
-  it("[issue-codex-dispatch-mode] codex breadcrumb defaults to inline dispatch when config absent", () => {
+  it("[issue-codex-dispatch-mode] codex breadcrumb defaults to native auto dispatch when config absent", () => {
     setupTaskRepo();
     writeSessionContext("session_workflow-a", ".trellis/tasks/issue-106");
     const codexHookPath = writeCodexInjectHook();
@@ -4789,8 +5105,8 @@ print(len(entries))
       ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     const ctx = parsed.hookSpecificOutput.additionalContext;
-    expect(ctx).toContain("MAIN SESSION edits code");
-    expect(ctx).not.toContain("DISPATCH the trellis-implement");
+    expect(ctx).toContain("DISPATCH the trellis-implement");
+    expect(ctx).not.toContain("MAIN SESSION edits code");
   });
 
   it("[issue-codex-dispatch-mode] codex breadcrumb routes to plain status when codex.dispatch_mode=sub-agent", () => {
@@ -4951,8 +5267,9 @@ print(len(entries))
     ) as Record<string, string>;
     expect(result.codex_inline).toBe("in_progress-inline");
     expect(result.codex_subagent).toBe("in_progress");
-    // Default for codex (missing config) is inline since 0.5.9.
-    expect(result.codex_missing).toBe("in_progress-inline");
+    // Default for Codex is native auto dispatch; only explicit inline swaps
+    // to the main-session breadcrumb.
+    expect(result.codex_missing).toBe("in_progress");
     expect(result.claude_inline).toBe("in_progress");
   });
 
@@ -5017,6 +5334,7 @@ print(len(entries))
         "from common.workflow_phase import resolve_effective_platform",
         "result = {",
         "  'codex_default': resolve_effective_platform('codex', {}),",
+        "  'codex_explicit_auto': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'auto'}}),",
         "  'codex_explicit_subagent': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'sub-agent'}}),",
         "  'codex_inline': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'inline'}}),",
         "  'codex_invalid_mode': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'invalid'}}),",
@@ -5035,10 +5353,11 @@ print(len(entries))
         .filter((l) => l.startsWith("{"))
         .pop() ?? "{}",
     ) as Record<string, string>;
-    expect(result.codex_default).toBe("codex-inline");
+    expect(result.codex_default).toBe("codex-sub-agent");
+    expect(result.codex_explicit_auto).toBe("codex-sub-agent");
     expect(result.codex_explicit_subagent).toBe("codex-sub-agent");
     expect(result.codex_inline).toBe("codex-inline");
-    // Invalid mode falls back to default inline rather than passing through.
+    // Invalid mode falls back to explicit inline rather than dispatching.
     expect(result.codex_invalid_mode).toBe("codex-inline");
     // Non-codex platforms ignore the codex.dispatch_mode setting.
     expect(result.claude_passthrough).toBe("claude");
@@ -5061,7 +5380,7 @@ print(len(entries))
       "[workflow-state:in_progress]\nDISPATCH the trellis-implement.\n[/workflow-state:in_progress]\n[workflow-state:in_progress-inline]\nMAIN SESSION inline edit.\n[/workflow-state:in_progress-inline]\n",
     );
 
-    // Default (no config.yaml) → inline banner.
+    // Default (no config.yaml) → native auto-dispatch banner.
     const defaultRun = JSON.parse(
       runPython(
         codexHookPath,
@@ -5069,10 +5388,10 @@ print(len(entries))
       ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     expect(defaultRun.hookSpecificOutput.additionalContext).toContain(
-      "<codex-mode>inline: the main session implements/checks directly; do not dispatch implement/check sub-agents.</codex-mode>",
+      "<codex-mode>auto: implement/check work defaults to Trellis sub-agents; native Codex context injection is preferred and child-side loading is the fallback. The main session still coordinates, clarifies, updates specs, commits, and finishes.</codex-mode>",
     );
 
-    // Explicit sub-agent → sub-agent banner.
+    // Legacy sub-agent alias → the auto-dispatch banner.
     writeConfigYaml("codex:\n  dispatch_mode: sub-agent\n");
     const subAgentRun = JSON.parse(
       runPython(
@@ -5081,7 +5400,7 @@ print(len(entries))
       ),
     ) as { hookSpecificOutput: { additionalContext: string } };
     expect(subAgentRun.hookSpecificOutput.additionalContext).toContain(
-      "<codex-mode>sub-agent: implement/check work defaults to Trellis sub-agents; the main session still coordinates, clarifies, updates specs, commits, and finishes.</codex-mode>",
+      "<codex-mode>auto: implement/check work defaults to Trellis sub-agents; native Codex context injection is preferred and child-side loading is the fallback. The main session still coordinates, clarifies, updates specs, commits, and finishes.</codex-mode>",
     );
   });
 
@@ -5503,7 +5822,7 @@ describe("regression: cli_adapter platform support (beta.9, beta.13, beta.16)", 
     expect(taskStore as string).toContain('".grok"');
     expect(taskStore as string).toContain('_CODEX_CONFIG_DIR = ".codex"');
     expect(taskStore as string).toContain(
-      'get_codex_dispatch_mode(repo_root) == "sub-agent"',
+      'get_codex_dispatch_mode(repo_root) == "auto"',
     );
     expect(commonConfig).toContain("def get_codex_dispatch_mode");
     // Seed row is self-describing and has no `file` field (so consumers skip
@@ -6121,7 +6440,7 @@ describe("regression: cross-platform-thinking-guide dead code removed (0.3.1)", 
 // =============================================================================
 
 describe("regression: class-2 platforms use pull-based sub-agent context", () => {
-  // Class 2: gemini, qoder, codex, copilot — hooks can't reliably inject
+  // Class 2: gemini, qoder, copilot — hooks can't reliably inject
   // sub-agent prompts, so sub-agents Read jsonl/prd themselves.
   // implement/check get the pull-based prelude; research does not (it
   // searches the spec tree and has no task-level context dependency).
@@ -6143,15 +6462,6 @@ describe("regression: class-2 platforms use pull-based sub-agent context", () =>
         ".gemini/agents/trellis-check.md",
       ],
       nonPreludeAgents: [".gemini/agents/trellis-research.md"],
-    },
-    {
-      id: "codex" as const,
-      hooksDir: ".codex/hooks",
-      preludeAgents: [
-        ".codex/agents/trellis-implement.toml",
-        ".codex/agents/trellis-check.toml",
-      ],
-      nonPreludeAgents: [".codex/agents/trellis-research.toml"],
     },
     {
       id: "copilot" as const,
@@ -6225,12 +6535,11 @@ describe("regression: class-2 platforms use pull-based sub-agent context", () =>
       });
 
       it("hook config does not reference inject-subagent-context.py", () => {
-        const configPaths = [
-          ".qoder/settings.json",
-          ".gemini/settings.json",
-          ".codex/hooks.json",
-          ".github/copilot/hooks.json",
-          ".github/hooks/trellis.json",
+          const configPaths = [
+            ".qoder/settings.json",
+            ".gemini/settings.json",
+            ".github/copilot/hooks.json",
+            ".github/hooks/trellis.json",
         ];
         for (const p of configPaths) {
           const full = path.join(tmpDir, p);
@@ -6242,6 +6551,63 @@ describe("regression: class-2 platforms use pull-based sub-agent context", () =>
       });
     });
   }
+});
+
+// =============================================================================
+// Native Codex SubagentStart Context Delivery (0.6)
+// =============================================================================
+
+describe("regression: Codex uses native SubagentStart context delivery", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-codex-native-"));
+    setWriteMode("force");
+    await configurePlatform("codex", tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("installs the native context hook and preserves the main-session workflow hook", () => {
+    const hooks = fs.readdirSync(path.join(tmpDir, ".codex", "hooks"));
+    expect(hooks).toContain("inject-subagent-context.py");
+    expect(hooks).toContain("inject-workflow-state.py");
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".codex", "hooks.json"), "utf-8"),
+    ) as {
+      hooks: {
+        UserPromptSubmit?: unknown[];
+        SubagentStart?: {
+          matcher?: string;
+          hooks?: { command?: string }[];
+        }[];
+      };
+    };
+    const subagentStart = config.hooks.SubagentStart?.[0];
+
+    expect(config.hooks.UserPromptSubmit).toBeDefined();
+    expect(subagentStart?.matcher).toBe(
+      "trellis-implement|trellis-check|trellis-research",
+    );
+    expect(subagentStart?.hooks?.[0]?.command).toContain(
+      ".codex/hooks/inject-subagent-context.py",
+    );
+  });
+
+  it("uses marker-gated role profiles rather than the old unconditional pull prelude", () => {
+    for (const role of ["implement", "check", "research"] as const) {
+      const content = fs.readFileSync(
+        path.join(tmpDir, ".codex", "agents", `trellis-${role}.toml`),
+        "utf-8",
+      );
+      expect(content).toContain("<!-- trellis-hook-injected -->");
+      expect(content).toContain("Active task:");
+      expect(content).not.toContain("Required: Load Trellis Context First");
+    }
+  });
 });
 
 describe("regression: copilot agents use YAML tools frontmatter", () => {

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -6593,7 +6593,7 @@ describe("regression: Codex uses native SubagentStart context delivery", () => {
 
     expect(config.hooks.UserPromptSubmit).toBeDefined();
     expect(subagentStart?.matcher).toBe(
-      "trellis-implement|trellis-check|trellis-research",
+      "^(?:trellis-implement|trellis-check|trellis-research)$",
     );
     expect(subagentStart?.hooks?.[0]?.command).toContain(
       ".codex/hooks/inject-subagent-context.py",

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -5338,6 +5338,7 @@ print(len(entries))
         "  'codex_explicit_subagent': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'sub-agent'}}),",
         "  'codex_inline': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'inline'}}),",
         "  'codex_invalid_mode': resolve_effective_platform('codex', {'codex': {'dispatch_mode': 'invalid'}}),",
+        "  'codex_invalid_config': resolve_effective_platform('codex', {'codex': True}),",
         "  'claude_passthrough': resolve_effective_platform('claude', {'codex': {'dispatch_mode': 'inline'}}),",
         "}",
         "print(json.dumps(result))",
@@ -5359,6 +5360,8 @@ print(len(entries))
     expect(result.codex_inline).toBe("codex-inline");
     // Invalid mode falls back to explicit inline rather than dispatching.
     expect(result.codex_invalid_mode).toBe("codex-inline");
+    // A malformed codex section must match config.py's safe inline fallback.
+    expect(result.codex_invalid_config).toBe("codex-inline");
     // Non-codex platforms ignore the codex.dispatch_mode setting.
     expect(result.claude_passthrough).toBe("claude");
   });

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -6,6 +6,7 @@ import {
   getAllAgents,
   getAllCodexSkills,
   getConfigTemplate,
+  getHooksConfig,
 } from "../../src/templates/codex/index.js";
 import { resolveAllAsSkills } from "../../src/configurators/shared.js";
 import { AI_TOOLS } from "../../src/types/ai-tools.js";
@@ -57,6 +58,31 @@ describe("codex getAllAgents", () => {
       expect(agent.content).toContain("description = ");
       expect(agent.content).toContain("developer_instructions = ");
     }
+  });
+});
+
+describe("codex native sub-agent hooks", () => {
+  it("preserves main-session workflow injection and scopes SubagentStart to Trellis roles", () => {
+    const config = JSON.parse(getHooksConfig()) as {
+      hooks: Record<
+        string,
+        { matcher?: string; hooks: { command: string }[] }[]
+      >;
+    };
+
+    expect(config.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(config.hooks.UserPromptSubmit[0]?.hooks[0]?.command).toContain(
+      ".codex/hooks/inject-workflow-state.py",
+    );
+
+    expect(config.hooks.SubagentStart).toHaveLength(1);
+    const subagentStart = config.hooks.SubagentStart[0];
+    expect(subagentStart?.matcher).toBe(
+      "trellis-implement|trellis-check|trellis-research",
+    );
+    expect(subagentStart?.hooks[0]?.command).toContain(
+      ".codex/hooks/inject-subagent-context.py",
+    );
   });
 });
 
@@ -113,6 +139,42 @@ describe("codex sub-agent recursion guard (issue #234)", () => {
       expect(content).toMatch(/SessionStart|dispatch.*main session|breadcrumb/i);
     });
   }
+});
+
+describe("codex two-channel sub-agent context (native SubagentStart)", () => {
+  for (const name of [
+    "trellis-implement",
+    "trellis-check",
+    "trellis-research",
+  ] as const) {
+    it(`${name}.toml uses a marker-gated active-task fallback without legacy collaboration disables`, () => {
+      const tomlPath = path.join(
+        repoRoot,
+        "packages/cli/src/templates/codex/agents",
+        `${name}.toml`,
+      );
+      const content = fs.readFileSync(tomlPath, "utf-8");
+
+      expect(content).toContain("<!-- trellis-hook-injected -->");
+      expect(content).toContain("Active task: <path>");
+      expect(content).not.toContain("[features]");
+      expect(content).not.toContain("multi_agent = false");
+      expect(content).not.toContain("[features.multi_agent_v2]");
+    });
+  }
+
+  it("keeps research task resolution role-isolated from implement/check manifests", () => {
+    const researchPath = path.join(
+      repoRoot,
+      "packages/cli/src/templates/codex/agents/trellis-research.toml",
+    );
+    const content = fs.readFileSync(researchPath, "utf-8");
+
+    expect(content).toContain("Do not load `implement.jsonl` or `check.jsonl`");
+    expect(content).not.toContain(
+      "Run `python3 ./.trellis/scripts/task.py current --source`",
+    );
+  });
 });
 
 describe("codex session-start.py compact SessionStart context", () => {

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -78,8 +78,13 @@ describe("codex native sub-agent hooks", () => {
     expect(config.hooks.SubagentStart).toHaveLength(1);
     const subagentStart = config.hooks.SubagentStart[0];
     expect(subagentStart?.matcher).toBe(
-      "trellis-implement|trellis-check|trellis-research",
+      "^(?:trellis-implement|trellis-check|trellis-research)$",
     );
+    const matcher = new RegExp(subagentStart?.matcher ?? "");
+    expect(matcher.test("trellis-implement")).toBe(true);
+    expect(matcher.test("trellis-check")).toBe(true);
+    expect(matcher.test("trellis-research")).toBe(true);
+    expect(matcher.test("trellis-implement-extra")).toBe(false);
     expect(subagentStart?.hooks[0]?.command).toContain(
       ".codex/hooks/inject-subagent-context.py",
     );

--- a/packages/cli/test/templates/shared-hooks.test.ts
+++ b/packages/cli/test/templates/shared-hooks.test.ts
@@ -56,10 +56,10 @@ describe("shared-hooks capability table", () => {
     }
   });
 
-  it("inject-subagent-context.py is restricted to class-1 push-based platforms", () => {
-    // Class-2 (pull-based) platforms load context via agent-definition prelude,
-    // not a hook-mutated prompt.
-    const class2 = new Set(["codex", "copilot", "gemini", "qoder", "trae"]);
+  it("inject-subagent-context.py is restricted to platforms with native sub-agent context delivery", () => {
+    // Codex uses SubagentStart.additionalContext; these remaining platforms
+    // are class-2 and load their context from an agent-definition prelude.
+    const class2 = new Set(["copilot", "gemini", "qoder", "trae"]);
     for (const [platform, hooks] of Object.entries(
       SHARED_HOOKS_BY_PLATFORM,
     )) {
@@ -70,6 +70,10 @@ describe("shared-hooks capability table", () => {
           `${platform} is class-2 pull-based and must not ship inject-subagent-context.py`,
         ).toBe(false);
     }
+
+    expect(SHARED_HOOKS_BY_PLATFORM.codex).toContain(
+      "inject-subagent-context.py",
+    );
   });
 
   it("codex + copilot do not take the shared session-start.py (they bundle their own)", () => {

--- a/packages/cli/test/templates/trellis.test.ts
+++ b/packages/cli/test/templates/trellis.test.ts
@@ -85,11 +85,12 @@ describe("trellis template constants", () => {
   }
 
   function platformBlock(section: string, openingMarker: string): string {
+    const normalizedSection = section.replace(/\r\n/g, "\n");
     const escaped = openingMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const closingMarker = openingMarker.replace("[", "[/");
     const escapedClosing = closingMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const pattern = new RegExp(`${escaped}\\n([\\s\\S]*?)\\n${escapedClosing}`);
-    const match = pattern.exec(section);
+    const match = pattern.exec(normalizedSection);
     if (!match) {
       throw new Error(`workflow.md block ${openingMarker} must exist`);
     }
@@ -162,29 +163,28 @@ describe("trellis template constants", () => {
     }
   });
 
-  it("[issue-225] workflow.md in_progress breadcrumb has class-2 sub-agent dispatch protocol", () => {
+  it("[codex-native-subagents] workflow.md preserves the dispatch prompt for Codex native fallback", () => {
     // The in_progress breadcrumb instructs the main agent to prefix
-    // dispatch prompts with "Active task: <path>" on class-2 platforms.
-    // Without this line, codex/copilot/gemini/qoder sub-agents cannot
-    // find the active task (no PreToolUse hook to inject context).
+    // dispatch prompts with "Active task: <path>". Codex uses native
+    // SubagentStart context injection, but retains this child-side fallback
+    // whenever a project hook is unavailable or untrusted.
     const block = inProgressBreadcrumb();
     expect(block).toContain("Active task:");
-    expect(block.toLowerCase()).toContain("class-2");
-    expect(block).toMatch(/codex|copilot|gemini|qoder/);
+    expect(workflowMdTemplate).toContain("native Codex `SubagentStart`");
+    expect(workflowMdTemplate).toContain("child-side pull fallback");
   });
 
-  it("[issue-zcode-repeat] pull-based platforms use the pull-based implement block, not hook auto-handles", () => {
+  it("[codex-native-subagents] Codex uses the native hook implement block, while class-2 platforms stay pull-based", () => {
     const implement = stepSection("2.1");
     const hookAutoBlock = platformBlock(
       implement,
-      "[Claude Code, Cursor, OpenCode, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]",
+      "[Claude Code, Cursor, OpenCode, codex-sub-agent, CodeBuddy, Droid, Pi, ZCode, Oh My Pi]",
     );
     const pullBasedMarker =
-      "[codex-sub-agent, Gemini, Qoder, Copilot, Reasonix, Trae, Grok]";
+      "[Gemini, Qoder, Copilot, Reasonix, Trae, Grok]";
     const pullBasedBlock = platformBlock(implement, pullBasedMarker);
 
     const workflowLabelByPlatform: Partial<Record<AITool, string>> = {
-      codex: "codex-sub-agent",
       gemini: "Gemini",
       qoder: "Qoder",
       copilot: "Copilot",
@@ -194,8 +194,14 @@ describe("trellis template constants", () => {
     // Pi templates keep a pull-based fallback, but workflow 2.1 routes Pi
     // through the extension-backed context path.
     const extensionBackedPreludeFallbackPlatforms = new Set<AITool>(["pi"]);
+    // Codex retains a child-side prelude as a compatibility fallback, but
+    // its primary workflow route is the native SubagentStart hook block.
+    const nativePushPreludeFallbackPlatforms = new Set<AITool>(["codex"]);
     const generatedPullBasedLabels = PLATFORM_IDS.flatMap((id) => {
-      if (extensionBackedPreludeFallbackPlatforms.has(id)) {
+      if (
+        extensionBackedPreludeFallbackPlatforms.has(id) ||
+        nativePushPreludeFallbackPlatforms.has(id)
+      ) {
         return [];
       }
       const templates = collectPlatformTemplates(id);
@@ -230,6 +236,23 @@ describe("trellis template constants", () => {
     expect(pullBasedBlock).toContain(
       "The pull-based sub-agent definition auto-handles the context load requirement",
     );
+    expect(hookAutoBlock).toContain("codex-sub-agent");
+    expect(hookAutoBlock).toContain("SubagentStart");
+  });
+
+  it("[codex-native-subagents] template mode helpers default to auto and fail invalid values closed to inline", () => {
+    const scripts = getAllScripts();
+    const config = scripts.get("common/config.py") ?? "";
+    const workflowPhase = scripts.get("common/workflow_phase.py") ?? "";
+    const taskStore = scripts.get("common/task_store.py") ?? "";
+
+    expect(config).toContain('DEFAULT_CODEX_DISPATCH_MODE = "auto"');
+    expect(config).toContain('if mode == "sub-agent":');
+    expect(config).toContain('return "auto"');
+    expect(config).toContain("using inline");
+    expect(workflowPhase).toContain('mode = "auto"');
+    expect(workflowPhase).toContain('return "codex-sub-agent" if mode == "auto" else "codex-inline"');
+    expect(taskStore).toContain('get_codex_dispatch_mode(repo_root) == "auto"');
   });
 
   it("[issue-237] workflow.md in_progress breadcrumb self-exempts implement/check sub-agents", () => {


### PR DESCRIPTION
Closes #444 

## Summary

_Ready for review. Targeted automated validation and Windows manual tests are complete;
full-suite baseline failures are noted below._

This change enables Trellis to deliver role-specific task context to native
Codex subagents through `SubagentStart`. The default `auto` mode dispatches
subagents by default, while explicit `inline` execution remains available and
the child-side pull path remains a fallback.

## Motivation

Codex now exposes a role-filtered subagent-start hook, the parent session ID,
and developer-context injection. Trellis currently has only a pull-based
Codex integration, which can make a child agent load main-session workflow
routing and lose its precise task context.

## Implemented changes

- Register a `SubagentStart` hook for the three Trellis Codex roles.
- Resolve the active task from the parent Codex session without a sole-session
  fallback and inject each role's curated developer context.
- Keep unrelated agents untouched and fail open when no valid task exists.
- Use a marker-gated pull fallback when the native hook does not run; preserve
  explicit `inline` and retain `sub-agent` as a compatibility alias for `auto`.
- Align templates, config parsing, workflow routing, JSONL seeding, update
  collection, and regression coverage.

The generated marketplace native workflow is updated together with the built-in
workflow template. The resolver keeps its existing defaults for every caller;
only the native Codex hook opts out of environment-context and single-session
fallbacks.

## Validation

- Unit-test role matching, parent-session resolution, role-specific context,
  no-task behavior, and non-Trellis agent isolation.
- Regression-test dispatch modes, fallback behavior, recursion prevention, and
  `trellis init` / `trellis update` template consistency.
- Run the targeted CLI suite, then lint, typecheck, and the full test suite.

Completed validation:

- `pnpm lint`, `pnpm typecheck`, and the relevant Python syntax checks pass.
- 97 directly related Codex/template/shared-hook/platform assertions pass,
  including the three native Codex workflow-routing assertions. The native-hook
  black-box cases and migration assertions pass.
- The core package test suite passes (327 tests). A current Windows execution
  of the larger CLI regression file has 22 failures out of 346 tests, dominated
  by the missing `python3` executable and CRLF/LF-sensitive legacy assertions.
  It is therefore not claimed as a green full-suite result; Linux CI should
  provide the final full-suite verification.
- The built-in workflow template and marketplace native workflow were updated
  together. The marketplace update is committed at `c78392a`; the parent
  repository records that submodule pointer in `8438c0fd`.
- Windows manual testing previously passed for generated `SubagentStart` hooks,
  default native `auto` dispatch, strict two-session sentinel isolation,
  explicit `inline`, and the legacy `sub-agent` alias. The current `0.6.7`
  tarball passes a version smoke check; re-running the UI scenarios on that
  artifact remains recommended before treating manual testing as final-package
  evidence. The optional unapproved-hook fallback scenario was not manually
  repeated; it is covered by automated tests.

## Compatibility

- Explicit `inline` remains available.
- Native injection is additive; if it does not run, the child self-loads its
  context through the established pull path.
- The parent-session resolver remains backward compatible for all existing
  callers. Only the Codex `SubagentStart` path disables its sole-session
  fallback, preventing cross-session task-context injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex now defaults to automatic sub-agent dispatch for implement, check, and research.
  * Added native Codex `SubagentStart` context injection with strict resolver rules and safe child-side fallback when needed.
* **Bug Fixes**
  * Active-task/context resolution can optionally ignore environment-derived identity to prevent cross-session/window contamination.
  * Improved handling of missing, stale, or malformed parent task context for Codex sub-agent startup.
* **Documentation**
  * Updated guides for `codex.dispatch_mode` (`auto` default, `inline` opt-out, `sub-agent` alias) and the new context delivery protocol.
  * Refreshed workflow guidance and readiness gates for sub-agent execution.
* **Tests**
  * Expanded Codex native SubagentStart regression coverage and updated template/config expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->