### PR TITLE
docs(spec): refresh contracts for #439/#445/#448 merge batch

### DIFF
--- a/.trellis/spec/cli/backend/commands-channel.md
+++ b/.trellis/spec/cli/backend/commands-channel.md
@@ -65,6 +65,10 @@ trellis channel spawn <name> [opts]
   --cwd <path>           : worker cwd (default process.cwd())
   --model <id>           : model override
   --resume <id>          : resume an existing session/thread id
+  --sandbox <mode>       : codex-only: read-only | workspace-write | danger-full-access
+                           (default workspace-write; overrides thread/start sandbox
+                           to match the user's main-session Codex permissions; ignored
+                           for other providers; invalid value throws before spawn)
   --timeout <duration>   : auto-kill after duration (e.g. "30m", "1h", "7200s")
                            — no default; opt-in hard cutoff
   --warn-before <duration>: emit `supervisor_warning` before timeout

--- a/.trellis/spec/cli/backend/commands-platforms.md
+++ b/.trellis/spec/cli/backend/commands-platforms.md
@@ -1,0 +1,50 @@
+# `trellis platforms` Command
+
+Machine-readable report of which AI platforms are configured (active) in the
+current project. Downstream tooling (docs, dashboards, other CLIs) can read
+this instead of hand-maintaining a per-platform marker-file table that drifts
+as the platform count grows or a `configDir` is renamed.
+
+---
+
+## User-facing contract
+
+```text
+trellis platforms [--json]
+```
+
+Behavior:
+
+- Reads `getConfiguredPlatforms(cwd)` (`configurators/index.ts`) to find every
+  platform whose `configDir` exists at the repo root, then looks up each
+  platform's `displayName` (`AI_TOOLS[id].name`) and `configDir`
+  (`AI_TOOLS[id].configDir`) from the `AI_TOOLS` registry
+  (`types/ai-tools.ts`).
+- `--json` prints `{"platforms": [{id, displayName, configDir}, ...]}` via
+  `JSON.stringify(..., null, 2)`.
+- Without `--json`, prints a human list: `  <displayName> (<id>) — <configDir>`
+  per line, or `No platforms configured in this project.` when none are
+  configured.
+- Both output modes exit 0, including the empty-list case — an empty result
+  is not an error.
+
+## Failure behavior
+
+- On any thrown error, print `Error: <message>` and exit 1.
+- When `DEBUG` or `TRELLIS_DEBUG` is set, also print the error stack.
+- No special-casing per platform: this command is a thin read over the same
+  registry data `init`/`update` already use, so a new platform only needs its
+  Step 1 registry entry (see
+  [platform-integration.md](./platform-integration.md)) to show up here.
+
+## Test requirements
+
+- `--json` reports `id`/`displayName`/`configDir` for each configured
+  platform, sourced from the real `AI_TOOLS` registry (not hardcoded).
+- `--json` reports an empty `platforms` array (not an error) when no platform
+  is configured.
+- Human output (no `--json`) lists `displayName` and `configDir` per
+  configured platform.
+- See `test/commands/platforms.integration.test.ts` (#396) — spawns the built
+  CLI binary because `src/cli/index.ts` has import-time side effects that
+  make direct unit import brittle.

--- a/.trellis/spec/cli/backend/directory-structure.md
+++ b/.trellis/spec/cli/backend/directory-structure.md
@@ -424,9 +424,13 @@ import { downloadTemplate } from "giget";
 
 await downloadTemplate("gh:mindfold-ai/Trellis/marketplace/specs/electron-fullstack", {
   dir: destDir,
-  preferOffline: true,
 });
 ```
+
+**Note**: `downloadWithStrategy()` does not pass `preferOffline` — giget's
+default network-first behavior applies at all three call sites (skip,
+overwrite, append), so `init`/`update` always check the remote registry
+for new content instead of silently serving a stale cached tarball.
 
 ### Directory Conflict Strategy (skip/overwrite/append)
 

--- a/.trellis/spec/cli/backend/index.md
+++ b/.trellis/spec/cli/backend/index.md
@@ -30,6 +30,7 @@ This directory contains guidelines for backend development. Fill in each file wi
 | [`trellis upgrade` Command](./commands-upgrade.md) | Global CLI self-upgrade wrapper: channel inference, npm invocation, failure behavior | Done |
 | [`trellis update` Command](./commands-update.md) | Update pipeline: flags, plan composition, migration trigger semantics, apply phase, idempotency, boundaries with `migrations.md` | Done |
 | [`trellis workflow` Command](./commands-workflow.md) | Workflow marketplace templates, project-local workflow switching, hash ownership contract, and parser compatibility | Done |
+| [`trellis platforms` Command](./commands-platforms.md) | Machine-readable report of configured AI platforms: `--json` shape, registry sourcing, failure behavior | Done |
 | [`trellis uninstall` Command](./commands-uninstall.md) | Uninstall orchestration: plan composition, structured-file dispatch, execute phases, `.trellis/` removal | Done |
 | [Uninstall Scrubbers](./uninstall-scrubbers.md) | Pure scrubber contract for structured config files (`settings.json`, `hooks.json`, `package.json`, `config.toml`) | Done |
 | [`trellis channel` Command](./commands-channel.md) | Multi-agent collaboration runtime: events.jsonl protocol, per-worker supervisor, provider adapters (claude / codex), project buckets, ephemeral / run lifecycle, ShutdownController state machine | Done |
@@ -55,6 +56,7 @@ Before writing backend code, read the relevant guidelines based on your task:
 - Editing `commands/upgrade.ts` (global CLI self-upgrade behavior) → [commands-upgrade.md](./commands-upgrade.md)
 - Editing `commands/update.ts` (flags, plan, apply phases, idempotency) → [commands-update.md](./commands-update.md) — manifest mechanics still in [migrations.md](./migrations.md)
 - Editing `commands/workflow.ts`, `utils/workflow-resolver.ts`, workflow marketplace entries, or `init --workflow` behavior → [commands-workflow.md](./commands-workflow.md)
+- Editing the `platforms` subcommand in `cli/index.ts` → [commands-platforms.md](./commands-platforms.md)
 - Editing `commands/uninstall.ts` or `utils/uninstall-scrubbers.ts` → [commands-uninstall.md](./commands-uninstall.md) + [uninstall-scrubbers.md](./uninstall-scrubbers.md)
 - Editing `commands/channel/**` (events.jsonl protocol, supervisors, adapters, project buckets, channel-lifecycle commands) → [commands-channel.md](./commands-channel.md)
 

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -103,7 +103,7 @@ When adding a new platform `{platform}`, update the following:
 | `src/templates/{platform}/extensions/trellis/index.ts.txt` | Project-local extension source written to `.pi/extensions/trellis/index.ts`               |
 | `src/templates/{platform}/settings.json`                   | Platform settings that enable extension, skills, and prompts                              |
 
-> Note: Pi Agent uses project-local TypeScript extensions instead of Trellis Python hooks. Keep generated hooks under `.pi/extensions/`, write prompt templates under `.pi/prompts/trellis-*.md`, write Agent Skills under `.pi/skills/`, and do not copy `shared-hooks/*.py` into `.pi/`. Do not redirect Pi to shared `.agents/skills` until shared Agent Skill text is platform-neutral; Codex and Pi command references can differ. For the nested Pi launcher contract, see "Scenario: Pi Sub-Agent Launcher".
+> Note: Pi Agent uses project-local TypeScript extensions instead of Trellis Python hooks. Keep generated hooks under `.pi/extensions/`, write prompt templates under `.pi/prompts/trellis-*.md`, and do not copy `shared-hooks/*.py` into `.pi/`. Agent Skills write to the shared `.agents/skills/` root (same path Codex and Gemini CLI use) via `resolveSkillsNeutral()`, not a private `.pi/skills/` root — Pi discovers `.agents/skills/` natively, and keeping a separate `.pi/skills/` copy caused Pi to see every skill twice when Codex or Gemini was also installed (#447). `configDir` stays `.pi`; `supportsAgentSkills: true` adds `.agents/skills` to Pi's managed paths, same as Codex/Gemini. A rename-dir migration (`0.6.8.json`) relocates any pre-#447 `.pi/skills/` install into `.agents/skills/` on `trellis update`. For the nested Pi launcher contract, see "Scenario: Pi Sub-Agent Launcher".
 >
 > Pi is an explicit `trellis-start` exception: `session_start` is notify-only and cannot mutate model-visible context, so the configurator must keep `.pi/prompts/trellis-start.md` as a manual bootstrap fallback while the extension injects startup/full Trellis context through `before_agent_start.systemPrompt` and persists compact workflow/session context through a hidden custom message returned from `before_agent_start`.
 >
@@ -620,7 +620,7 @@ Configurator output:
 ```text
 .pi/settings.json
 .pi/prompts/trellis-<command>.md
-.pi/skills/<skill>/SKILL.md
+.agents/skills/<skill>/SKILL.md
 .pi/agents/trellis-<agent>.md
 .pi/extensions/trellis/index.ts
 ```
@@ -671,7 +671,7 @@ Good:
 ```text
 .pi/extensions/trellis/index.ts
 .pi/agents/trellis-implement.md
-.pi/skills/update-spec/SKILL.md
+.agents/skills/update-spec/SKILL.md
 ```
 
 Base:

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -306,6 +306,28 @@ def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]
 - Returns `(1, "", error_message)` on exception (never raises)
 - Backward-compatible alias in `git_context.py`: `_run_git_command = run_git`
 
+```python
+def resolve_default_branch(repo_root: Path) -> str | None
+def branch_exists_locally(branch: str, repo_root: Path) -> bool
+```
+
+- `resolve_default_branch()` tries the local `refs/remotes/origin/HEAD`
+  symbolic ref first (no network access), then falls back to
+  `git remote show origin` (`HEAD branch: <name>`, which may hit the network
+  but also repairs a missing/stale symbolic-ref). Returns `None` when neither
+  resolves — callers fall back to their own pre-existing behavior.
+- `task_store.py:cmd_create` stamps `task.json.base_branch` from
+  `resolve_default_branch()`, falling back to the checked-out branch
+  (`git branch --show-current`, or `"main"`) only when the default can't be
+  resolved. This fixes creating a task from a feature branch mis-recording
+  that feature branch as the PR target (#399).
+- `branch_exists_locally()` checks `git rev-parse --verify --quiet
+  refs/heads/<branch>`. `task_context.py:cmd_validate` and
+  `task_store.py:cmd_archive` call it against `task.json.branch` and print a
+  yellow warning (not a failure/block) when the recorded branch no longer
+  exists locally — the common case is the branch was already merged and
+  deleted upstream.
+
 ### `common/active_task.py` — Active Task Resolver
 
 All current-task consumers must use the active task resolver instead of reading
@@ -378,7 +400,8 @@ a `.current-task` fallback or a Python hook directory.
 
 - `python3 .trellis/scripts/task.py create "<title>" [--slug <slug>] [--description <text>] [--no-start]`
 - `python3 .trellis/scripts/task.py start <task-dir>`
-- `python3 .trellis/scripts/task.py current [--source]`
+- `python3 .trellis/scripts/task.py current [--source] [--json]`
+- `python3 .trellis/scripts/task.py list [--mine] [--status <status>] [--json]`
 - `python3 .trellis/scripts/task.py finish`
 - `resolve_active_task(repo_root, platform_input=None, platform=None) -> ActiveTask`
 - `set_active_task(task_path, repo_root, platform_input=None, platform=None) -> ActiveTask | None`
@@ -401,10 +424,13 @@ a `.current-task` fallback or a Python hook directory.
 - `task.py create` without a context key creates the task and does not create
   `.trellis/.runtime/`.
 - `task.py create` creates `implement.jsonl` / `check.jsonl` only when the
-  repo has a platform configured that consumes those files. `.codex/` is not
-  enough by itself: Codex defaults to `codex.dispatch_mode: inline`, which
-  loads context through skills. Codex seeds JSONL only when
-  `codex.dispatch_mode: sub-agent` is explicitly configured.
+  repo has a platform configured that consumes those files. For `.codex/`,
+  this is gated by `get_codex_dispatch_mode()`: the default is
+  `codex.dispatch_mode: auto` (native `SubagentStart` context injection with
+  a child-side pull fallback), which seeds JSONL like every other sub-agent
+  platform. `sub-agent` is a backwards-compatible alias for `auto`. Setting
+  `codex.dispatch_mode: inline` opts out and loads context through skills
+  instead, so JSONL is not seeded.
 - `task.py start` writes session-local state only when a context key is
   available. Otherwise it enters degraded mode: no session pointer is persisted,
   `.trellis/.current-task` is not written, and `task.json.status` may still move
@@ -435,6 +461,24 @@ a `.current-task` fallback or a Python hook directory.
   `task.py archive src` would otherwise resolve to and `shutil.move` the
   repo's real `src/` directory. See
   [Filesystem Safety](./filesystem-safety.md#2-path--name-safety--validate-at-the-chokepoint-before-pathjoin).
+- `task.py current --json` prints `{current_task, source, stale}` on one
+  line (`ensure_ascii=False`); `current_task` is `null` when there is no
+  active task, otherwise `{dir, id, title, status, parent, children, branch,
+  base_branch}` read from that task's `task.json`. Exit 0 when a task is
+  active, exit 1 when `current_task` is `null`. Human output (no `--json`)
+  is unchanged.
+- `task.py list --json` prints `{tasks: [...]}` on one line, one object per
+  task after `--mine`/`--status` filtering: `{dir, id, title, status,
+  display_status, priority, assignee, parent, children, package}`. With
+  `--mine --json` and no developer configured, prints `{"error": "No
+  developer set"}` to stderr and exits 1 (mirrors the human-mode error).
+  `--json` and human `list` share one iteration pass over
+  `iter_active_tasks()` — do not add a second pass for either mode.
+- `display_status` (`_display_status()` in `task.py`) shows `"active"`
+  instead of the stored `"planning"` for a parent task when at least one
+  child's status is not `None`/`"planning"`. This is a display-only label —
+  it never writes back to `task.json.status` — surfaced in both the human
+  `list` line and the JSON `display_status` field (#399 item 3).
 
 ##### 4. Validation & Error Matrix
 
@@ -444,12 +488,17 @@ a `.current-task` fallback or a Python hook directory.
 | `create` with context key, default mode | Task files exist; session runtime points at the new task; activation and source are printed; no `.current-task` |
 | `create --no-start` with context key | Task files exist; existing session runtime is unchanged; skip notice is printed; no `.current-task` |
 | `create` without context key | Task files exist; no `.runtime`; no `.current-task` |
-| `create` with `.codex/` and no `codex.dispatch_mode` override | Task files exist; no `implement.jsonl`; no `check.jsonl` |
-| `create` with `.codex/` and `codex.dispatch_mode: sub-agent` | Task files exist; `implement.jsonl` and `check.jsonl` contain seed `_example` rows |
+| `create` with `.codex/` and no `codex.dispatch_mode` override (default `auto`) | Task files exist; `implement.jsonl` and `check.jsonl` contain seed `_example` rows |
+| `create` with `.codex/` and `codex.dispatch_mode: inline` | Task files exist; no `implement.jsonl`; no `check.jsonl` |
 | `start` without context key | Returns success in degraded mode; no `.runtime`; no `.current-task`; hints IDE/session identity or `TRELLIS_CONTEXT_ID` |
 | `start` with `TRELLIS_CONTEXT_ID` | Writes `.runtime/sessions/<key>.json`; does not require `.current-task` |
 | `current --source` with same context key | Prints `Source: session:<key>` |
 | `current --source` without context | Prints `(none)` and `Source: none` |
+| `current --json` with active task | `{current_task: {...}, source, stale}`; exit 0 |
+| `current --json` with no active task | `{current_task: null, source, stale}`; exit 1 |
+| `list --json --mine` with no developer configured | `{"error": "No developer set"}` on stderr; exit 1 |
+| `list --json` / `list` with a parent whose stored status is `planning` and a child past `planning` | `display_status` (and human list label) shows `"active"`; `task.json.status` on disk stays `planning` |
+| `archive` / `validate` when `task.json.branch` no longer exists locally | Prints a yellow warning; does not block archive or fail validation |
 | stale session task + stale `.current-task` exists | Returns stale session state; no `.current-task` fallback |
 | `finish` with context key and active task | Deletes `.runtime/sessions/<key>.json` |
 | `finish` without context key | Returns no current task; does not delete `.current-task` |
@@ -1340,8 +1389,9 @@ Two near-misses worth remembering:
   `# default` comment on the user's config silently broke dispatch routing.
 - `task.py create` must read `codex.dispatch_mode` through
   `get_codex_dispatch_mode()` before deciding whether `.codex/` should seed
-  `implement.jsonl` / `check.jsonl`. Missing or invalid values default to
-  `inline`, not `sub-agent`.
+  `implement.jsonl` / `check.jsonl`. A missing key defaults to `auto`;
+  an invalid explicit value falls back to `inline` (with a stderr warning),
+  not `auto`.
 - `session_auto_commit` (0.5.11) almost shipped with a one-line
   `config.get(...).strip()` reader before being routed through
   `get_session_auto_commit`.


### PR DESCRIPTION
Brings `.trellis/spec/cli/backend/` up to date with today's merges:

- `platform-integration.md`: Pi skill root references `.pi/skills/` → `.agents/skills/` (#447); #439/#445 had already documented the adaptive notice and SubagentStart scenario.
- `script-conventions.md`: dispatch-mode default `inline` → `auto` corrections, `resolve_default_branch()`/`branch_exists_locally()` contracts, `task.py --json` + `_display_status()` roll-up (#445/#399/#395).
- `directory-structure.md`: drop stale `preferOffline: true` from the giget example (#383).
- `commands-channel.md`: document `channel spawn --sandbox` (#413).
- `commands-platforms.md` (new) + `index.md` registration: `trellis platforms [--json]` contract (#396).

All claims verified against merged code. Tests: core 333/333, CLI 1415/1415.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documented the new `trellis channel spawn --sandbox` option, including supported modes and validation behavior.
  * Added user-facing specifications for `trellis platforms`, including human-readable and JSON output.
  * Clarified JSON reporting for active-task commands and Codex dispatch behavior.

* **Documentation**
  * Updated template download behavior to reflect network-first checks.
  * Documented shared Agent Skills storage for Pi Agent.
  * Expanded CLI conventions, branch handling, validation, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->