### PR TITLE
fix: post-review hardening — #447 migration repair + five review cleanups

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -26,3 +26,14 @@ project_doc_fallback_filenames = ["AGENTS.md"]
 # aborts the entire config load and blocks Codex from starting. Codex's own
 # default for multi_agent_v2 is used instead; tune it in your user-level
 # config if needed.
+
+# Pin the subagent recursion depth explicitly instead of relying on Codex's
+# default. #445 removed the per-agent `[features] multi_agent = false` guard
+# (the #240/#241 wait_agent-deadlock structural fix) because native subagent
+# dispatch already caps recursion via `agents.max_depth` — but that key is
+# global/user-level, not settable inside an individual agent's .toml. Pinning
+# it here means an upstream default change, or a user's own global override,
+# can't silently reopen the recursion the #240/#241 fix closed. Project config
+# (this file) takes precedence over user-level `~/.codex/config.toml`.
+[agents]
+max_depth = 1

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -300,9 +300,27 @@ def cmd_create(args: argparse.Namespace) -> int:
     # mis-stamp that feature branch as the PR target (#399 item 1). Falls
     # back to the checked-out branch when the default can't be resolved
     # (no remote configured, offline, etc.) — the pre-existing behavior.
+    # --base-branch lets the caller override both when neither is correct.
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
-    base_branch = resolve_default_branch(repo_root) or current_branch
+    explicit_base_branch: str | None = getattr(args, "base_branch", None)
+    if explicit_base_branch:
+        base_branch = explicit_base_branch
+    else:
+        resolved_base_branch = resolve_default_branch(repo_root)
+        if resolved_base_branch:
+            base_branch = resolved_base_branch
+        else:
+            base_branch = current_branch
+            print(
+                colored(
+                    f"warning: could not resolve the repository's default branch "
+                    f"(no remote configured, offline, etc.); stamping base_branch as "
+                    f"the checked-out branch '{base_branch}'. Pass --base-branch to override.",
+                    Colors.YELLOW,
+                ),
+                file=sys.stderr,
+            )
 
     description = (args.description or "").strip()
     if not description.strip():

