### PR TITLE
ci: build before test so CLI integration tests find dist/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,13 @@ jobs:
       - name: Lint (core + cli)
         run: pnpm lint
 
-      - name: Test (core + cli)
-        run: pnpm test
-
+      # Build before test: integration tests spawn the real CLI via
+      # bin/trellis.js, which imports dist/ and needs build output to exist.
       - name: Build (core then cli)
         run: pnpm build
+
+      - name: Test (core + cli)
+        run: pnpm test
 
       - name: Verify build output
         run: |


### PR DESCRIPTION
## Summary
Main CI has been red since #448: the new `platforms.integration.test.ts` spawns the real CLI (`bin/trellis.js` → `import("../dist/cli/index.js")`), but CI runs `pnpm test` before `pnpm build`, so on a fresh checkout there is no `dist/` and the spawned CLI exits 1 — failing all three assertions (`:47/:65/:75`). Locally this never reproduces because a stale `dist/` exists.

## Fix
Reorder CI steps: build before test. Verify-build-output stays after build.

Failing runs: [#450 merge](https://github.com/mindfold-ai/Trellis/actions/runs/29727812362), [#452 merge](https://github.com/mindfold-ai/Trellis/actions/runs/29890233602).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to build the project before running tests.
  * Improved workflow guidance for integration tests that depend on built output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->