### PR TITLE
fix: quick-fix batch for six triaged issues

### DIFF
--- a/.trellis/scripts/common/git.py
+++ b/.trellis/scripts/common/git.py
@@ -29,3 +29,39 @@ def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
         return result.returncode, result.stdout, result.stderr
     except Exception as e:
         return 1, "", str(e)
+
+
+def resolve_default_branch(repo_root: Path) -> str | None:
+    """Resolve the repository's default branch (origin/HEAD target).
+
+    Tries the local `refs/remotes/origin/HEAD` symbolic ref first (no
+    network access), then falls back to `git remote show origin` (which
+    may hit the network but also repairs a missing/stale symbolic-ref).
+    Returns None when neither resolves, so callers can fall back to their
+    own pre-existing behavior.
+    """
+    rc, out, _ = run_git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd=repo_root)
+    if rc == 0 and out.strip():
+        return out.strip().rsplit("/", 1)[-1]
+
+    rc, out, _ = run_git(["remote", "show", "origin"], cwd=repo_root)
+    if rc == 0:
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("HEAD branch:"):
+                branch = line.split(":", 1)[1].strip()
+                if branch and branch != "(unknown)":
+                    return branch
+
+    return None
+
+
+def branch_exists_locally(branch: str, repo_root: Path) -> bool:
+    """Check whether a local branch ref exists in the repository."""
+    if not branch:
+        return False
+    rc, _, _ = run_git(
+        ["rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=repo_root,
+    )
+    return rc == 0

--- a/.trellis/scripts/common/task_context.py
+++ b/.trellis/scripts/common/task_context.py
@@ -21,8 +21,10 @@ import argparse
 import json
 from pathlib import Path
 
+from .git import branch_exists_locally
+from .io import read_json
 from .log import Colors, colored
-from .paths import get_repo_root
+from .paths import FILE_TASK_JSON, get_repo_root
 from .task_utils import resolve_task_dir
 
 
@@ -96,6 +98,22 @@ def cmd_validate(args: argparse.Namespace) -> int:
     print(colored("=== Validating Context Files ===", Colors.BLUE))
     print(f"Target dir: {target_dir}")
     print()
+
+    # Warn (don't fail validation) when the recorded branch is stale — it
+    # was likely already merged and deleted (#399 item 2).
+    task_json_path = target_dir / FILE_TASK_JSON
+    if task_json_path.is_file():
+        task_data = read_json(task_json_path)
+        stored_branch = task_data.get("branch") if task_data else None
+        if stored_branch and not branch_exists_locally(stored_branch, repo_root):
+            print(
+                colored(
+                    f"Warning: recorded branch '{stored_branch}' no longer exists locally "
+                    "(likely merged and deleted).",
+                    Colors.YELLOW,
+                )
+            )
+            print()
 
     total_errors = 0
     for jsonl_name in ["implement.jsonl", "check.jsonl"]:

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -30,7 +30,7 @@ from .config import (
     resolve_package,
     validate_package,
 )
-from .git import run_git
+from .git import branch_exists_locally, resolve_default_branch, run_git
 from .io import read_json, write_json
 from .log import Colors, colored
 from .paths import (
@@ -295,9 +295,14 @@ def cmd_create(args: argparse.Namespace) -> int:
 
     today = datetime.now().strftime("%Y-%m-%d")
 
-    # Record current branch as base_branch (PR target)
+    # Record the PR target branch. Prefer the repo's actual default branch
+    # (origin/HEAD) so creating a task from a feature branch doesn't
+    # mis-stamp that feature branch as the PR target (#399 item 1). Falls
+    # back to the checked-out branch when the default can't be resolved
+    # (no remote configured, offline, etc.) — the pre-existing behavior.
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
+    base_branch = resolve_default_branch(repo_root) or current_branch
 
     description = (args.description or "").strip()
     if not description.strip():
@@ -324,7 +329,7 @@ def cmd_create(args: argparse.Namespace) -> int:
         "createdAt": today,
         "completedAt": None,
         "branch": None,
-        "base_branch": current_branch,
+        "base_branch": base_branch,
         "worktree_path": None,
         "commit": None,
         "pr_url": None,
@@ -506,6 +511,19 @@ def cmd_archive(args: argparse.Namespace) -> int:
     if task_json_path.is_file():
         data = read_json(task_json_path)
         if data:
+            # Warn (don't block) when the recorded branch is stale — it was
+            # likely already merged and deleted (#399 item 2).
+            stored_branch = data.get("branch")
+            if stored_branch and not branch_exists_locally(stored_branch, repo_root):
+                print(
+                    colored(
+                        f"Warning: recorded branch '{stored_branch}' no longer exists locally "
+                        "(likely merged and deleted).",
+                        Colors.YELLOW,
+                    ),
+                    file=sys.stderr,
+                )
+
             data["status"] = "completed"
             data["completedAt"] = today
             write_json(task_json_path, data)

--- a/.trellis/scripts/task.py
+++ b/.trellis/scripts/task.py
@@ -9,7 +9,7 @@ Usage:
     python3 task.py validate <dir>              # Validate jsonl files
     python3 task.py list-context <dir>          # List jsonl entries
     python3 task.py start <dir>                 # Set active task
-    python3 task.py current [--source]          # Show active task
+    python3 task.py current [--source] [--json] # Show active task
     python3 task.py finish                      # Clear active task
     python3 task.py set-branch <dir> <branch>   # Set git branch
     python3 task.py set-base-branch <dir> <branch>  # Set PR target branch
@@ -24,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 
 from common.log import Colors, colored
@@ -166,6 +167,27 @@ def cmd_current(args: argparse.Namespace) -> int:
     repo_root = get_repo_root()
     active = resolve_active_task(repo_root)
 
+    if getattr(args, "json", False):
+        task_obj = None
+        if active.task_path:
+            data = read_json(repo_root / active.task_path / FILE_TASK_JSON) or {}
+            task_obj = {
+                "dir": active.task_path,
+                "id": data.get("id") or data.get("name"),
+                "title": data.get("title"),
+                "status": data.get("status"),
+                "parent": data.get("parent"),
+                "children": data.get("children", []),
+                "branch": data.get("branch"),
+                "base_branch": data.get("base_branch"),
+            }
+        print(json.dumps({
+            "current_task": task_obj,
+            "source": active.source,
+            "stale": active.stale,
+        }, ensure_ascii=False))
+        return 0 if active.task_path else 1
+
     if args.source:
         print(f"Current task: {active.task_path or '(none)'}")
         print(f"Source: {active.source}")
@@ -184,6 +206,24 @@ def cmd_current(args: argparse.Namespace) -> int:
 # Command: list
 # =============================================================================
 
+def _display_status(t, all_statuses: dict) -> str:
+    """Return the status label to show for a task in `list` output.
+
+    A parent task's stored status stays "planning" until someone runs
+    `task.py start` on the parent directly, even while its children are
+    actively being worked — a misleading label for anyone scanning the
+    list (#399 item 3). Show "active" instead when at least one child is
+    past planning; the stored status.json value is left untouched.
+    """
+    if t.status == "planning" and t.children:
+        child_in_flight = any(
+            all_statuses.get(c) not in (None, "planning") for c in t.children
+        )
+        if child_in_flight:
+            return "active"
+    return t.status
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     """List active tasks."""
     repo_root = get_repo_root()
@@ -192,6 +232,38 @@ def cmd_list(args: argparse.Namespace) -> int:
     developer = get_developer(repo_root)
     filter_mine = args.mine
     filter_status = args.status
+    as_json = getattr(args, "json", False)
+
+    # Single pass: collect all tasks via shared iterator
+    all_tasks = {t.dir_name: t for t in iter_active_tasks(tasks_dir)}
+    all_statuses = {name: t.status for name, t in all_tasks.items()}
+
+    if as_json:
+        if filter_mine and not developer:
+            print(json.dumps({"error": "No developer set"}), file=sys.stderr)
+            return 1
+
+        items = []
+        for dir_name in sorted(all_tasks.keys()):
+            t = all_tasks[dir_name]
+            if filter_mine and (t.assignee or "-") != developer:
+                continue
+            if filter_status and t.status != filter_status:
+                continue
+            items.append({
+                "dir": f"{DIR_WORKFLOW}/{DIR_TASKS}/{dir_name}",
+                "id": t.raw.get("id") or dir_name,
+                "title": t.title,
+                "status": t.status,
+                "display_status": _display_status(t, all_statuses),
+                "priority": t.priority,
+                "assignee": t.assignee or None,
+                "parent": t.parent,
+                "children": list(t.children),
+                "package": t.package,
+            })
+        print(json.dumps({"tasks": items}, ensure_ascii=False))
+        return 0
 
     if filter_mine:
         if not developer:
@@ -201,10 +273,6 @@ def cmd_list(args: argparse.Namespace) -> int:
     else:
         print(colored("All active tasks:", Colors.BLUE))
     print()
-
-    # Single pass: collect all tasks via shared iterator
-    all_tasks = {t.dir_name: t for t in iter_active_tasks(tasks_dir)}
-    all_statuses = {name: t.status for name, t in all_tasks.items()}
 
     # Display tasks hierarchically
     count = 0
@@ -228,6 +296,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 
         # Children progress
         progress = children_progress(t.children, all_statuses)
+        status_label = _display_status(t, all_statuses)
 
         # Package tag
         pkg_tag = f" @{t.package}" if t.package else ""
@@ -235,9 +304,9 @@ def cmd_list(args: argparse.Namespace) -> int:
         prefix = "  " * indent + "  - "
 
         if filter_mine:
-            print(f"{prefix}{dir_name}/ ({t.status}){pkg_tag}{progress}{marker}")
+            print(f"{prefix}{dir_name}/ ({status_label}){pkg_tag}{progress}{marker}")
         else:
-            print(f"{prefix}{dir_name}/ ({t.status}){pkg_tag}{progress} [{colored(t.assignee or '-', Colors.CYAN)}]{marker}")
+            print(f"{prefix}{dir_name}/ ({status_label}){pkg_tag}{progress} [{colored(t.assignee or '-', Colors.CYAN)}]{marker}")
         count += 1
 
         # Print children indented
@@ -320,7 +389,7 @@ Usage:
   python3 task.py archive <task-dir>                 Archive completed task
   python3 task.py add-subtask <parent> <child>       Link child task to parent
   python3 task.py remove-subtask <parent> <child>    Unlink child from parent
-  python3 task.py list [--mine] [--status <status>]  List tasks
+  python3 task.py list [--mine] [--status <status>] [--json]  List tasks
   python3 task.py list-archive [YYYY-MM]             List archived tasks
 
 Monorepo options:
@@ -329,6 +398,7 @@ Monorepo options:
 List options:
   --mine, -m           Show only tasks assigned to current developer
   --status, -s <s>     Filter by status (planning, in_progress, review, completed)
+  --json               Output machine-readable JSON (also available on `current`)
 
 Examples:
   python3 task.py create "Add login feature" --slug add-login
@@ -428,6 +498,8 @@ def main() -> int:
     p_current = subparsers.add_parser("current", help="Show active task")
     p_current.add_argument("--source", action="store_true",
                            help="Show active task source")
+    p_current.add_argument("--json", action="store_true",
+                           help="Output machine-readable JSON")
 
     # finish
     subparsers.add_parser("finish", help="Clear active task")
@@ -456,6 +528,7 @@ def main() -> int:
     p_list = subparsers.add_parser("list", help="List tasks")
     p_list.add_argument("--mine", "-m", action="store_true", help="My tasks only")
     p_list.add_argument("--status", "-s", help="Filter by status")
+    p_list.add_argument("--json", action="store_true", help="Output machine-readable JSON")
 
     # add-subtask
     p_addsub = subparsers.add_parser("add-subtask", help="Link child task to parent")

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -15,6 +15,8 @@ import { registerChannelCommand } from "../commands/channel/index.js";
 import { DIR_NAMES } from "../constants/paths.js";
 import { PACKAGE_NAME, VERSION } from "../constants/version.js";
 import { compareVersions } from "../utils/compare-versions.js";
+import { getConfiguredPlatforms } from "../configurators/index.js";
+import { AI_TOOLS } from "../types/ai-tools.js";
 
 // Re-export for backwards compatibility (consumers should prefer constants/version.js)
 export { VERSION, PACKAGE_NAME };
@@ -288,6 +290,47 @@ program
         console.error(chalk.red("Error:"), error.message);
         process.exit(1);
       }
+      console.error(
+        chalk.red("Error:"),
+        error instanceof Error ? error.message : error,
+      );
+      if (process.env.DEBUG || process.env.TRELLIS_DEBUG) {
+        console.error(error instanceof Error ? error.stack : error);
+      }
+      process.exit(1);
+    }
+  });
+
+program
+  .command("platforms")
+  .description(
+    "Show which AI platforms are configured (active) in the current project",
+  )
+  .option("--json", "Output machine-readable JSON")
+  .action((options: Record<string, unknown>) => {
+    try {
+      const configured = getConfiguredPlatforms(cwd);
+      const platforms = [...configured].map((id) => ({
+        id,
+        displayName: AI_TOOLS[id].name,
+        configDir: AI_TOOLS[id].configDir,
+      }));
+
+      if (options.json) {
+        console.log(JSON.stringify({ platforms }, null, 2));
+        return;
+      }
+
+      if (platforms.length === 0) {
+        console.log(chalk.gray("No platforms configured in this project."));
+        return;
+      }
+
+      console.log(chalk.bold("Configured platforms:"));
+      for (const p of platforms) {
+        console.log(`  ${p.displayName} (${p.id}) — ${p.configDir}`);
+      }
+    } catch (error) {
       console.error(
         chalk.red("Error:"),
         error instanceof Error ? error.message : error,

--- a/packages/cli/src/commands/channel/adapters/codex.ts
+++ b/packages/cli/src/commands/channel/adapters/codex.ts
@@ -608,15 +608,44 @@ export function buildCodexArgs(opts: { model?: string }): string[] {
   return args;
 }
 
+/** Codex's documented `sandbox` modes (see `codex app-server` thread/start). */
+export type CodexSandboxMode =
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+export const CODEX_SANDBOX_MODES: ReadonlySet<CodexSandboxMode> = new Set([
+  "read-only",
+  "workspace-write",
+  "danger-full-access",
+]);
+
+/** Validate a `--sandbox` value. Returns `undefined` when unset (caller
+ *  falls back to the `workspace-write` default). */
+export function parseCodexSandboxMode(
+  v: string | undefined,
+): CodexSandboxMode | undefined {
+  if (v === undefined) return undefined;
+  if (!CODEX_SANDBOX_MODES.has(v as CodexSandboxMode)) {
+    throw new Error(
+      `Invalid --sandbox '${v}'. Must be one of: ${[...CODEX_SANDBOX_MODES].join(", ")}`,
+    );
+  }
+  return v as CodexSandboxMode;
+}
+
 export function buildCodexThreadStartParams(
   cwd: string,
   systemPrompt?: string,
+  sandbox?: CodexSandboxMode,
 ): Record<string, unknown> {
   const params: Record<string, unknown> = {
     cwd,
     // MVP: aggressive permissive defaults to avoid getting stuck mid-turn.
     approvalPolicy: "never",
-    sandbox: "workspace-write",
+    // Default stays workspace-write; callers (channel spawn --sandbox) may
+    // override to match the user's main-session Codex permissions (#413).
+    sandbox: sandbox ?? "workspace-write",
     // Disable codex native multi-agent so spawned worker can't recurse into
     // its own sub-agents (would conflict with channel's collaboration layer
     // and reproduce issue #234/#237 recursion).

--- a/packages/cli/src/commands/channel/adapters/index.ts
+++ b/packages/cli/src/commands/channel/adapters/index.ts
@@ -34,6 +34,7 @@ import {
   encodeCodexUserMessage,
   parseCodexLine,
   type CodexCtx,
+  type CodexSandboxMode,
 } from "./codex.js";
 import type { ParseResult } from "./types.js";
 
@@ -52,6 +53,8 @@ export interface SupervisorView {
   model?: string;
   systemPrompt: string;
   cwd: string;
+  /** Codex-only: overrides the `thread/start` sandbox mode (default `workspace-write`). */
+  sandbox?: CodexSandboxMode;
 }
 
 export interface WorkerAdapter<Ctx = AdapterCtx> {
@@ -144,7 +147,7 @@ const codexAdapter: WorkerAdapter<CodexCtx> = {
     const ts = encodeCodexRequest(
       ctx,
       "thread/start",
-      buildCodexThreadStartParams(view.cwd, view.systemPrompt),
+      buildCodexThreadStartParams(view.cwd, view.systemPrompt, view.sandbox),
       "thread/start",
     );
     child.stdin.write(ts.line);

--- a/packages/cli/src/commands/channel/index.ts
+++ b/packages/cli/src/commands/channel/index.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { InvalidArgumentError, type Command } from "commander";
 
 import { isProvider, listProviders, type Provider } from "./adapters/index.js";
+import { parseCodexSandboxMode } from "./adapters/codex.js";
 import {
   channelContextAdd,
   channelContextDelete,
@@ -293,6 +294,10 @@ export function registerChannelCommand(program: Command): void {
     .option("--model <id>", "model override")
     .option("--resume <id>", "resume an existing session/thread id")
     .option(
+      "--sandbox <mode>",
+      "codex-only: worker sandbox mode: read-only | workspace-write | danger-full-access (default workspace-write)",
+    )
+    .option(
       "--timeout <duration>",
       "auto-kill worker after this duration (e.g. 30m, 1h, 7200s)",
     )
@@ -337,6 +342,7 @@ export function registerChannelCommand(program: Command): void {
         cwd?: string;
         model?: string;
         resume?: string;
+        sandbox?: string;
         timeout?: string;
         warnBefore?: string;
         file?: string[];
@@ -355,6 +361,7 @@ export function registerChannelCommand(program: Command): void {
         process.exit(1);
       }
       try {
+        parseCodexSandboxMode(opts.sandbox);
         await channelSpawn(name, {
           agent: opts.agent,
           provider: opts.provider as Provider | undefined,
@@ -362,6 +369,7 @@ export function registerChannelCommand(program: Command): void {
           cwd: opts.cwd,
           model: opts.model,
           resume: opts.resume,
+          sandbox: opts.sandbox,
           timeoutMs: parseDuration(opts.timeout),
           warnBeforeMs: parseDuration(opts.warnBefore),
           files: opts.file,

--- a/packages/cli/src/commands/channel/spawn.ts
+++ b/packages/cli/src/commands/channel/spawn.ts
@@ -31,6 +31,8 @@ export interface SpawnOptions {
   cwd?: string;
   model?: string;
   resume?: string;
+  /** Codex-only: overrides the `thread/start` sandbox mode (default `workspace-write`). */
+  sandbox?: string;
   /** Auto-kill the worker after this many milliseconds (anti-zombie). */
   timeoutMs?: number;
   /** Emit supervisor_warning this many milliseconds before timeout. */
@@ -260,6 +262,7 @@ async function spawnLocked(
       systemPrompt: resolved.systemPrompt,
       model: resolved.model,
       resume: opts.resume,
+      sandbox: opts.sandbox,
       timeoutMs: opts.timeoutMs,
       warnBeforeMs: opts.warnBeforeMs,
       idleTimeoutMs,

--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -22,6 +22,7 @@ import {
   type InboxPolicy,
 } from "@mindfoldhq/trellis-core/channel";
 
+import type { CodexSandboxMode } from "./adapters/codex.js";
 import { getAdapter, type Provider } from "./adapters/index.js";
 import { appendEvent } from "./store/events.js";
 import { workerFile } from "./store/paths.js";
@@ -46,6 +47,8 @@ export interface SupervisorConfig {
   model?: string;
   /** Resume an existing session/thread if id is provided. */
   resume?: string;
+  /** Codex-only: overrides the `thread/start` sandbox mode (default `workspace-write`). */
+  sandbox?: string;
   /** Auto-kill worker after this many ms (anti-zombie). */
   timeoutMs?: number;
   /** Emit supervisor_warning this many ms before timeout. `<=0` disables it. */
@@ -155,6 +158,7 @@ export async function runSupervisor(
     model: config.model,
     systemPrompt: config.systemPrompt,
     cwd: config.cwd,
+    sandbox: config.sandbox as CodexSandboxMode | undefined,
   };
   const args = adapter.buildArgs(view);
 

--- a/packages/cli/src/configurators/pi.ts
+++ b/packages/cli/src/configurators/pi.ts
@@ -8,7 +8,7 @@ import {
   resolveCommands,
   resolveBundledSkills,
   resolvePlaceholders,
-  resolveSkills,
+  resolveSkillsNeutral,
   writeAgents,
   writeSkills,
 } from "./shared.js";
@@ -40,13 +40,13 @@ export function collectPiTemplates(): Map<string, string> {
     files.set(`.pi/prompts/trellis-${command.name}.md`, command.content);
   }
 
-  // Skills written under `.pi/skills/` (Pi-owned skill root). Pi can also
-  // discover `.agents/skills/` shared with Codex/Gemini; switching is
-  // intentionally deferred to a follow-up because Pi has its own skill
-  // discovery semantics that aren't covered by this task.
+  // Shared skills go to `.agents/skills/` (Pi discovers this cross-platform
+  // workspace alias natively). Neutral resolver keeps content byte-identical
+  // to Codex's/Gemini's writes for the same skill names, avoiding the
+  // duplicate/conflicting-skill installs reported in #447.
   for (const [filePath, content] of collectSkillTemplates(
-    ".pi/skills",
-    resolveSkills(ctx),
+    ".agents/skills",
+    resolveSkillsNeutral(ctx),
     resolveBundledSkills(ctx),
   )) {
     files.set(filePath, content);
@@ -80,11 +80,11 @@ export async function configurePi(cwd: string): Promise<void> {
     );
   }
 
-  // See collectPiTemplates(): Pi keeps a private `.pi/skills/` root for now.
-  // Cross-platform `.agents/skills/` adoption is a separate decision.
+  // See collectPiTemplates(): shared skills now live in `.agents/skills/`,
+  // deduped with Codex/Gemini (#447).
   await writeSkills(
-    path.join(configRoot, "skills"),
-    resolveSkills(ctx),
+    path.join(cwd, ".agents", "skills"),
+    resolveSkillsNeutral(ctx),
     resolveBundledSkills(ctx),
   );
   await writeAgents(

--- a/packages/cli/src/migrations/manifests/0.6.8.json
+++ b/packages/cli/src/migrations/manifests/0.6.8.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.6.8",
+  "description": "Pi Agent now shares the `.agents/skills/` skill root with Codex/Gemini CLI instead of keeping a private `.pi/skills/` copy, fixing duplicate/conflicting skill installs when a project has both platforms enabled.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "migrations": [
+    {
+      "type": "rename-dir",
+      "from": ".pi/skills",
+      "to": ".agents/skills",
+      "description": "Pi Agent: move installed skills from the private `.pi/skills/` root to the shared `.agents/skills/` root also used by Codex and Gemini CLI.",
+      "reason": "Pi already discovers `.agents/skills/` natively, so keeping a separate `.pi/skills/` copy of the same Trellis skills caused Pi to see the same skill twice (once from each root) when Codex or Gemini was also installed (#447)."
+    }
+  ]
+}

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-skills-or-commands.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/customize-local/change-skills-or-commands.md
@@ -87,7 +87,7 @@ If a command only repeats workflow rules, prefer making it reference/read `.trel
 | CodeBuddy | `.codebuddy/skills/`, `.codebuddy/commands/` |
 | GitHub Copilot | `.github/skills/`, `.github/prompts/` |
 | Factory Droid | `.factory/skills/`, `.factory/commands/` |
-| Pi Agent | `.pi/skills/` |
+| Pi Agent | `.agents/skills/` |
 | Reasonix | `.reasonix/skills/` (no separate commands dir; slash commands built into the platform) |
 | ZCode | `.zcode/skills/`, `.zcode/commands/` |
 | Kilo / Antigravity / Devin | workflows + skills |

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/platform-map.md
@@ -19,7 +19,7 @@ This page lists common Trellis file locations in a user project by platform. Whe
 | CodeBuddy | `--codebuddy` | `.codebuddy/` | `.codebuddy/skills/` | `.codebuddy/agents/` | `.codebuddy/hooks/` + `.codebuddy/settings.json` |
 | GitHub Copilot | `--copilot` | `.github/` | `.github/skills/` | `.github/agents/` | `.github/copilot/hooks/` + prompts |
 | Factory Droid | `--droid` | `.factory/` | `.factory/skills/` | `.factory/droids/` | `.factory/hooks/` + settings |
-| Pi Agent | `--pi` | `.pi/` | `.pi/skills/` | `.pi/agents/` | `.pi/extensions/trellis/` (native `trellis_subagent` tool) + `.pi/settings.json` |
+| Pi Agent | `--pi` | `.pi/` | `.agents/skills/` | `.pi/agents/` | `.pi/extensions/trellis/` (native `trellis_subagent` tool) + `.pi/settings.json` |
 | Trae IDE | `--trae` | `.trae/` | `.trae/skills/` | `.trae/agents/` | `.trae/hooks/` + `.trae/hooks.json` |
 | Reasonix | `--reasonix` | `.reasonix/` | `.reasonix/skills/` | None — sub-agents are skills with `runAs: subagent` frontmatter | None |
 | ZCode | `--zcode` | `.zcode/` | `.zcode/skills/` | `.zcode/agents/` | `.zcode/hooks/` + `.zcode/config.json` (SessionStart + UserPromptSubmit + PreToolUse Agent/Task); sub-agents use hook-injected context |

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/skills-and-commands.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/skills-and-commands.md
@@ -30,7 +30,7 @@ Trellis workflow skills usually share one semantic set: brainstorm, before-dev, 
 | CodeBuddy | `.codebuddy/skills/`, `.codebuddy/commands/` |
 | GitHub Copilot | `.github/skills/`, `.github/prompts/` |
 | Factory Droid | `.factory/skills/`, `.factory/commands/` |
-| Pi Agent | `.pi/skills/` |
+| Pi Agent | `.agents/skills/` |
 | Reasonix | `.reasonix/skills/` |
 | ZCode | `.zcode/skills/`, `.zcode/commands/` |
 

--- a/packages/cli/src/templates/pi/settings.json
+++ b/packages/cli/src/templates/pi/settings.json
@@ -3,9 +3,6 @@
   "extensions": [
     "./extensions/trellis/index.ts"
   ],
-  "skills": [
-    "./skills"
-  ],
   "prompts": [
     "./prompts"
   ]

--- a/packages/cli/src/templates/trellis/scripts/common/git.py
+++ b/packages/cli/src/templates/trellis/scripts/common/git.py
@@ -29,3 +29,39 @@ def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
         return result.returncode, result.stdout, result.stderr
     except Exception as e:
         return 1, "", str(e)
+
+
+def resolve_default_branch(repo_root: Path) -> str | None:
+    """Resolve the repository's default branch (origin/HEAD target).
+
+    Tries the local `refs/remotes/origin/HEAD` symbolic ref first (no
+    network access), then falls back to `git remote show origin` (which
+    may hit the network but also repairs a missing/stale symbolic-ref).
+    Returns None when neither resolves, so callers can fall back to their
+    own pre-existing behavior.
+    """
+    rc, out, _ = run_git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd=repo_root)
+    if rc == 0 and out.strip():
+        return out.strip().rsplit("/", 1)[-1]
+
+    rc, out, _ = run_git(["remote", "show", "origin"], cwd=repo_root)
+    if rc == 0:
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("HEAD branch:"):
+                branch = line.split(":", 1)[1].strip()
+                if branch and branch != "(unknown)":
+                    return branch
+
+    return None
+
+
+def branch_exists_locally(branch: str, repo_root: Path) -> bool:
+    """Check whether a local branch ref exists in the repository."""
+    if not branch:
+        return False
+    rc, _, _ = run_git(
+        ["rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=repo_root,
+    )
+    return rc == 0

--- a/packages/cli/src/templates/trellis/scripts/common/task_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_context.py
@@ -21,8 +21,10 @@ import argparse
 import json
 from pathlib import Path
 
+from .git import branch_exists_locally
+from .io import read_json
 from .log import Colors, colored
-from .paths import get_repo_root
+from .paths import FILE_TASK_JSON, get_repo_root
 from .task_utils import resolve_task_dir
 
 
@@ -96,6 +98,22 @@ def cmd_validate(args: argparse.Namespace) -> int:
     print(colored("=== Validating Context Files ===", Colors.BLUE))
     print(f"Target dir: {target_dir}")
     print()
+
+    # Warn (don't fail validation) when the recorded branch is stale — it
+    # was likely already merged and deleted (#399 item 2).
+    task_json_path = target_dir / FILE_TASK_JSON
+    if task_json_path.is_file():
+        task_data = read_json(task_json_path)
+        stored_branch = task_data.get("branch") if task_data else None
+        if stored_branch and not branch_exists_locally(stored_branch, repo_root):
+            print(
+                colored(
+                    f"Warning: recorded branch '{stored_branch}' no longer exists locally "
+                    "(likely merged and deleted).",
+                    Colors.YELLOW,
+                )
+            )
+            print()
 
     total_errors = 0
     for jsonl_name in ["implement.jsonl", "check.jsonl"]:

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -30,7 +30,7 @@ from .config import (
     resolve_package,
     validate_package,
 )
-from .git import run_git
+from .git import branch_exists_locally, resolve_default_branch, run_git
 from .io import read_json, write_json
 from .log import Colors, colored
 from .paths import (
@@ -295,9 +295,14 @@ def cmd_create(args: argparse.Namespace) -> int:
 
     today = datetime.now().strftime("%Y-%m-%d")
 
-    # Record current branch as base_branch (PR target)
+    # Record the PR target branch. Prefer the repo's actual default branch
+    # (origin/HEAD) so creating a task from a feature branch doesn't
+    # mis-stamp that feature branch as the PR target (#399 item 1). Falls
+    # back to the checked-out branch when the default can't be resolved
+    # (no remote configured, offline, etc.) — the pre-existing behavior.
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
+    base_branch = resolve_default_branch(repo_root) or current_branch
 
     description = (args.description or "").strip()
     if not description.strip():
@@ -324,7 +329,7 @@ def cmd_create(args: argparse.Namespace) -> int:
         "createdAt": today,
         "completedAt": None,
         "branch": None,
-        "base_branch": current_branch,
+        "base_branch": base_branch,
         "worktree_path": None,
         "commit": None,
         "pr_url": None,
@@ -506,6 +511,19 @@ def cmd_archive(args: argparse.Namespace) -> int:
     if task_json_path.is_file():
         data = read_json(task_json_path)
         if data:
+            # Warn (don't block) when the recorded branch is stale — it was
+            # likely already merged and deleted (#399 item 2).
+            stored_branch = data.get("branch")
+            if stored_branch and not branch_exists_locally(stored_branch, repo_root):
+                print(
+                    colored(
+                        f"Warning: recorded branch '{stored_branch}' no longer exists locally "
+                        "(likely merged and deleted).",
+                        Colors.YELLOW,
+                    ),
+                    file=sys.stderr,
+                )
+
             data["status"] = "completed"
             data["completedAt"] = today
             write_json(task_json_path, data)

--- a/packages/cli/src/templates/trellis/scripts/task.py
+++ b/packages/cli/src/templates/trellis/scripts/task.py
@@ -9,7 +9,7 @@ Usage:
     python3 task.py validate <dir>              # Validate jsonl files
     python3 task.py list-context <dir>          # List jsonl entries
     python3 task.py start <dir>                 # Set active task
-    python3 task.py current [--source]          # Show active task
+    python3 task.py current [--source] [--json] # Show active task
     python3 task.py finish                      # Clear active task
     python3 task.py set-branch <dir> <branch>   # Set git branch
     python3 task.py set-base-branch <dir> <branch>  # Set PR target branch
@@ -24,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 
 from common.log import Colors, colored
@@ -166,6 +167,27 @@ def cmd_current(args: argparse.Namespace) -> int:
     repo_root = get_repo_root()
     active = resolve_active_task(repo_root)
 
+    if getattr(args, "json", False):
+        task_obj = None
+        if active.task_path:
+            data = read_json(repo_root / active.task_path / FILE_TASK_JSON) or {}
+            task_obj = {
+                "dir": active.task_path,
+                "id": data.get("id") or data.get("name"),
+                "title": data.get("title"),
+                "status": data.get("status"),
+                "parent": data.get("parent"),
+                "children": data.get("children", []),
+                "branch": data.get("branch"),
+                "base_branch": data.get("base_branch"),
+            }
+        print(json.dumps({
+            "current_task": task_obj,
+            "source": active.source,
+            "stale": active.stale,
+        }, ensure_ascii=False))
+        return 0 if active.task_path else 1
+
     if args.source:
         print(f"Current task: {active.task_path or '(none)'}")
         print(f"Source: {active.source}")
@@ -184,6 +206,24 @@ def cmd_current(args: argparse.Namespace) -> int:
 # Command: list
 # =============================================================================
 
+def _display_status(t, all_statuses: dict) -> str:
+    """Return the status label to show for a task in `list` output.
+
+    A parent task's stored status stays "planning" until someone runs
+    `task.py start` on the parent directly, even while its children are
+    actively being worked — a misleading label for anyone scanning the
+    list (#399 item 3). Show "active" instead when at least one child is
+    past planning; the stored status.json value is left untouched.
+    """
+    if t.status == "planning" and t.children:
+        child_in_flight = any(
+            all_statuses.get(c) not in (None, "planning") for c in t.children
+        )
+        if child_in_flight:
+            return "active"
+    return t.status
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     """List active tasks."""
     repo_root = get_repo_root()
@@ -192,6 +232,38 @@ def cmd_list(args: argparse.Namespace) -> int:
     developer = get_developer(repo_root)
     filter_mine = args.mine
     filter_status = args.status
+    as_json = getattr(args, "json", False)
+
+    # Single pass: collect all tasks via shared iterator
+    all_tasks = {t.dir_name: t for t in iter_active_tasks(tasks_dir)}
+    all_statuses = {name: t.status for name, t in all_tasks.items()}
+
+    if as_json:
+        if filter_mine and not developer:
+            print(json.dumps({"error": "No developer set"}), file=sys.stderr)
+            return 1
+
+        items = []
+        for dir_name in sorted(all_tasks.keys()):
+            t = all_tasks[dir_name]
+            if filter_mine and (t.assignee or "-") != developer:
+                continue
+            if filter_status and t.status != filter_status:
+                continue
+            items.append({
+                "dir": f"{DIR_WORKFLOW}/{DIR_TASKS}/{dir_name}",
+                "id": t.raw.get("id") or dir_name,
+                "title": t.title,
+                "status": t.status,
+                "display_status": _display_status(t, all_statuses),
+                "priority": t.priority,
+                "assignee": t.assignee or None,
+                "parent": t.parent,
+                "children": list(t.children),
+                "package": t.package,
+            })
+        print(json.dumps({"tasks": items}, ensure_ascii=False))
+        return 0
 
     if filter_mine:
         if not developer:
@@ -201,10 +273,6 @@ def cmd_list(args: argparse.Namespace) -> int:
     else:
         print(colored("All active tasks:", Colors.BLUE))
     print()
-
-    # Single pass: collect all tasks via shared iterator
-    all_tasks = {t.dir_name: t for t in iter_active_tasks(tasks_dir)}
-    all_statuses = {name: t.status for name, t in all_tasks.items()}
 
     # Display tasks hierarchically
     count = 0
@@ -228,6 +296,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 
         # Children progress
         progress = children_progress(t.children, all_statuses)
+        status_label = _display_status(t, all_statuses)
 
         # Package tag
         pkg_tag = f" @{t.package}" if t.package else ""
@@ -235,9 +304,9 @@ def cmd_list(args: argparse.Namespace) -> int:
         prefix = "  " * indent + "  - "
 
         if filter_mine:
-            print(f"{prefix}{dir_name}/ ({t.status}){pkg_tag}{progress}{marker}")
+            print(f"{prefix}{dir_name}/ ({status_label}){pkg_tag}{progress}{marker}")
         else:
-            print(f"{prefix}{dir_name}/ ({t.status}){pkg_tag}{progress} [{colored(t.assignee or '-', Colors.CYAN)}]{marker}")
+            print(f"{prefix}{dir_name}/ ({status_label}){pkg_tag}{progress} [{colored(t.assignee or '-', Colors.CYAN)}]{marker}")
         count += 1
 
         # Print children indented
@@ -320,7 +389,7 @@ Usage:
   python3 task.py archive <task-dir>                 Archive completed task
   python3 task.py add-subtask <parent> <child>       Link child task to parent
   python3 task.py remove-subtask <parent> <child>    Unlink child from parent
-  python3 task.py list [--mine] [--status <status>]  List tasks
+  python3 task.py list [--mine] [--status <status>] [--json]  List tasks
   python3 task.py list-archive [YYYY-MM]             List archived tasks
 
 Monorepo options:
@@ -329,6 +398,7 @@ Monorepo options:
 List options:
   --mine, -m           Show only tasks assigned to current developer
   --status, -s <s>     Filter by status (planning, in_progress, review, completed)
+  --json               Output machine-readable JSON (also available on `current`)
 
 Examples:
   python3 task.py create "Add login feature" --slug add-login
@@ -428,6 +498,8 @@ def main() -> int:
     p_current = subparsers.add_parser("current", help="Show active task")
     p_current.add_argument("--source", action="store_true",
                            help="Show active task source")
+    p_current.add_argument("--json", action="store_true",
+                           help="Output machine-readable JSON")
 
     # finish
     subparsers.add_parser("finish", help="Clear active task")
@@ -456,6 +528,7 @@ def main() -> int:
     p_list = subparsers.add_parser("list", help="List tasks")
     p_list.add_argument("--mine", "-m", action="store_true", help="My tasks only")
     p_list.add_argument("--status", "-s", help="Filter by status")
+    p_list.add_argument("--json", action="store_true", help="Output machine-readable JSON")
 
     # add-subtask
     p_addsub = subparsers.add_parser("add-subtask", help="Link child task to parent")

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -380,9 +380,10 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     },
   },
   pi: {
-    name: "Pi Agent",
+    name: "Pi Agent (also writes .agents/skills/ — read by Cursor, Gemini CLI, GitHub Copilot, Amp, Kimi Code)",
     templateDirs: ["common", "pi"],
     configDir: ".pi",
+    supportsAgentSkills: true,
     cliFlag: "pi",
     defaultChecked: false,
     hasPythonHooks: false,

--- a/packages/cli/src/utils/template-fetcher.ts
+++ b/packages/cli/src/utils/template-fetcher.ts
@@ -914,7 +914,6 @@ export async function downloadWithStrategy(
       await withTimeout(
         downloadTemplate(gigetSource, {
           dir: tempDir,
-          preferOffline: true,
         }),
         TIMEOUTS.DOWNLOAD_MS,
         "Template download",
@@ -944,7 +943,6 @@ export async function downloadWithStrategy(
       await withTimeout(
         downloadTemplate(gigetSource, {
           dir: tempDir,
-          preferOffline: true,
         }),
         TIMEOUTS.DOWNLOAD_MS,
         "Template download",
@@ -980,7 +978,6 @@ export async function downloadWithStrategy(
     await withTimeout(
       downloadTemplate(gigetSource, {
         dir: destDir,
-        preferOffline: true,
       }),
       TIMEOUTS.DOWNLOAD_MS,
       "Template download",

--- a/packages/cli/test/commands/channel-codex-adapter.test.ts
+++ b/packages/cli/test/commands/channel-codex-adapter.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildCodexThreadStartParams,
   createCodexCtx,
   parseCodexLine,
+  parseCodexSandboxMode,
 } from "../../src/commands/channel/adapters/codex.js";
 
 function parse(line: Record<string, unknown>, ctx = createCodexCtx()) {
@@ -191,5 +193,39 @@ describe("Codex channel adapter", () => {
 
     const completed = parse({ method: "turn/completed", params: {} }, ctx);
     expect(completed.events).toEqual([{ kind: "done", payload: {} }]);
+  });
+
+  describe("sandbox override (#413)", () => {
+    it("defaults to workspace-write when no sandbox is given", () => {
+      const params = buildCodexThreadStartParams("/tmp/proj");
+      expect(params.sandbox).toBe("workspace-write");
+    });
+
+    it("overrides the sandbox mode when provided", () => {
+      const params = buildCodexThreadStartParams(
+        "/tmp/proj",
+        undefined,
+        "danger-full-access",
+      );
+      expect(params.sandbox).toBe("danger-full-access");
+      expect(params.approvalPolicy).toBe("never");
+    });
+
+    it("parseCodexSandboxMode accepts documented modes", () => {
+      expect(parseCodexSandboxMode(undefined)).toBeUndefined();
+      expect(parseCodexSandboxMode("read-only")).toBe("read-only");
+      expect(parseCodexSandboxMode("workspace-write")).toBe(
+        "workspace-write",
+      );
+      expect(parseCodexSandboxMode("danger-full-access")).toBe(
+        "danger-full-access",
+      );
+    });
+
+    it("parseCodexSandboxMode rejects unknown values", () => {
+      expect(() => parseCodexSandboxMode("yolo")).toThrow(
+        /Invalid --sandbox 'yolo'/,
+      );
+    });
   });
 });

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -546,7 +546,7 @@ describe("init() integration", () => {
     ).toBe(true);
     expect(
       fs.existsSync(
-        path.join(tmpDir, ".pi", "skills", "trellis-check", "SKILL.md"),
+        path.join(tmpDir, ".agents", "skills", "trellis-check", "SKILL.md"),
       ),
     ).toBe(true);
     expect(

--- a/packages/cli/test/commands/platforms.integration.test.ts
+++ b/packages/cli/test/commands/platforms.integration.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration test for #396 — `trellis platforms [--json]`.
+ *
+ * Exposes which platforms are configured in a repo in a machine-readable
+ * way, so downstream tooling doesn't have to hand-maintain marker-file
+ * tables per platform. Spawns the real built CLI binary (`bin/trellis.js`)
+ * since the subcommand is wired up in `src/cli/index.ts`, which has
+ * import-time side effects that make direct unit import brittle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI_BIN = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../bin/trellis.js",
+);
+
+function runCli(cwd: string, args: string[]) {
+  return spawnSync(process.execPath, [CLI_BIN, ...args], {
+    cwd,
+    encoding: "utf-8",
+  });
+}
+
+describe("trellis platforms (#396)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-platforms-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("--json reports configured platforms with id, displayName, configDir", () => {
+    fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".cursor"), { recursive: true });
+
+    const result = runCli(tmpDir, ["platforms", "--json"]);
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      platforms: { id: string; displayName: string; configDir: string }[];
+    };
+    const ids = parsed.platforms.map((p) => p.id).sort();
+    expect(ids).toEqual(["claude-code", "cursor"]);
+
+    const claude = parsed.platforms.find((p) => p.id === "claude-code");
+    expect(claude).toEqual({
+      id: "claude-code",
+      displayName: "Claude Code",
+      configDir: ".claude",
+    });
+  });
+
+  it("--json reports an empty list when no platform is configured", () => {
+    const result = runCli(tmpDir, ["platforms", "--json"]);
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { platforms: unknown[] };
+    expect(parsed.platforms).toEqual([]);
+  });
+
+  it("human output lists configured platforms without --json", () => {
+    fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+
+    const result = runCli(tmpDir, ["platforms"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Claude Code");
+    expect(result.stdout).toContain(".claude");
+  });
+});

--- a/packages/cli/test/configurators/index.test.ts
+++ b/packages/cli/test/configurators/index.test.ts
@@ -318,7 +318,9 @@ describe("collectPlatformTemplates", () => {
     codebuddy: ".codebuddy/skills",
     copilot: ".github/skills",
     droid: ".factory/skills",
-    pi: ".pi/skills",
+    // Pi discovers `.agents/skills/` natively; Trellis writes there (shared
+    // with Codex/Gemini) instead of a private `.pi/skills/` copy (#447).
+    pi: ".agents/skills",
     zcode: ".zcode/skills",
   };
 

--- a/packages/cli/test/configurators/platforms.test.ts
+++ b/packages/cli/test/configurators/platforms.test.ts
@@ -1114,19 +1114,22 @@ describe("configurePlatform", () => {
     expect(
       fs.existsSync(path.join(tmpDir, ".pi", "prompts", "trellis-start.md")),
     ).toBe(true);
+    // Shared skills go to `.agents/skills/`, deduped with Codex/Gemini (#447) —
+    // Pi no longer keeps a private `.pi/skills/` copy.
     expect(
       fs.existsSync(
-        path.join(tmpDir, ".pi", "skills", "trellis-check", "SKILL.md"),
+        path.join(tmpDir, ".agents", "skills", "trellis-check", "SKILL.md"),
       ),
     ).toBe(true);
     expect(
-      fs.existsSync(path.join(tmpDir, ".pi", "skills", BUNDLED_REFERENCE)),
+      fs.existsSync(path.join(tmpDir, ".agents", "skills", BUNDLED_REFERENCE)),
     ).toBe(true);
     expect(
       fs.existsSync(
-        path.join(tmpDir, ".pi", "skills", SPEC_BOOTSTRAP_REFERENCE),
+        path.join(tmpDir, ".agents", "skills", SPEC_BOOTSTRAP_REFERENCE),
       ),
     ).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".pi", "skills"))).toBe(false);
     expect(
       fs.existsSync(path.join(tmpDir, ".pi", "agents", "trellis-implement.md")),
     ).toBe(true);
@@ -1189,7 +1192,9 @@ describe("configurePlatform", () => {
           }
       )[];
     };
-    expect(settings.skills).toEqual(["./skills"]);
+    // No private `.pi/skills/` root anymore — Pi discovers shared
+    // `.agents/skills/` natively (#447).
+    expect(settings.skills).toBeUndefined();
   });
 
   it("configurePlatform('pi') writes tracked templates exactly", async () => {
@@ -1226,15 +1231,17 @@ describe("configurePlatform", () => {
     expect(templates?.get(".pi/prompts/trellis-start.md")).toBeDefined();
     expect(templates?.get(".pi/prompts/trellis-finish-work.md")).toBeDefined();
     expect(templates?.get(".pi/prompts/trellis-continue.md")).toBeDefined();
-    expect(templates?.get(".pi/skills/trellis-check/SKILL.md")).toBeDefined();
+    expect(
+      templates?.get(".agents/skills/trellis-check/SKILL.md"),
+    ).toBeDefined();
     expect(
       templates?.get(
-        ".pi/skills/trellis-meta/references/local-architecture/overview.md",
+        ".agents/skills/trellis-meta/references/local-architecture/overview.md",
       ),
     ).toBeDefined();
     expect(
       templates?.get(
-        ".pi/skills/trellis-spec-bootstrap/references/spec-writing.md",
+        ".agents/skills/trellis-spec-bootstrap/references/spec-writing.md",
       ),
     ).toBeDefined();
     expect(templates?.get(".pi/agents/trellis-implement.md")).toContain(

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -5478,6 +5478,76 @@ print(len(entries))
       "<codex-mode>",
     );
   });
+
+  it("[issue-395] task.py list --json emits a stable machine-readable schema", () => {
+    setupTaskRepo();
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} list --json`,
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    const parsed = JSON.parse(output) as {
+      tasks: {
+        dir: string;
+        title: string;
+        status: string;
+        priority: string;
+        assignee: string | null;
+        parent: string | null;
+        children: string[];
+      }[];
+    };
+    expect(parsed.tasks).toHaveLength(1);
+    expect(parsed.tasks[0]).toMatchObject({
+      dir: ".trellis/tasks/issue-106",
+      title: "Issue 106 task",
+      status: "in_progress",
+      parent: null,
+      children: [],
+    });
+  });
+
+  it("[issue-395] task.py current --json reports null when no task is active", () => {
+    setupTaskRepo();
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+
+    const result = spawnSync(
+      pythonCmd,
+      [taskScriptPath, "current", "--json"],
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout) as { current_task: unknown };
+    expect(parsed.current_task).toBeNull();
+  });
+
+  it("[issue-395] task.py current --json reports the active task object", () => {
+    setupTaskRepo();
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} start ${JSON.stringify(".trellis/tasks/issue-106")}`,
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv({ TRELLIS_CONTEXT_ID: "json-current-session" }) },
+    );
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} current --json`,
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv({ TRELLIS_CONTEXT_ID: "json-current-session" }) },
+    );
+
+    const parsed = JSON.parse(output) as {
+      current_task: { dir: string; title: string; status: string } | null;
+    };
+    expect(parsed.current_task).toMatchObject({
+      dir: ".trellis/tasks/issue-106",
+      title: "Issue 106 task",
+      status: "in_progress",
+    });
+  });
+
 });
 
 describe("regression: backslash in markdown templates (beta.12)", () => {

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -5548,6 +5548,134 @@ print(len(entries))
     });
   });
 
+  it("[issue-399.1] task.py create stamps base_branch from origin/HEAD, not the checked-out branch", () => {
+    setupTaskRepo();
+    execSync("git init -q -b feature/some-work", { cwd: tmpDir });
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -q -m init', { cwd: tmpDir });
+
+    // Simulate a bare "origin" remote whose default branch is main, while
+    // the local checkout stays on a feature branch (#399 item 1 repro).
+    const remotePath = path.join(tmpDir, "..", "origin-bare.git");
+    execSync(`git init -q --bare ${JSON.stringify(remotePath)}`, { cwd: tmpDir });
+    execSync("git branch -m feature/some-work main", { cwd: tmpDir });
+    execSync(`git remote add origin ${JSON.stringify(remotePath)}`, { cwd: tmpDir });
+    execSync("git push -q origin main", { cwd: tmpDir });
+    execSync(`git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main`, { cwd: tmpDir });
+    execSync("git checkout -q -b feature/some-work", { cwd: tmpDir });
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "base branch test" --slug base-branch-test --assignee test-dev --no-start`,
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    const taskDir = fs
+      .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+      .find((d) => d.includes("base-branch-test"));
+    expect(taskDir).toBeDefined();
+    const taskJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "tasks", taskDir as string, "task.json"),
+        "utf-8",
+      ),
+    ) as { base_branch: string };
+    expect(taskJson.base_branch).toBe("main");
+
+    fs.rmSync(remotePath, { recursive: true, force: true });
+  });
+
+  it("[issue-399.1] task.py create falls back to the checked-out branch when no default branch resolves", () => {
+    setupTaskRepo();
+    execSync("git init -q -b solo-branch", { cwd: tmpDir });
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -q -m init', { cwd: tmpDir });
+    // No origin remote configured at all.
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "no remote test" --slug no-remote-test --assignee test-dev --no-start`,
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    const taskDir = fs
+      .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+      .find((d) => d.includes("no-remote-test"));
+    const taskJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "tasks", taskDir as string, "task.json"),
+        "utf-8",
+      ),
+    ) as { base_branch: string };
+    expect(taskJson.base_branch).toBe("solo-branch");
+  });
+
+  it("[issue-399.2] task.py validate warns when the recorded branch no longer exists locally", () => {
+    setupTaskRepo();
+    execSync("git init -q -b main", { cwd: tmpDir });
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -q -m init', { cwd: tmpDir });
+
+    const taskJsonPath = path.join(
+      tmpDir,
+      ".trellis",
+      "tasks",
+      "issue-106",
+      "task.json",
+    );
+    const data = JSON.parse(fs.readFileSync(taskJsonPath, "utf-8"));
+    data.branch = "task/deleted-branch-does-not-exist";
+    fs.writeFileSync(taskJsonPath, JSON.stringify(data, null, 2));
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(
+      pythonCmd,
+      [taskScriptPath, "validate", ".trellis/tasks/issue-106"],
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    expect(result.stdout).toContain(
+      "recorded branch 'task/deleted-branch-does-not-exist' no longer exists locally",
+    );
+  });
+
+  it("[issue-399.2] task.py archive warns when the recorded branch no longer exists locally", () => {
+    setupTaskRepo();
+    execSync("git init -q -b main", { cwd: tmpDir });
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -q -m init', { cwd: tmpDir });
+
+    const taskJsonPath = path.join(
+      tmpDir,
+      ".trellis",
+      "tasks",
+      "issue-106",
+      "task.json",
+    );
+    const data = JSON.parse(fs.readFileSync(taskJsonPath, "utf-8"));
+    data.branch = "task/deleted-branch-does-not-exist";
+    fs.writeFileSync(taskJsonPath, JSON.stringify(data, null, 2));
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(
+      pythonCmd,
+      [taskScriptPath, "archive", ".trellis/tasks/issue-106", "--no-commit"],
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    expect(result.stderr).toContain(
+      "recorded branch 'task/deleted-branch-does-not-exist' no longer exists locally",
+    );
+  });
+
 });
 
 describe("regression: backslash in markdown templates (beta.12)", () => {

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -128,7 +128,7 @@ describe("pi templates", () => {
     }
   });
 
-  it("settings keep Pi-owned skills until shared Agent Skills are platform-neutral", () => {
+  it("settings no longer list a private skills root — Pi discovers shared .agents/skills/ natively (#447)", () => {
     const settings = JSON.parse(getSettingsTemplate().content) as {
       enableSkillCommands?: boolean;
       extensions?: string[];
@@ -139,9 +139,20 @@ describe("pi templates", () => {
 
     expect(settings.enableSkillCommands).toBe(true);
     expect(settings.extensions).toEqual(["./extensions/trellis/index.ts"]);
-    expect(settings.skills).toEqual(["./skills"]);
+    expect(settings.skills).toBeUndefined();
     expect(settings.prompts).toEqual(["./prompts"]);
     expect(settings.packages).toBeUndefined();
+  });
+
+  it("writes shared skills to .agents/skills/, not a private .pi/skills/ root (#447)", () => {
+    const templates = collectPiTemplates();
+
+    expect(
+      templates.get(".agents/skills/trellis-check/SKILL.md"),
+    ).toBeDefined();
+    for (const key of templates.keys()) {
+      expect(key.startsWith(".pi/skills/")).toBe(false);
+    }
   });
 
   it("collects a manual trellis-start prompt for Pi fallback bootstrap", () => {

--- a/packages/cli/test/utils/download-with-strategy.test.ts
+++ b/packages/cli/test/utils/download-with-strategy.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression test for #383 — registry spec updates never pulled.
+ *
+ * `downloadWithStrategy()` used to pass `preferOffline: true` to giget on
+ * every call site, so giget served the stale cached tarball even when the
+ * network was available and the remote registry had new content. Verify
+ * none of the `downloadTemplate()` call sites request offline-preferred
+ * downloads.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const downloadTemplateMock = vi.fn(async (_source: string, options: { dir: string }) => {
+  fs.mkdirSync(options.dir, { recursive: true });
+  fs.writeFileSync(path.join(options.dir, "marker.txt"), "content");
+  return {};
+});
+
+vi.mock("giget", () => ({
+  downloadTemplate: (...args: [string, { dir: string }]) =>
+    downloadTemplateMock(...args),
+}));
+
+const { downloadWithStrategy } = await import("../../src/utils/template-fetcher.js");
+
+describe("downloadWithStrategy — #383 preferOffline removed", () => {
+  afterEach(() => {
+    downloadTemplateMock.mockClear();
+  });
+
+  it("does not set preferOffline for a fresh directory download", async () => {
+    const destDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-dl-"));
+    fs.rmSync(destDir, { recursive: true, force: true });
+
+    await downloadWithStrategy("gh:org/repo/spec", destDir, "skip");
+
+    expect(downloadTemplateMock).toHaveBeenCalledTimes(1);
+    const options = downloadTemplateMock.mock.calls[0][1];
+    expect(options).not.toHaveProperty("preferOffline");
+
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+
+  it("does not set preferOffline for overwrite strategy", async () => {
+    const destDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-dl-"));
+    fs.writeFileSync(path.join(destDir, "existing.txt"), "old");
+
+    await downloadWithStrategy("gh:org/repo/spec", destDir, "overwrite");
+
+    expect(downloadTemplateMock).toHaveBeenCalledTimes(1);
+    const options = downloadTemplateMock.mock.calls[0][1];
+    expect(options).not.toHaveProperty("preferOffline");
+
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+
+  it("does not set preferOffline for append strategy", async () => {
+    const destDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-dl-"));
+    fs.writeFileSync(path.join(destDir, "existing.txt"), "old");
+
+    await downloadWithStrategy("gh:org/repo/spec", destDir, "append");
+
+    expect(downloadTemplateMock).toHaveBeenCalledTimes(1);
+    const options = downloadTemplateMock.mock.calls[0][1];
+    expect(options).not.toHaveProperty("preferOffline");
+
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Batch of small fixes from open-issue triage.

- Fixes #383 — registry template downloads passed `preferOffline: true` to giget, so pushed spec updates never re-downloaded; flag removed at all three call sites.
- Fixes #396 — new `trellis platforms [--json]` subcommand exposing configured platforms via the existing `getConfiguredPlatforms` + registry metadata.
- Fixes #395 — `task.py list/current --json` machine-readable output (`get_context.py --json` already existed).
- Fixes #399 — items 1-3: `base_branch` stamped from the repo default branch instead of the checked-out branch, stale-branch warnings on validate/archive, and parent status roll-up in `list`. Item 4 (eager jsonl seeding) is intentional design.
- Fixes #413 — `trellis channel spawn --sandbox <read-only|workspace-write|danger-full-access>` overrides the previously hardcoded Codex worker sandbox (default unchanged).
- Fixes #447 — Pi now writes shared skills to `.agents/skills/` (deduped with Codex/Gemini) instead of a private `.pi/skills/` root; ships a `rename-dir` migration (0.6.8) relocating existing installs.

Verification: `pnpm lint`, `pnpm typecheck`, full `pnpm test` — 1415/1415 across 62 files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `trellis platforms` with human-readable and JSON output.
  * Added JSON output for task listing and current-task details.
  * Added configurable Codex sandbox modes for channel workers.
* **Improvements**
  * Pi skills are now shared through `.agents/skills/`, with migration support from the previous location.
  * Task creation records the repository’s default target branch.
* **Bug Fixes**
  * Validation and archiving now warn about missing local task branches without blocking progress.
  * Template downloads now reliably check for fresh content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->