--- a/.trellis/scripts/task.py
+++ b/.trellis/scripts/task.py
@@ -470,6 +470,10 @@ def main() -> int:
     p_create.add_argument("--parent", help="Parent task directory (establishes subtask link)")
     p_create.add_argument("--package", help="Package name for monorepo projects")
     p_create.add_argument(
+        "--base-branch",
+        help="PR target branch (overrides origin/HEAD detection and the checked-out-branch fallback)",
+    )
+    p_create.add_argument(
         "--no-start",
         action="store_true",
         help="Create the task without making it active in this session",

--- a/packages/cli/src/commands/channel/index.ts
+++ b/packages/cli/src/commands/channel/index.ts
@@ -361,7 +361,7 @@ export function registerChannelCommand(program: Command): void {
         process.exit(1);
       }
       try {
-        parseCodexSandboxMode(opts.sandbox);
+        const sandbox = parseCodexSandboxMode(opts.sandbox);
         await channelSpawn(name, {
           agent: opts.agent,
           provider: opts.provider as Provider | undefined,
@@ -369,7 +369,7 @@ export function registerChannelCommand(program: Command): void {
           cwd: opts.cwd,
           model: opts.model,
           resume: opts.resume,
-          sandbox: opts.sandbox,
+          sandbox,
           timeoutMs: parseDuration(opts.timeout),
           warnBeforeMs: parseDuration(opts.warnBefore),
           files: opts.file,

--- a/packages/cli/src/commands/channel/spawn.ts
+++ b/packages/cli/src/commands/channel/spawn.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import type { InboxPolicy } from "@mindfoldhq/trellis-core/channel";
 
 import { loadAgent } from "./agent-loader.js";
+import type { CodexSandboxMode } from "./adapters/codex.js";
 import type { Provider } from "./adapters/index.js";
 import { assembleContext } from "./context-loader.js";
 import {
@@ -32,7 +33,7 @@ export interface SpawnOptions {
   model?: string;
   resume?: string;
   /** Codex-only: overrides the `thread/start` sandbox mode (default `workspace-write`). */
-  sandbox?: string;
+  sandbox?: CodexSandboxMode;
   /** Auto-kill the worker after this many milliseconds (anti-zombie). */
   timeoutMs?: number;
   /** Emit supervisor_warning this many milliseconds before timeout. */

--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -48,7 +48,7 @@ export interface SupervisorConfig {
   /** Resume an existing session/thread if id is provided. */
   resume?: string;
   /** Codex-only: overrides the `thread/start` sandbox mode (default `workspace-write`). */
-  sandbox?: string;
+  sandbox?: CodexSandboxMode;
   /** Auto-kill worker after this many ms (anti-zombie). */
   timeoutMs?: number;
   /** Emit supervisor_warning this many ms before timeout. `<=0` disables it. */
@@ -158,7 +158,7 @@ export async function runSupervisor(
     model: config.model,
     systemPrompt: config.systemPrompt,
     cwd: config.cwd,
-    sandbox: config.sandbox as CodexSandboxMode | undefined,
+    sandbox: config.sandbox,
   };
   const args = adapter.buildArgs(view);
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1370,6 +1370,39 @@ function collectAllFiles(dirPath: string, cwd = process.cwd()): string[] {
 }
 
 /**
+ * Whether every file under `dirRelativePath` byte-matches the CURRENT
+ * template content for its path. Stricter than {@link isDirectorySafeToReplace},
+ * which also accepts files that are merely unmodified relative to an old
+ * stored hash (i.e. stale-but-untouched). Used to decide the safe *direction*
+ * of a rename-dir merge when both source and target exist: if the target
+ * already holds canonical current-version bytes, the source (however it got
+ * there) must not be allowed to overwrite it with older/differently-flavored
+ * content (#447 — a legacy `.pi/skills/` copy rendered with the Pi-specific
+ * resolver must not clobber the shared, neutral `.agents/skills/` content
+ * Codex/Gemini already wrote).
+ */
+function dirMatchesCurrentTemplates(
+  cwd: string,
+  dirRelativePath: string,
+  templates: Map<string, string>,
+): boolean {
+  const dirFullPath = path.join(cwd, dirRelativePath);
+  if (!fs.existsSync(dirFullPath)) return false;
+
+  const files = collectAllFiles(dirFullPath, cwd);
+  if (files.length === 0) return false;
+
+  for (const fullPath of files) {
+    const relativePath = toPosix(path.relative(cwd, fullPath));
+    const templateContent = templates.get(relativePath);
+    if (templateContent === undefined) return false;
+    if (fs.readFileSync(fullPath, "utf-8") !== templateContent) return false;
+  }
+
+  return true;
+}
+
+/**
  * Check if a directory only contains unmodified template files
  * Returns true if safe to delete:
  * - All files are tracked and unmodified, OR
@@ -1785,10 +1818,11 @@ export function sortMigrationsForExecution(
  * @param options.skipAll - Skip all modified files without asking
  * If neither is set, prompts interactively for modified files
  */
-async function executeMigrations(
+export async function executeMigrations(
   classified: ClassifiedMigrations,
   cwd: string,
   options: { force?: boolean; skipAll?: boolean },
+  templates: Map<string, string>,
 ): Promise<MigrationResult> {
   const result: MigrationResult = {
     renamed: 0,
@@ -1825,6 +1859,31 @@ async function executeMigrations(
     } else if (item.type === "rename-dir" && item.to) {
       const oldPath = path.join(cwd, item.from);
       const newPath = path.join(cwd, item.to);
+      const oldPrefix = item.from.endsWith("/") ? item.from : item.from + "/";
+      const newPrefix = item.to.endsWith("/") ? item.to : item.to + "/";
+
+      // Target already exists and already holds canonical, current-version
+      // content (e.g. Codex/Gemini already wrote the shared `.agents/skills/`
+      // root before Pi's legacy `.pi/skills/` copy gets retired). Renaming
+      // the source in would clobber good content with older/differently-
+      // flavored bytes, so just drop the now-redundant source instead (#447).
+      if (
+        fs.existsSync(newPath) &&
+        dirMatchesCurrentTemplates(cwd, item.to, templates)
+      ) {
+        removeDirectoryRecursive(oldPath);
+
+        const hashes = loadHashes(cwd);
+        const updatedHashes: TemplateHashes = {};
+        for (const [hashPath, hashValue] of Object.entries(hashes)) {
+          if (hashPath.startsWith(oldPrefix)) continue; // source retired
+          updatedHashes[hashPath] = hashValue;
+        }
+        saveHashes(cwd, updatedHashes);
+
+        result.deleted++;
+        continue;
+      }
 
       // If target exists (safe to replace, already checked in classification)
       // delete it first before renaming
@@ -1840,8 +1899,6 @@ async function executeMigrations(
 
       // Batch update hash tracking for all files in the directory
       const hashes = loadHashes(cwd);
-      const oldPrefix = item.from.endsWith("/") ? item.from : item.from + "/";
-      const newPrefix = item.to.endsWith("/") ? item.to : item.to + "/";
 
       const updatedHashes: TemplateHashes = {};
       for (const [hashPath, hashValue] of Object.entries(hashes)) {
@@ -2474,10 +2531,15 @@ export async function update(options: UpdateOptions): Promise<void> {
 
   // Execute migrations if --migrate flag is set
   if (options.migrate && classifiedMigrations) {
-    const migrationResult = await executeMigrations(classifiedMigrations, cwd, {
-      force: options.force,
-      skipAll: options.skipAll,
-    });
+    const migrationResult = await executeMigrations(
+      classifiedMigrations,
+      cwd,
+      {
+        force: options.force,
+        skipAll: options.skipAll,
+      },
+      templates,
+    );
     printMigrationResult(migrationResult);
 
     // Hardcoded: Rename traces-*.md to journal-*.md in workspace directories

--- a/packages/cli/src/templates/codex/config.toml
+++ b/packages/cli/src/templates/codex/config.toml
@@ -26,3 +26,14 @@ project_doc_fallback_filenames = ["AGENTS.md"]
 # aborts the entire config load and blocks Codex from starting. Codex's own
 # default for multi_agent_v2 is used instead; tune it in your user-level
 # config if needed.
+
+# Pin the subagent recursion depth explicitly instead of relying on Codex's
+# default. #445 removed the per-agent `[features] multi_agent = false` guard
+# (the #240/#241 wait_agent-deadlock structural fix) because native subagent
+# dispatch already caps recursion via `agents.max_depth` — but that key is
+# global/user-level, not settable inside an individual agent's .toml. Pinning
+# it here means an upstream default change, or a user's own global override,
+# can't silently reopen the recursion the #240/#241 fix closed. Project config
+# (this file) takes precedence over user-level `~/.codex/config.toml`.
+[agents]
+max_depth = 1

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -228,6 +228,29 @@ def _read_trellis_config(root: Path) -> dict:
         return {}
 
 
+def _resolve_codex_dispatch_mode(config: dict) -> str:
+    """Normalize `codex.dispatch_mode` from .trellis/config.yaml to "auto" or "inline".
+
+    Defaults to `auto`. The legacy `sub-agent` value is an alias for `auto`.
+    Any other explicit value (including invalid ones) falls back to `inline`
+    without per-turn warnings. Shared by `_codex_mode_banner` (the per-turn
+    banner) and `resolve_breadcrumb_key` (the breadcrumb tag key) so the two
+    stay in lockstep.
+    """
+    mode = "auto"
+    if isinstance(config, dict):
+        codex_cfg = config.get("codex")
+        if isinstance(codex_cfg, dict):
+            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
+            if cfg_mode == "inline":
+                mode = "inline"
+            elif cfg_mode in ("auto", "sub-agent"):
+                mode = "auto"
+            else:
+                mode = "inline"
+    return mode
+
+
 def _codex_mode_banner(config: dict) -> str:
     """Emit a `<codex-mode>` banner for the additionalContext payload.
 
@@ -243,17 +266,7 @@ def _codex_mode_banner(config: dict) -> str:
     body which is per-status. Mode tells AI which dispatch protocol to follow;
     workflow-state tells AI what step it's at.
     """
-    mode = "auto"
-    if isinstance(config, dict):
-        codex_cfg = config.get("codex")
-        if isinstance(codex_cfg, dict):
-            cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
-            if cfg_mode == "inline":
-                mode = "inline"
-            elif cfg_mode in ("auto", "sub-agent"):
-                mode = "auto"
-            else:
-                mode = "inline"
+    mode = _resolve_codex_dispatch_mode(config)
     if mode == "auto":
         meaning = (
             "auto: implement/check work defaults to Trellis sub-agents; native Codex "
@@ -283,17 +296,7 @@ def resolve_breadcrumb_key(
     Non-codex platforms return the plain status unchanged.
     """
     if platform == "codex":
-        mode = "auto"
-        if isinstance(config, dict):
-            codex_cfg = config.get("codex")
-            if isinstance(codex_cfg, dict):
-                cfg_mode = str(codex_cfg.get("dispatch_mode", mode)).strip().lower()
-                if cfg_mode == "inline":
-                    mode = "inline"
-                elif cfg_mode in ("auto", "sub-agent"):
-                    mode = "auto"
-                else:
-                    mode = "inline"
+        mode = _resolve_codex_dispatch_mode(config)
         return f"{status}-inline" if mode == "inline" else status
     return status
 

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -300,9 +300,27 @@ def cmd_create(args: argparse.Namespace) -> int:
     # mis-stamp that feature branch as the PR target (#399 item 1). Falls
     # back to the checked-out branch when the default can't be resolved
     # (no remote configured, offline, etc.) — the pre-existing behavior.
+    # --base-branch lets the caller override both when neither is correct.
     _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
     current_branch = branch_out.strip() or "main"
-    base_branch = resolve_default_branch(repo_root) or current_branch
+    explicit_base_branch: str | None = getattr(args, "base_branch", None)
+    if explicit_base_branch:
+        base_branch = explicit_base_branch
+    else:
+        resolved_base_branch = resolve_default_branch(repo_root)
+        if resolved_base_branch:
+            base_branch = resolved_base_branch
+        else:
+            base_branch = current_branch
+            print(
+                colored(
+                    f"warning: could not resolve the repository's default branch "
+                    f"(no remote configured, offline, etc.); stamping base_branch as "
+                    f"the checked-out branch '{base_branch}'. Pass --base-branch to override.",
+                    Colors.YELLOW,
+                ),
+                file=sys.stderr,
+            )
 
     description = (args.description or "").strip()
     if not description.strip():

--- a/packages/cli/src/templates/trellis/scripts/task.py
+++ b/packages/cli/src/templates/trellis/scripts/task.py
@@ -470,6 +470,10 @@ def main() -> int:
     p_create.add_argument("--parent", help="Parent task directory (establishes subtask link)")
     p_create.add_argument("--package", help="Package name for monorepo projects")
     p_create.add_argument(
+        "--base-branch",
+        help="PR target branch (overrides origin/HEAD detection and the checked-out-branch fallback)",
+    )
+    p_create.add_argument(
         "--no-start",
         action="store_true",
         help="Create the task without making it active in this session",

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -380,7 +380,11 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
     },
   },
   pi: {
-    name: "Pi Agent (also writes .agents/skills/ — read by Cursor, Gemini CLI, GitHub Copilot, Amp, Kimi Code)",
+    // Pi also writes .agents/skills/, which is read by Cursor, Gemini CLI,
+    // GitHub Copilot, Amp, and Kimi Code. Keep that detail here rather than
+    // in `name` — `name` leaks verbatim into `trellis platforms` output and
+    // init checkboxes, where a long parenthetical reads badly.
+    name: "Pi Agent",
     templateDirs: ["common", "pi"],
     configDir: ".pi",
     supportsAgentSkills: true,

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -51,7 +51,11 @@ vi.mock("giget", async () => {
 // === Imports ===
 
 import { init } from "../../src/commands/init.js";
-import { update } from "../../src/commands/update.js";
+import {
+  update,
+  classifyMigrations,
+  executeMigrations,
+} from "../../src/commands/update.js";
 import { VERSION } from "../../src/constants/version.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../../src/constants/paths.js";
 import { computeHash } from "../../src/utils/template-hash.js";
@@ -62,7 +66,15 @@ import {
   COPILOT_INSTRUCTIONS_PATH,
   getCopilotInstructions,
 } from "../../src/templates/copilot/index.js";
-import { replacePythonCommandLiterals } from "../../src/configurators/shared.js";
+import {
+  replacePythonCommandLiterals,
+  resolveSkills,
+  resolveSkillsNeutral,
+  resolveAllAsSkillsNeutral,
+  resolveBundledSkills,
+  collectSkillTemplates,
+} from "../../src/configurators/shared.js";
+import { AI_TOOLS } from "../../src/types/ai-tools.js";
 
 // A managed template file that update always handles (Python script)
 const MANAGED_FILE = `${PATHS.SCRIPTS}/get_context.py`;
@@ -295,6 +307,105 @@ describe("update() integration", () => {
       fs.existsSync(projectFile(".zcode/agents/trellis-research.md")),
     ).toBe(true);
     expect(fs.existsSync(projectFile(".agents/skills"))).toBe(false);
+  });
+
+  it("[issue-447] 0.6.8 rename-dir migration moves legacy .pi/skills/ into shared .agents/skills/ even when Codex already installed the shared root", async () => {
+    // Simulate a pre-0.6.8 project: Pi + Codex both installed. Pre-fix Pi
+    // wrote its own Pi-flavored copy under `.pi/skills/` (via resolveSkills,
+    // not resolveSkillsNeutral), while Codex already wrote the shared,
+    // neutral `.agents/skills/` root. Reproduces the #447 repro shape.
+    //
+    // This exercises classifyMigrations()/executeMigrations() directly
+    // (like the existing "rename-dir ownership gate" tests in
+    // update-internals.test.ts) rather than the full update() CLI flow,
+    // because the 0.6.8 manifest only becomes "pending" once the CLI's own
+    // package.json version reaches 0.6.8 — a release-time bump orthogonal to
+    // this bug fix.
+    await init({ yes: true, force: true, pi: true, codex: true });
+
+    // `.agents/skills/` now holds the correct, neutral, current-version
+    // content (written by both Codex and current Pi in current code).
+    const neutralContent = readProjectFile(
+      ".agents/skills/trellis-update-spec/SKILL.md",
+    );
+
+    // Fabricate the pre-fix `.pi/skills/` leftover with Pi-flavored bytes
+    // (old pi.ts used resolveSkills(ctx), not resolveSkillsNeutral(ctx)).
+    const piCtx = AI_TOOLS.pi.templateContext;
+    const legacyPiSkillFiles = collectSkillTemplates(
+      ".pi/skills",
+      resolveSkills(piCtx),
+      resolveBundledSkills(piCtx),
+    );
+
+    const legacyContent = legacyPiSkillFiles.get(
+      ".pi/skills/trellis-update-spec/SKILL.md",
+    );
+    expect(legacyContent).toBeDefined();
+    // Sanity: the Pi-flavored bytes actually differ from the shared neutral
+    // bytes already on disk (otherwise this test wouldn't be exercising the
+    // reported bug at all).
+    expect(legacyContent).not.toBe(neutralContent);
+
+    const hashes = readHashesV2(hashFilePath());
+    for (const [relativePath, content] of legacyPiSkillFiles) {
+      writeProjectFile(relativePath, content);
+      hashes[relativePath] = computeHash(content);
+    }
+    writeHashesV2(hashFilePath(), hashes);
+
+    expect(fs.existsSync(projectFile(".pi/skills/trellis-update-spec"))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(projectFile(".agents/skills/trellis-update-spec")),
+    ).toBe(true);
+
+    // Build the current-version templates map for `.agents/skills/` the way
+    // both real writers (Codex, Pi) produce it — mirrors what update()'s
+    // collectTemplateFiles() would assemble for this project.
+    const codexCtx = AI_TOOLS.codex.templateContext;
+    const currentTemplates = new Map<string, string>([
+      ...collectSkillTemplates(
+        ".agents/skills",
+        resolveAllAsSkillsNeutral(codexCtx),
+        resolveBundledSkills(codexCtx),
+      ),
+      ...collectSkillTemplates(
+        ".agents/skills",
+        resolveSkillsNeutral(piCtx),
+        resolveBundledSkills(piCtx),
+      ),
+    ]);
+
+    const migrationItem = {
+      type: "rename-dir" as const,
+      from: ".pi/skills",
+      to: ".agents/skills",
+    };
+    const finalHashes = readHashesV2(hashFilePath());
+    const classified = classifyMigrations(
+      [migrationItem],
+      tmpDir,
+      finalHashes,
+      currentTemplates,
+    );
+
+    // The merged 0.6.8 migration must resolve this automatically — not
+    // punt to the user as an unresolved conflict.
+    expect(classified.conflict).toHaveLength(0);
+    expect(classified.auto).toHaveLength(1);
+
+    await executeMigrations(classified, tmpDir, { force: true, skipAll: false }, currentTemplates);
+
+    // No duplicate/leftover `.pi/skills/` directory should survive.
+    expect(fs.existsSync(projectFile(".pi/skills"))).toBe(false);
+
+    // `.agents/skills/` must end up with the correct, current, neutral
+    // content — not the stale Pi-flavored bytes from the deleted legacy dir.
+    expect(
+      readProjectFile(".agents/skills/trellis-update-spec/SKILL.md"),
+    ).toBe(neutralContent);
   });
 
   it("#2 dry run makes no file changes even when changes exist", async () => {

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -4012,6 +4012,18 @@ print(json.dumps({
     expect(py).not.toMatch(/_FALLBACK_BREADCRUMBS\s*=\s*\{/);
   });
 
+  it("[workflow-state-dispatch-mode-dedup] _codex_mode_banner and resolve_breadcrumb_key share one normalization helper", () => {
+    // _codex_mode_banner and resolve_breadcrumb_key both normalize
+    // codex.dispatch_mode to auto/inline (sub-agent alias, invalid → inline).
+    // That cascade must live in exactly one place so the two never drift.
+    const py = injectWorkflowStateScript ?? "";
+    expect(py).toContain("def _resolve_codex_dispatch_mode(");
+    const cascadeOccurrences = (
+      py.match(/elif cfg_mode in \("auto", "sub-agent"\):/g) ?? []
+    ).length;
+    expect(cascadeOccurrences).toBe(1);
+  });
+
   it("[workflow-state-r5] opencode inject-workflow-state.js contains no FALLBACK_BREADCRUMBS dict", () => {
     const jsURL = new URL(
       "../src/templates/opencode/plugins/inject-workflow-state.js",

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -5597,10 +5597,27 @@ print(len(entries))
     // No origin remote configured at all.
 
     const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
-    execSync(
-      `${pythonCmd} ${JSON.stringify(taskScriptPath)} create "no remote test" --slug no-remote-test --assignee test-dev --no-start`,
+    const result = spawnSync(
+      pythonCmd,
+      [
+        taskScriptPath,
+        "create",
+        "no remote test",
+        "--slug",
+        "no-remote-test",
+        "--assignee",
+        "test-dev",
+        "--no-start",
+      ],
       { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
     );
+
+    // #399 follow-up: silently falling back must now warn on stderr, naming
+    // the branch that got stamped.
+    expect(result.stderr).toContain(
+      "warning: could not resolve the repository's default branch",
+    );
+    expect(result.stderr).toContain("solo-branch");
 
     const taskDir = fs
       .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
@@ -5612,6 +5629,50 @@ print(len(entries))
       ),
     ) as { base_branch: string };
     expect(taskJson.base_branch).toBe("solo-branch");
+  });
+
+  it("[issue-399.1] task.py create --base-branch overrides both origin/HEAD detection and the fallback", () => {
+    setupTaskRepo();
+    execSync("git init -q -b solo-branch", { cwd: tmpDir });
+    execSync("git config user.email test@example.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -q -m init', { cwd: tmpDir });
+    // No origin remote configured at all — would otherwise fall back with a warning.
+
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const result = spawnSync(
+      pythonCmd,
+      [
+        taskScriptPath,
+        "create",
+        "explicit base branch test",
+        "--slug",
+        "explicit-base-branch-test",
+        "--assignee",
+        "test-dev",
+        "--base-branch",
+        "release/1.0",
+        "--no-start",
+      ],
+      { cwd: tmpDir, encoding: "utf-8", env: sessionEnv() },
+    );
+
+    expect(result.stderr).not.toContain(
+      "warning: could not resolve the repository's default branch",
+    );
+
+    const taskDir = fs
+      .readdirSync(path.join(tmpDir, ".trellis", "tasks"))
+      .find((d) => d.includes("explicit-base-branch-test"));
+    expect(taskDir).toBeDefined();
+    const taskJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "tasks", taskDir as string, "task.json"),
+        "utf-8",
+      ),
+    ) as { base_branch: string };
+    expect(taskJson.base_branch).toBe("release/1.0");
   });
 
   it("[issue-399.2] task.py validate warns when the recorded branch no longer exists locally", () => {

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -115,6 +115,16 @@ describe("codex getConfigTemplate", () => {
     const config = getConfigTemplate();
     expect(config.content).not.toMatch(/^\[features\.multi_agent_v2\]/m);
   });
+
+  // #445 removed the per-agent `[features] multi_agent = false` guard (the
+  // #240/#241 wait_agent-deadlock structural fix), relying on Codex's default
+  // `agents.max_depth = 1`. That key is global/user-level, not settable inside
+  // an individual agent's .toml, so pin it here in the project config Trellis
+  // owns — this is the config surface that outranks a user's global override.
+  it("pins agents.max_depth = 1 to guard against recursion reopening (#240, #241, #445)", () => {
+    const config = getConfigTemplate();
+    expect(config.content).toMatch(/^\[agents\]\s*\nmax_depth = 1/m);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Follow-ups from today's post-merge code review.

**#447 migration repair (verified by live repro):** with Pi + Codex coexisting, the 0.6.8 `rename-dir` migration classified as conflict and left the duplicate `.pi/skills/` behind; forcing it would overwrite canonical neutral `.agents/skills/` content with stale Pi-flavored bytes. `executeMigrations` now deletes the source dir (clearing hash entries) when the target already byte-matches current templates, instead of renaming over it. New integration test fails pre-fix / passes post-fix.

**Hardening/cleanups:**
- Pin `[agents] max_depth = 1` in the project `.codex/config.toml` (global-level key per Codex docs — cannot live in per-agent TOMLs); restores a structural recursion guard after #445 removed `multi_agent = false` (#240/#241 context).
- `task.py create`: warn on default-branch resolution failure instead of silently stamping the checked-out branch; new `--base-branch` override (#399).
- Extract duplicated dispatch-mode cascade inside `inject-workflow-state.py`.
- Channel spawn `--sandbox` value stays typed `CodexSandboxMode` end-to-end; removed the re-cast (#413).
- Shorten Pi's registry `name` to "Pi Agent"; cross-reader detail moved to a comment.

Verification: lint/typecheck clean; core 333, CLI 1419 — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--base-branch` to task creation, allowing users to explicitly choose the PR target branch.
  - Improved channel sandbox handling for more consistent execution behavior.
  - Added safeguards to prevent unwanted agent recursion.

- **Bug Fixes**
  - Task creation now warns when the default branch cannot be detected and safely falls back to the current branch.
  - Improved workflow status reporting for Codex dispatch modes.
  - Safer directory migrations preserve canonical files and remove redundant legacy directories.
  - Updated the Pi Agent display name for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->