### PR TITLE
fix(cli): treat sub-agent context manifests as indexes with caps (#441)

### DIFF
--- a/.opencode/lib/trellis-context.js
+++ b/.opencode/lib/trellis-context.js
@@ -5,7 +5,7 @@
  * JSONL parsing, and context building capabilities.
  */
 
-import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync } from "fs"
 import { isAbsolute, join } from "path"
 import { platform } from "os"
 import { execSync } from "child_process"
@@ -15,6 +15,22 @@ import process from "process"
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
 // Debug logging
 const DEBUG_LOG = "/tmp/trellis-plugin-debug.log"
+
+// Context budget (keep in sync with inject-subagent-context.py / pi extension)
+const MAX_MANIFEST_ENTRIES = 50
+const MAX_DIR_LISTING_FILES = 20
+const MAX_ARTIFACT_CHARS = 20000
+const MAX_TOTAL_CONTEXT_CHARS = 60000
+
+// Header for the curated reference index: tells the sub-agent the listed
+// references are NOT inlined and must be read on demand.
+const REFERENCE_INDEX_HEADER = `## Curated Reference Index
+
+The references below were curated for this task. Their contents are NOT inlined here — read the files yourself with your file tools (Read/Glob/Grep) before relying on them.`
+
+function humanSize(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
 
 function debugLog(prefix, ...args) {
   const timestamp = new Date().toISOString()
@@ -279,44 +295,69 @@ export class TrellisContext {
   }
 
   // ============================================================
-  // JSONL Reading
+  // JSONL Reading (reference index — contents are never inlined)
   // ============================================================
 
-  readDirectoryMdFiles(dirPath, maxFiles = 20) {
-    const results = []
+  fileSizeLabel(filePath) {
+    try {
+      return humanSize(statSync(filePath).size)
+    } catch {
+      return "missing"
+    }
+  }
+
+  /**
+   * Read a task artifact, truncating at MAX_ARTIFACT_CHARS with a notice.
+   * `displayPath` is the path shown in the truncation notice.
+   */
+  readArtifact(filePath, displayPath) {
+    const content = this.readFile(filePath)
+    if (content && content.length > MAX_ARTIFACT_CHARS) {
+      return (
+        content.slice(0, MAX_ARTIFACT_CHARS) +
+        `\n\n... [truncated at ${MAX_ARTIFACT_CHARS} chars — read ${displayPath} for the full content]`
+      )
+    }
+    return content
+  }
+
+  /**
+   * List .md files in a directory with sizes (no contents).
+   * Returns { entries: [{ path, size }], omitted }.
+   */
+  listDirectoryMdFiles(dirPath, maxFiles = MAX_DIR_LISTING_FILES) {
+    const entries = []
+    let omitted = 0
     const fullPath = join(this.directory, dirPath)
 
     if (!existsSync(fullPath)) {
-      return results
+      return { entries, omitted }
     }
 
     try {
       const files = readdirSync(fullPath)
         .filter(f => f.endsWith(".md"))
         .sort()
-        .slice(0, maxFiles)
-
-      for (const filename of files) {
+      omitted = Math.max(0, files.length - maxFiles)
+      for (const filename of files.slice(0, maxFiles)) {
         const filePath = join(dirPath, filename)
-        const content = this.readProjectFile(filePath)
-        if (content) {
-          results.push({ path: filePath, content })
-        }
+        entries.push({ path: filePath, size: this.fileSizeLabel(join(this.directory, filePath)) })
       }
     } catch {
       // Ignore directory read errors
     }
 
-    return results
+    return { entries, omitted }
   }
 
   /**
-   * Read a JSONL file and load referenced files/directories
+   * Read a JSONL manifest as curated index entries (no file bodies)
    * Supports:
    *   {"file": "path/to/file.md", "reason": "..."}
    *   {"file": "path/to/dir/", "type": "directory", "reason": "..."}
+   * Returns: [{ path, type, reason }, ...]
    */
-  readJsonlWithFiles(jsonlPath) {
+  readJsonlEntries(jsonlPath) {
     const results = []
     const content = this.readFile(jsonlPath)
     if (!content) return results
@@ -326,20 +367,14 @@ export class TrellisContext {
       try {
         const item = JSON.parse(line)
         const file = item.file || item.path
-        const entryType = item.type || "file"
 
         if (!file) continue
 
-        if (entryType === "directory") {
-          const dirEntries = this.readDirectoryMdFiles(file)
-          results.push(...dirEntries)
-        } else {
-          const fullPath = join(this.directory, file)
-          const fileContent = this.readFile(fullPath)
-          if (fileContent) {
-            results.push({ path: file, content: fileContent })
-          }
-        }
+        results.push({
+          path: file,
+          type: item.type || "file",
+          reason: typeof item.reason === "string" ? item.reason : "",
+        })
       } catch {
         // Ignore parse errors for individual lines
       }
@@ -347,8 +382,64 @@ export class TrellisContext {
     return results
   }
 
-  buildContextFromEntries(entries) {
-    return entries.map(e => `=== ${e.path} ===\n${e.content}`).join("\n\n")
+  /**
+   * Render a JSONL manifest as a reference index: path + reason + file
+   * metadata per entry (size for files, a capped .md listing for
+   * directories). Referenced contents are never inlined.
+   */
+  buildReferenceIndex(jsonlPath, jsonlName) {
+    const entries = this.readJsonlEntries(jsonlPath)
+    if (entries.length === 0) return ""
+
+    const lines = [REFERENCE_INDEX_HEADER, ""]
+    for (const entry of entries.slice(0, MAX_MANIFEST_ENTRIES)) {
+      const suffix = entry.reason ? ` — ${entry.reason}` : ""
+      if (entry.type === "directory") {
+        lines.push(`- ${entry.path} (directory)${suffix}`)
+        const { entries: dirEntries, omitted } = this.listDirectoryMdFiles(entry.path)
+        for (const dirEntry of dirEntries) {
+          lines.push(`  - ${dirEntry.path} (${dirEntry.size})`)
+        }
+        if (omitted > 0) {
+          lines.push(`  - ... [${omitted} more files omitted]`)
+        }
+      } else {
+        const size = this.fileSizeLabel(join(this.directory, entry.path))
+        lines.push(`- ${entry.path} (${size})${suffix}`)
+      }
+    }
+
+    const omittedEntries = entries.length - MAX_MANIFEST_ENTRIES
+    if (omittedEntries > 0) {
+      lines.push(
+        `... [${omittedEntries} more curated entries omitted — read ${jsonlName} for the full list]`
+      )
+    }
+
+    return lines.join("\n")
+  }
+
+  /**
+   * Join context sections, enforcing the aggregate MAX_TOTAL_CONTEXT_CHARS
+   * budget. Sections that would overflow the budget are dropped and
+   * reported with an explicit omission notice.
+   */
+  joinContextParts(parts) {
+    let result = ""
+    let omitted = 0
+    for (const part of parts) {
+      if (!part) continue
+      const candidate = result ? `${result}\n\n${part}` : part
+      if (candidate.length > MAX_TOTAL_CONTEXT_CHARS) {
+        omitted += 1
+        continue
+      }
+      result = candidate
+    }
+    if (omitted > 0) {
+      result += `\n\n... [${omitted} section(s) omitted — total context cap of ${MAX_TOTAL_CONTEXT_CHARS} chars reached; read the referenced files directly]`
+    }
+    return result
   }
 }
 

--- a/.opencode/plugins/inject-subagent-context.js
+++ b/.opencode/plugins/inject-subagent-context.js
@@ -28,35 +28,36 @@ function extractActiveTaskHint(prompt) {
 /**
  * Get context for implement agent. `taskDir` may be relative
  * (`.trellis/tasks/foo`) or absolute; both are resolved via
- * `ctx.resolveTaskDir`.
+ * `ctx.resolveTaskDir`. The jsonl manifest is rendered as a reference
+ * index (path + reason + metadata); task artifacts are inlined with
+ * per-file truncation and an aggregate budget.
  */
 function getImplementContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
-  const jsonlPath = join(taskDirFull, "implement.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const index = ctx.buildReferenceIndex(join(taskDirFull, "implement.jsonl"), "implement.jsonl")
+  if (index) {
+    parts.push(index)
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
+  const prd = ctx.readArtifact(join(taskDirFull, "prd.md"), `${taskDir}/prd.md`)
   if (prd) {
     parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
   }
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
+  const design = ctx.readArtifact(join(taskDirFull, "design.md"), `${taskDir}/design.md`)
   if (design) {
     parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
   }
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
+  const implementPlan = ctx.readArtifact(join(taskDirFull, "implement.md"), `${taskDir}/implement.md`)
   if (implementPlan) {
     parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
   }
 
-  return parts.join("\n\n")
+  return ctx.joinContextParts(parts)
 }
 
 /**
@@ -67,28 +68,27 @@ function getCheckContext(ctx, taskDir) {
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
-  const jsonlPath = join(taskDirFull, "check.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const index = ctx.buildReferenceIndex(join(taskDirFull, "check.jsonl"), "check.jsonl")
+  if (index) {
+    parts.push(index)
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
+  const prd = ctx.readArtifact(join(taskDirFull, "prd.md"), `${taskDir}/prd.md`)
   if (prd) {
     parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
   }
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
+  const design = ctx.readArtifact(join(taskDirFull, "design.md"), `${taskDir}/design.md`)
   if (design) {
     parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
   }
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
+  const implementPlan = ctx.readArtifact(join(taskDirFull, "implement.md"), `${taskDir}/implement.md`)
   if (implementPlan) {
     parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
   }
 
-  return parts.join("\n\n")
+  return ctx.joinContextParts(parts)
 }
 
 /**
@@ -179,7 +179,7 @@ ${originalPrompt}
 
 ## Workflow
 
-1. **Understand specs** - All dev specs are injected above
+1. **Understand specs** - Read the curated references listed in the index above
 2. **Understand task artifacts** - Read requirements, technical design if present, and execution plan if present
 3. **Implement feature** - Follow specs and task artifacts
 4. **Self-check** - Ensure code quality
@@ -187,7 +187,7 @@ ${originalPrompt}
 ## Important Constraints
 
 - Do NOT execute git commit
-- Follow all dev specs injected above
+- Follow all dev specs referenced above
 - Report list of modified/created files when done`,
 
     check: isFinish ? `<!-- trellis-hook-injected -->
@@ -246,7 +246,7 @@ ${originalPrompt}
 ## Workflow
 
 1. **Get changes** - Run \`git diff --name-only\` and \`git diff\`
-2. **Check against specs** - Check item by item
+2. **Check against specs** - Read the curated references in the index above, then check item by item
 3. **Self-fix** - Fix issues directly, don't just report
 4. **Run verification** - Run lint and typecheck
 

--- a/packages/cli/src/templates/opencode/lib/trellis-context.js
+++ b/packages/cli/src/templates/opencode/lib/trellis-context.js
@@ -5,7 +5,7 @@
  * JSONL parsing, and context building capabilities.
  */
 
-import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync } from "fs"
 import { isAbsolute, join } from "path"
 import { platform } from "os"
 import { execSync } from "child_process"
@@ -15,6 +15,22 @@ import process from "process"
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
 // Debug logging
 const DEBUG_LOG = "/tmp/trellis-plugin-debug.log"
+
+// Context budget (keep in sync with inject-subagent-context.py / pi extension)
+const MAX_MANIFEST_ENTRIES = 50
+const MAX_DIR_LISTING_FILES = 20
+const MAX_ARTIFACT_CHARS = 20000
+const MAX_TOTAL_CONTEXT_CHARS = 60000
+
+// Header for the curated reference index: tells the sub-agent the listed
+// references are NOT inlined and must be read on demand.
+const REFERENCE_INDEX_HEADER = `## Curated Reference Index
+
+The references below were curated for this task. Their contents are NOT inlined here — read the files yourself with your file tools (Read/Glob/Grep) before relying on them.`
+
+function humanSize(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
 
 function debugLog(prefix, ...args) {
   const timestamp = new Date().toISOString()
@@ -279,44 +295,69 @@ export class TrellisContext {
   }
 
   // ============================================================
-  // JSONL Reading
+  // JSONL Reading (reference index — contents are never inlined)
   // ============================================================
 
-  readDirectoryMdFiles(dirPath, maxFiles = 20) {
-    const results = []
+  fileSizeLabel(filePath) {
+    try {
+      return humanSize(statSync(filePath).size)
+    } catch {
+      return "missing"
+    }
+  }
+
+  /**
+   * Read a task artifact, truncating at MAX_ARTIFACT_CHARS with a notice.
+   * `displayPath` is the path shown in the truncation notice.
+   */
+  readArtifact(filePath, displayPath) {
+    const content = this.readFile(filePath)
+    if (content && content.length > MAX_ARTIFACT_CHARS) {
+      return (
+        content.slice(0, MAX_ARTIFACT_CHARS) +
+        `\n\n... [truncated at ${MAX_ARTIFACT_CHARS} chars — read ${displayPath} for the full content]`
+      )
+    }
+    return content
+  }
+
+  /**
+   * List .md files in a directory with sizes (no contents).
+   * Returns { entries: [{ path, size }], omitted }.
+   */
+  listDirectoryMdFiles(dirPath, maxFiles = MAX_DIR_LISTING_FILES) {
+    const entries = []
+    let omitted = 0
     const fullPath = join(this.directory, dirPath)
 
     if (!existsSync(fullPath)) {
-      return results
+      return { entries, omitted }
     }
 
     try {
       const files = readdirSync(fullPath)
         .filter(f => f.endsWith(".md"))
         .sort()
-        .slice(0, maxFiles)
-
-      for (const filename of files) {
+      omitted = Math.max(0, files.length - maxFiles)
+      for (const filename of files.slice(0, maxFiles)) {
         const filePath = join(dirPath, filename)
-        const content = this.readProjectFile(filePath)
-        if (content) {
-          results.push({ path: filePath, content })
-        }
+        entries.push({ path: filePath, size: this.fileSizeLabel(join(this.directory, filePath)) })
       }
     } catch {
       // Ignore directory read errors
     }
 
-    return results
+    return { entries, omitted }
   }
 
   /**
-   * Read a JSONL file and load referenced files/directories
+   * Read a JSONL manifest as curated index entries (no file bodies)
    * Supports:
    *   {"file": "path/to/file.md", "reason": "..."}
    *   {"file": "path/to/dir/", "type": "directory", "reason": "..."}
+   * Returns: [{ path, type, reason }, ...]
    */
-  readJsonlWithFiles(jsonlPath) {
+  readJsonlEntries(jsonlPath) {
     const results = []
     const content = this.readFile(jsonlPath)
     if (!content) return results
@@ -326,20 +367,14 @@ export class TrellisContext {
       try {
         const item = JSON.parse(line)
         const file = item.file || item.path
-        const entryType = item.type || "file"
 
         if (!file) continue
 
-        if (entryType === "directory") {
-          const dirEntries = this.readDirectoryMdFiles(file)
-          results.push(...dirEntries)
-        } else {
-          const fullPath = join(this.directory, file)
-          const fileContent = this.readFile(fullPath)
-          if (fileContent) {
-            results.push({ path: file, content: fileContent })
-          }
-        }
+        results.push({
+          path: file,
+          type: item.type || "file",
+          reason: typeof item.reason === "string" ? item.reason : "",
+        })
       } catch {
         // Ignore parse errors for individual lines
       }
@@ -347,8 +382,64 @@ export class TrellisContext {
     return results
   }
 
-  buildContextFromEntries(entries) {
-    return entries.map(e => `=== ${e.path} ===\n${e.content}`).join("\n\n")
+  /**
+   * Render a JSONL manifest as a reference index: path + reason + file
+   * metadata per entry (size for files, a capped .md listing for
+   * directories). Referenced contents are never inlined.
+   */
+  buildReferenceIndex(jsonlPath, jsonlName) {
+    const entries = this.readJsonlEntries(jsonlPath)
+    if (entries.length === 0) return ""
+
+    const lines = [REFERENCE_INDEX_HEADER, ""]
+    for (const entry of entries.slice(0, MAX_MANIFEST_ENTRIES)) {
+      const suffix = entry.reason ? ` — ${entry.reason}` : ""
+      if (entry.type === "directory") {
+        lines.push(`- ${entry.path} (directory)${suffix}`)
+        const { entries: dirEntries, omitted } = this.listDirectoryMdFiles(entry.path)
+        for (const dirEntry of dirEntries) {
+          lines.push(`  - ${dirEntry.path} (${dirEntry.size})`)
+        }
+        if (omitted > 0) {
+          lines.push(`  - ... [${omitted} more files omitted]`)
+        }
+      } else {
+        const size = this.fileSizeLabel(join(this.directory, entry.path))
+        lines.push(`- ${entry.path} (${size})${suffix}`)
+      }
+    }
+
+    const omittedEntries = entries.length - MAX_MANIFEST_ENTRIES
+    if (omittedEntries > 0) {
+      lines.push(
+        `... [${omittedEntries} more curated entries omitted — read ${jsonlName} for the full list]`
+      )
+    }
+
+    return lines.join("\n")
+  }
+
+  /**
+   * Join context sections, enforcing the aggregate MAX_TOTAL_CONTEXT_CHARS
+   * budget. Sections that would overflow the budget are dropped and
+   * reported with an explicit omission notice.
+   */
+  joinContextParts(parts) {
+    let result = ""
+    let omitted = 0
+    for (const part of parts) {
+      if (!part) continue
+      const candidate = result ? `${result}\n\n${part}` : part
+      if (candidate.length > MAX_TOTAL_CONTEXT_CHARS) {
+        omitted += 1
+        continue
+      }
+      result = candidate
+    }
+    if (omitted > 0) {
+      result += `\n\n... [${omitted} section(s) omitted — total context cap of ${MAX_TOTAL_CONTEXT_CHARS} chars reached; read the referenced files directly]`
+    }
+    return result
   }
 }
 

--- a/packages/cli/src/templates/opencode/plugins/inject-subagent-context.js
+++ b/packages/cli/src/templates/opencode/plugins/inject-subagent-context.js
@@ -28,35 +28,36 @@ function extractActiveTaskHint(prompt) {
 /**
  * Get context for implement agent. `taskDir` may be relative
  * (`.trellis/tasks/foo`) or absolute; both are resolved via
- * `ctx.resolveTaskDir`.
+ * `ctx.resolveTaskDir`. The jsonl manifest is rendered as a reference
+ * index (path + reason + metadata); task artifacts are inlined with
+ * per-file truncation and an aggregate budget.
  */
 function getImplementContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
-  const jsonlPath = join(taskDirFull, "implement.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const index = ctx.buildReferenceIndex(join(taskDirFull, "implement.jsonl"), "implement.jsonl")
+  if (index) {
+    parts.push(index)
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
+  const prd = ctx.readArtifact(join(taskDirFull, "prd.md"), `${taskDir}/prd.md`)
   if (prd) {
     parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
   }
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
+  const design = ctx.readArtifact(join(taskDirFull, "design.md"), `${taskDir}/design.md`)
   if (design) {
     parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
   }
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
+  const implementPlan = ctx.readArtifact(join(taskDirFull, "implement.md"), `${taskDir}/implement.md`)
   if (implementPlan) {
     parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
   }
 
-  return parts.join("\n\n")
+  return ctx.joinContextParts(parts)
 }
 
 /**
@@ -67,28 +68,27 @@ function getCheckContext(ctx, taskDir) {
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
-  const jsonlPath = join(taskDirFull, "check.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const index = ctx.buildReferenceIndex(join(taskDirFull, "check.jsonl"), "check.jsonl")
+  if (index) {
+    parts.push(index)
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
+  const prd = ctx.readArtifact(join(taskDirFull, "prd.md"), `${taskDir}/prd.md`)
   if (prd) {
     parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
   }
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
+  const design = ctx.readArtifact(join(taskDirFull, "design.md"), `${taskDir}/design.md`)
   if (design) {
     parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
   }
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
+  const implementPlan = ctx.readArtifact(join(taskDirFull, "implement.md"), `${taskDir}/implement.md`)
   if (implementPlan) {
     parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
   }
 
-  return parts.join("\n\n")
+  return ctx.joinContextParts(parts)
 }
 
 /**
@@ -179,7 +179,7 @@ ${originalPrompt}
 
 ## Workflow
 
-1. **Understand specs** - All dev specs are injected above
+1. **Understand specs** - Read the curated references listed in the index above
 2. **Understand task artifacts** - Read requirements, technical design if present, and execution plan if present
 3. **Implement feature** - Follow specs and task artifacts
 4. **Self-check** - Ensure code quality
@@ -187,7 +187,7 @@ ${originalPrompt}
 ## Important Constraints
 
 - Do NOT execute git commit
-- Follow all dev specs injected above
+- Follow all dev specs referenced above
 - Report list of modified/created files when done`,
 
     check: isFinish ? `<!-- trellis-hook-injected -->
@@ -246,7 +246,7 @@ ${originalPrompt}
 ## Workflow
 
 1. **Get changes** - Run \`git diff --name-only\` and \`git diff\`
-2. **Check against specs** - Check item by item
+2. **Check against specs** - Read the curated references in the index above, then check item by item
 3. **Self-fix** - Fix issues directly, don't just report
 4. **Run verification** - Run lint and typecheck
 

--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -80,6 +80,11 @@ const MAX_LINE_BUFFER = 1024 * 1024;
 const MAX_TOOL_ARG_CHARS = 2048;
 const MAX_TOOLS = 256;
 const MAX_PARALLEL_PROMPTS = 6;
+// Context budget — identical caps across the Python hook, Pi, and OpenCode implementations
+const MAX_MANIFEST_ENTRIES = 50;
+const MAX_DIR_LISTING_FILES = 20;
+const MAX_ARTIFACT_CHARS = 20000;
+const MAX_TOTAL_CONTEXT_CHARS = 60000;
 const ABORT_KILL_GRACE_MS = 1500;
 const SESSION_OVERVIEW_TIMEOUT_MS = 1500;
 const THROTTLE_MS = 500;
@@ -938,6 +943,111 @@ function buildStartupContext(
     .join("\n\n");
 }
 
+function humanSize(bytes: number): string {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function fileSizeLabel(p: string): string {
+  try {
+    return humanSize(statSync(p).size);
+  } catch {
+    return "missing";
+  }
+}
+
+function truncateArtifact(text: string, displayPath: string): string {
+  if (text.length <= MAX_ARTIFACT_CHARS) return text;
+  return (
+    text.slice(0, MAX_ARTIFACT_CHARS) +
+    `\n\n... [truncated at ${MAX_ARTIFACT_CHARS} chars — read ${displayPath} for the full content]`
+  );
+}
+
+function joinContextParts(parts: string[]): string {
+  let result = "";
+  let omitted = 0;
+  for (const part of parts) {
+    if (!part) continue;
+    const candidate = result ? `${result}\n\n${part}` : part;
+    if (candidate.length > MAX_TOTAL_CONTEXT_CHARS) {
+      omitted += 1;
+      continue;
+    }
+    result = candidate;
+  }
+  if (omitted)
+    result += `\n\n... [${omitted} section(s) omitted — total context cap of ${MAX_TOTAL_CONTEXT_CHARS} chars reached; read the referenced files directly]`;
+  return result;
+}
+
+/**
+ * Render a curated jsonl manifest as a reference index: path + reason +
+ * file metadata per entry (size for files, a capped .md listing for
+ * directories). Referenced contents are never inlined — the sub-agent
+ * reads them itself.
+ */
+function buildReferenceIndex(
+  root: string,
+  dir: string,
+  jsonlName: string,
+): string {
+  const rows: { file: string; type: string; reason: string }[] = [];
+  for (const line of readText(join(dir, jsonlName)).split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const r = JSON.parse(t) as JsonObject;
+      const f =
+        typeof r.file === "string"
+          ? r.file
+          : typeof r.path === "string"
+            ? r.path
+            : "";
+      if (!f) continue;
+      rows.push({
+        file: f,
+        type: typeof r.type === "string" ? r.type : "file",
+        reason: typeof r.reason === "string" ? r.reason : "",
+      });
+    } catch {}
+  }
+  if (!rows.length) return "";
+
+  const lines = [
+    "### Curated Reference Index",
+    "",
+    "These references were curated for this task. Their contents are NOT inlined — read them yourself with your file tools before relying on them.",
+    "",
+  ];
+  for (const row of rows.slice(0, MAX_MANIFEST_ENTRIES)) {
+    const suffix = row.reason ? ` — ${row.reason}` : "";
+    if (row.type === "directory") {
+      lines.push(`- ${row.file} (directory)${suffix}`);
+      let names: string[] = [];
+      try {
+        names = readdirSync(join(root, row.file))
+          .filter((n) => n.endsWith(".md"))
+          .sort();
+      } catch {}
+      for (const name of names.slice(0, MAX_DIR_LISTING_FILES)) {
+        const p = `${row.file.replace(/\/+$/, "")}/${name}`;
+        lines.push(`  - ${p} (${fileSizeLabel(join(root, p))})`);
+      }
+      if (names.length > MAX_DIR_LISTING_FILES)
+        lines.push(
+          `  - ... [${names.length - MAX_DIR_LISTING_FILES} more files omitted]`,
+        );
+    } else {
+      lines.push(`- ${row.file} (${fileSizeLabel(join(root, row.file))})${suffix}`);
+    }
+  }
+  if (rows.length > MAX_MANIFEST_ENTRIES)
+    lines.push(
+      `... [${rows.length - MAX_MANIFEST_ENTRIES} more curated entries omitted — read ${jsonlName} for the full list]`,
+    );
+  return lines.join("\n");
+}
+
 function buildContext(root: string, agent: string, key: string | null): string {
   const dir = readTaskDir(root, key);
   if (!dir)
@@ -946,32 +1056,22 @@ function buildContext(root: string, agent: string, key: string | null): string {
   const design = readText(join(dir, "design.md"));
   const impl = readText(join(dir, "implement.md"));
   const jsonlName = TRELLIS_AGENT_JSONL[agent] ?? "";
-  let spec = "";
-  if (jsonlName) {
-    const chunks: string[] = [];
-    for (const line of readText(join(dir, jsonlName)).split(/\r?\n/)) {
-      const t = line.trim();
-      if (!t) continue;
-      try {
-        const r = JSON.parse(t) as JsonObject;
-        const f = typeof r.file === "string" ? r.file : "";
-        if (f) {
-          const c = readText(join(root, f));
-          if (c) chunks.push(`## ${f}\n\n${c}`);
-        }
-      } catch {}
-    }
-    spec = chunks.join("\n\n---\n\n");
-  }
+  const spec = jsonlName ? buildReferenceIndex(root, dir, jsonlName) : "";
+  const parts = [
+    "### prd.md\n" + (prd ? truncateArtifact(prd, `${dir}/prd.md`) : "(missing)"),
+  ];
+  if (design)
+    parts.push("### design.md\n" + truncateArtifact(design, `${dir}/design.md`));
+  if (impl)
+    parts.push(
+      "### implement.md\n" + truncateArtifact(impl, `${dir}/implement.md`),
+    );
+  if (spec) parts.push(spec);
   return [
     `## Trellis Task Context`,
     `Task directory: ${dir}`,
     "",
-    "### prd.md",
-    prd || "(missing)",
-    design ? "\n### design.md\n" + design : "",
-    impl ? "\n### implement.md\n" + impl : "",
-    spec ? "\n### Curated Spec / Research Context\n" + spec : "",
+    joinContextParts(parts),
   ].join("\n");
 }
 

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -6,8 +6,12 @@ Multi-Platform Sub-Agent Context Injection Hook
 Injects task-specific context when sub-agents (implement, check, research) are spawned.
 
 Core Design Philosophy:
-- Hook is responsible for injecting all context, subagent works autonomously with complete info
-- Each agent has a dedicated jsonl file defining its context
+- Hook injects a bounded context payload: task artifacts (prd.md/design.md/
+  implement.md) are inlined with per-file truncation, while jsonl manifests
+  act as INDEXES — each curated entry is rendered as path + reason + file
+  metadata so the sub-agent reads the referenced files itself with its own
+  file tools before relying on them
+- Each agent has a dedicated jsonl file defining its context manifest
 - No resume needed, no segmentation, behavior controlled by code not prompt
 
 Trigger: PreToolUse (before Task tool call)
@@ -62,6 +66,28 @@ AGENT_RESEARCH = "trellis-research"
 AGENTS_REQUIRE_TASK = (AGENT_IMPLEMENT, AGENT_CHECK)
 # All supported agents
 AGENTS_ALL = (AGENT_IMPLEMENT, AGENT_CHECK, AGENT_RESEARCH)
+
+# =============================================================================
+# Context Budget Constants (keep in sync with the pi / opencode implementations)
+# =============================================================================
+
+# Max curated jsonl manifest entries rendered into the reference index
+MAX_MANIFEST_ENTRIES = 50
+# Max .md files listed per directory-type manifest entry
+MAX_DIR_LISTING_FILES = 20
+# Max chars inlined per task artifact (prd.md / design.md / implement.md)
+MAX_ARTIFACT_CHARS = 20000
+# Max chars of the aggregate injected context payload
+MAX_TOTAL_CONTEXT_CHARS = 60000
+
+# Header for the curated reference index: tells the sub-agent the listed
+# references are NOT inlined and must be read on demand.
+REFERENCE_INDEX_HEADER = (
+    "## Curated Reference Index\n\n"
+    "The references below were curated for this task. Their contents are NOT "
+    "inlined here — read the files yourself with your file tools "
+    "(Read/Glob/Grep) before relying on them."
+)
 
 
 def find_repo_root(start_path: str) -> str | None:
@@ -160,27 +186,54 @@ def read_file_content(base_path: str, file_path: str) -> str | None:
     return None
 
 
-def read_directory_contents(
-    base_path: str, dir_path: str, max_files: int = 20
-) -> list[tuple[str, str]]:
+def read_artifact_content(base_path: str, file_path: str) -> str | None:
+    """Read a task artifact, truncating at MAX_ARTIFACT_CHARS with a notice."""
+    content = read_file_content(base_path, file_path)
+    if content and len(content) > MAX_ARTIFACT_CHARS:
+        content = (
+            content[:MAX_ARTIFACT_CHARS]
+            + f"\n\n... [truncated at {MAX_ARTIFACT_CHARS} chars — "
+            f"read {file_path} for the full content]"
+        )
+    return content
+
+
+def _human_size(size_bytes: int) -> str:
+    """Human-readable file size in KB."""
+    return f"{size_bytes / 1024:.1f} KB"
+
+
+def _file_size_label(base_path: str, file_path: str) -> str:
+    """Human-readable size for a file, or 'missing' when it does not exist."""
+    full_path = os.path.join(base_path, file_path)
+    try:
+        return _human_size(os.path.getsize(full_path))
+    except OSError:
+        return "missing"
+
+
+def list_directory_md_files(
+    base_path: str, dir_path: str, max_files: int = MAX_DIR_LISTING_FILES
+) -> tuple[list[tuple[str, str]], int]:
     """
-    Read all .md files in a directory
+    List .md files in a directory with sizes (no contents)
 
     Args:
         base_path: Base path (usually repo_root)
         dir_path: Directory relative path
-        max_files: Max files to read (prevent huge directories)
+        max_files: Max files to list (prevent huge directories)
 
     Returns:
-        [(file_path, content), ...]
+        ([(file_path, size_label), ...], omitted_count)
     """
     full_path = os.path.join(base_path, dir_path)
     if not os.path.exists(full_path) or not os.path.isdir(full_path):
-        return []
+        return [], 0
 
     results = []
+    omitted = 0
     try:
-        # Only read .md files, sorted by filename
+        # Only list .md files, sorted by filename
         md_files = sorted(
             [
                 f
@@ -188,25 +241,19 @@ def read_directory_contents(
                 if f.endswith(".md") and os.path.isfile(os.path.join(full_path, f))
             ]
         )
-
+        omitted = max(0, len(md_files) - max_files)
         for filename in md_files[:max_files]:
-            file_full_path = os.path.join(full_path, filename)
             relative_path = os.path.join(dir_path, filename)
-            try:
-                with open(file_full_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-                    results.append((relative_path, content))
-            except Exception:
-                continue
+            results.append((relative_path, _file_size_label(base_path, relative_path)))
     except Exception:
         pass
 
-    return results
+    return results, omitted
 
 
-def read_jsonl_entries(base_path: str, jsonl_path: str) -> list[tuple[str, str]]:
+def read_jsonl_entries(base_path: str, jsonl_path: str) -> list[dict[str, str]]:
     """
-    Read all file/directory contents referenced in jsonl file
+    Read curated entries from a jsonl manifest as an INDEX (no file bodies)
 
     Schema:
         {"file": "path/to/file.md", "reason": "..."}
@@ -219,7 +266,7 @@ def read_jsonl_entries(base_path: str, jsonl_path: str) -> list[tuple[str, str]]
     emitted so the operator can debug missing context.
 
     Returns:
-        [(path, content), ...]
+        [{"path": ..., "type": "file"|"directory", "reason": ...}, ...]
     """
     full_path = os.path.join(base_path, jsonl_path)
     if not os.path.exists(full_path):
@@ -241,22 +288,19 @@ def read_jsonl_entries(base_path: str, jsonl_path: str) -> list[tuple[str, str]]
                 try:
                     item = json.loads(line)
                     file_path = item.get("file") or item.get("path")
-                    entry_type = item.get("type", "file")
 
                     if not file_path:
                         # Seed / comment row — skip silently
                         continue
 
                     saw_real_entry = True
-                    if entry_type == "directory":
-                        # Read all .md files in directory
-                        dir_contents = read_directory_contents(base_path, file_path)
-                        results.extend(dir_contents)
-                    else:
-                        # Read single file
-                        content = read_file_content(base_path, file_path)
-                        if content:
-                            results.append((file_path, content))
+                    results.append(
+                        {
+                            "path": file_path,
+                            "type": item.get("type", "file"),
+                            "reason": item.get("reason", "") or "",
+                        }
+                    )
                 except json.JSONDecodeError:
                     continue
     except Exception:
@@ -273,20 +317,74 @@ def read_jsonl_entries(base_path: str, jsonl_path: str) -> list[tuple[str, str]]
     return results
 
 
+def build_reference_index(base_path: str, jsonl_path: str) -> str:
+    """
+    Render a jsonl manifest as a reference index: each curated entry becomes
+    a line with path + reason + file metadata (size for files, a capped .md
+    listing for directories). Referenced contents are never inlined.
+    """
+    entries = read_jsonl_entries(base_path, jsonl_path)
+    if not entries:
+        return ""
+
+    lines = [REFERENCE_INDEX_HEADER, ""]
+    for entry in entries[:MAX_MANIFEST_ENTRIES]:
+        entry_path = entry["path"]
+        suffix = f" — {entry['reason']}" if entry["reason"] else ""
+        if entry["type"] == "directory":
+            lines.append(f"- {entry_path} (directory){suffix}")
+            dir_listing, dir_omitted = list_directory_md_files(base_path, entry_path)
+            for file_path, size_label in dir_listing:
+                lines.append(f"  - {file_path} ({size_label})")
+            if dir_omitted:
+                lines.append(f"  - ... [{dir_omitted} more files omitted]")
+        else:
+            size_label = _file_size_label(base_path, entry_path)
+            lines.append(f"- {entry_path} ({size_label}){suffix}")
+
+    omitted = len(entries) - MAX_MANIFEST_ENTRIES
+    if omitted > 0:
+        lines.append(
+            f"... [{omitted} more curated entries omitted — "
+            f"read {jsonl_path} for the full list]"
+        )
+
+    return "\n".join(lines)
+
+
+def join_context_parts(context_parts: list[str]) -> str:
+    """
+    Join context sections, enforcing the aggregate MAX_TOTAL_CONTEXT_CHARS
+    budget. Sections that would overflow the budget are dropped and reported
+    with an explicit omission notice.
+    """
+    result = ""
+    omitted = 0
+    for part in context_parts:
+        candidate = part if not result else f"{result}\n\n{part}"
+        if len(candidate) > MAX_TOTAL_CONTEXT_CHARS:
+            omitted += 1
+            continue
+        result = candidate
+
+    if omitted:
+        result += (
+            f"\n\n... [{omitted} section(s) omitted — total context cap of "
+            f"{MAX_TOTAL_CONTEXT_CHARS} chars reached; "
+            f"read the referenced files directly]"
+        )
+    return result
+
+
 
 
 def get_agent_context(repo_root: str, task_dir: str, agent_type: str) -> str:
     """
     Get context from {agent_type}.jsonl for the specified agent.
     Only reads implement.jsonl or check.jsonl (the two JSONL files the task system creates).
+    The manifest is rendered as a reference index, not inlined file bodies.
     """
-    context_parts = []
-
-    agent_jsonl = f"{task_dir}/{agent_type}.jsonl"
-    for file_path, content in read_jsonl_entries(repo_root, agent_jsonl):
-        context_parts.append(f"=== {file_path} ===\n{content}")
-
-    return "\n\n".join(context_parts)
+    return build_reference_index(repo_root, f"{task_dir}/{agent_type}.jsonl")
 
 
 def get_implement_context(repo_root: str, task_dir: str) -> str:
@@ -294,66 +392,67 @@ def get_implement_context(repo_root: str, task_dir: str) -> str:
     Complete context for Implement Agent
 
     Read order:
-    1. All files in implement.jsonl (spec/research manifests)
+    1. Reference index from implement.jsonl (spec/research manifests)
     2. prd.md (requirements)
     3. design.md if present (technical design)
     4. implement.md if present (execution plan)
     """
     context_parts = []
 
-    # 1. Read implement.jsonl
+    # 1. Read implement.jsonl as a reference index
     base_context = get_agent_context(repo_root, task_dir, "implement")
     if base_context:
         context_parts.append(base_context)
 
     # 2. Requirements document
-    prd_content = read_file_content(repo_root, f"{task_dir}/prd.md")
+    prd_content = read_artifact_content(repo_root, f"{task_dir}/prd.md")
     if prd_content:
         context_parts.append(f"=== {task_dir}/prd.md (Requirements) ===\n{prd_content}")
 
     # 3. Technical design for complex tasks
-    design_content = read_file_content(repo_root, f"{task_dir}/design.md")
+    design_content = read_artifact_content(repo_root, f"{task_dir}/design.md")
     if design_content:
         context_parts.append(
             f"=== {task_dir}/design.md (Technical Design) ===\n{design_content}"
         )
 
     # 4. Execution plan for complex tasks
-    implement_plan_content = read_file_content(repo_root, f"{task_dir}/implement.md")
+    implement_plan_content = read_artifact_content(repo_root, f"{task_dir}/implement.md")
     if implement_plan_content:
         context_parts.append(
             f"=== {task_dir}/implement.md (Execution Plan) ===\n{implement_plan_content}"
         )
 
-    return "\n\n".join(context_parts)
+    return join_context_parts(context_parts)
 
 
 def get_check_context(repo_root: str, task_dir: str) -> str:
     """
-    Context for Check Agent: check.jsonl + task artifacts.
+    Context for Check Agent: check.jsonl reference index + task artifacts.
     """
     context_parts = []
 
-    for file_path, content in read_jsonl_entries(repo_root, f"{task_dir}/check.jsonl"):
-        context_parts.append(f"=== {file_path} ===\n{content}")
+    index = build_reference_index(repo_root, f"{task_dir}/check.jsonl")
+    if index:
+        context_parts.append(index)
 
-    prd_content = read_file_content(repo_root, f"{task_dir}/prd.md")
+    prd_content = read_artifact_content(repo_root, f"{task_dir}/prd.md")
     if prd_content:
         context_parts.append(f"=== {task_dir}/prd.md (Requirements) ===\n{prd_content}")
 
-    design_content = read_file_content(repo_root, f"{task_dir}/design.md")
+    design_content = read_artifact_content(repo_root, f"{task_dir}/design.md")
     if design_content:
         context_parts.append(
             f"=== {task_dir}/design.md (Technical Design) ===\n{design_content}"
         )
 
-    implement_plan_content = read_file_content(repo_root, f"{task_dir}/implement.md")
+    implement_plan_content = read_artifact_content(repo_root, f"{task_dir}/implement.md")
     if implement_plan_content:
         context_parts.append(
             f"=== {task_dir}/implement.md (Execution Plan) ===\n{implement_plan_content}"
         )
 
-    return "\n\n".join(context_parts)
+    return join_context_parts(context_parts)
 
 
 def get_finish_context(repo_root: str, task_dir: str) -> str:
@@ -374,7 +473,7 @@ You are the Implement Agent in the Multi-Agent Pipeline.
 
 ## Your Context
 
-All the information you need has been prepared for you:
+Task artifacts are inlined below (truncated when large); curated references are listed as an index — read them yourself before relying on them:
 
 {context}
 
@@ -388,7 +487,7 @@ All the information you need has been prepared for you:
 
 ## Workflow
 
-1. **Understand specs** - All dev specs are injected above, understand them
+1. **Understand specs** - Read the curated references listed in the index above
     2. **Understand task artifacts** - Read requirements, technical design if present, and execution plan if present
     3. **Implement feature** - Implement following specs and task artifacts
 4. **Self-check** - Ensure code quality against check specs
@@ -396,7 +495,7 @@ All the information you need has been prepared for you:
 ## Important Constraints
 
 - Do NOT execute git commit, only code modifications
-- Follow all dev specs injected above
+- Follow all dev specs referenced above
 - Report list of modified/created files when done"""
 
 
@@ -409,7 +508,7 @@ You are the Check Agent in the Multi-Agent Pipeline (code and cross-layer checke
 
 ## Your Context
 
-All check specs and dev specs you need:
+Task artifacts are inlined below (truncated when large); curated check/dev specs are listed as an index — read them yourself before relying on them:
 
 {context}
 
@@ -424,7 +523,7 @@ All check specs and dev specs you need:
 ## Workflow
 
 1. **Get changes** - Run `git diff --name-only` and `git diff` to get code changes
-2. **Check against specs** - Check item by item against specs above
+2. **Check against specs** - Read the curated references in the index above, then check item by item
 3. **Self-fix** - Fix issues directly, don't just report
 4. **Run verification** - Run project's lint and typecheck commands
 
@@ -444,7 +543,7 @@ You are performing the final check before creating a PR.
 
 ## Your Context
 
-Finish checklist and requirements:
+Task artifacts are inlined below (truncated when large); the finish checklist is listed as an index — read the referenced files yourself:
 
 {context}
 

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -3162,7 +3162,11 @@ print(json.dumps({
     expect(context).toContain("Trellis Native Implement Subagent");
     expect(context).toContain("`trellis-implement` role");
     expect(context).toContain("Active task: .trellis/tasks/issue-106");
-    expect(context).toContain("TOKEN_CODEX_IMPLEMENT");
+    // [issue-441] curated references render as an index entry
+    // (path + reason + size), never as an inlined file body.
+    expect(context).toContain("src/implement-context.md");
+    expect(context).toContain("implement contract");
+    expect(context).not.toContain("TOKEN_CODEX_IMPLEMENT");
     expect(context).toContain("TOKEN_CODEX_DESIGN");
     expect(context).toContain("TOKEN_CODEX_PLAN");
   });
@@ -3209,9 +3213,9 @@ print(json.dumps({
       ),
     );
 
-    for (const [agentType, curatedToken] of [
-      ["trellis-implement", "TOKEN_IMPLEMENT_ORDER"],
-      ["trellis-check", "TOKEN_CHECK_ORDER"],
+    for (const [agentType, curatedPath, curatedBody] of [
+      ["trellis-implement", "src/implement-order.md", "TOKEN_IMPLEMENT_ORDER"],
+      ["trellis-check", "src/check-order.md", "TOKEN_CHECK_ORDER"],
     ] as const) {
       const output = runPython(
         hookPath,
@@ -3226,8 +3230,10 @@ print(json.dumps({
         hookSpecificOutput: { additionalContext: string };
       };
       const context = parsed.hookSpecificOutput.additionalContext;
+      // [issue-441] curated entries are index lines (path), not bodies.
+      expect(context).not.toContain(curatedBody);
       const positions = [
-        context.indexOf(curatedToken),
+        context.indexOf(curatedPath),
         context.indexOf("TOKEN_PRD_ORDER"),
         context.indexOf("TOKEN_DESIGN_ORDER"),
         context.indexOf("TOKEN_PLAN_ORDER"),
@@ -3389,12 +3395,15 @@ print(json.dumps({
       TRELLIS_CONTEXT_ID: "codex_parent-b",
     });
 
-    expect(sessionA).toContain("TOKEN_CODEX_SESSION_A");
-    expect(sessionA).not.toContain("TOKEN_CODEX_SESSION_B");
-    expect(sessionB).toContain("TOKEN_CODEX_SESSION_B");
-    expect(sessionB).not.toContain("TOKEN_CODEX_SESSION_A");
-    expect(parentWins).toContain("TOKEN_CODEX_SESSION_A");
-    expect(parentWins).not.toContain("TOKEN_CODEX_SESSION_B");
+    // [issue-441] curated entries appear as index paths, not inlined bodies.
+    expect(sessionA).toContain("src/session-a.md");
+    expect(sessionA).not.toContain("src/session-b.md");
+    expect(sessionA).not.toContain("TOKEN_CODEX_SESSION_A");
+    expect(sessionB).toContain("src/session-b.md");
+    expect(sessionB).not.toContain("src/session-a.md");
+    expect(sessionB).not.toContain("TOKEN_CODEX_SESSION_B");
+    expect(parentWins).toContain("src/session-a.md");
+    expect(parentWins).not.toContain("src/session-b.md");
   });
 
   it("[codex-native-subagents] non-Trellis SubagentStart agents stay silent", () => {
@@ -4520,6 +4529,135 @@ print(len(entries))
       stdio: ["pipe", "pipe", "pipe"],
     });
     expect(result.trim()).toBe("0");
+  });
+
+  // ------------------------------------------------------------
+  // [issue-441] Unbounded sub-agent context injection
+  //   Curated jsonl manifests render as an INDEX (path + reason +
+  //   metadata), task artifacts are truncated per-file, and the
+  //   aggregate payload is capped with explicit omission notices.
+  // ------------------------------------------------------------
+
+  function runClaudeImplementHook(sessionId: string): string {
+    const sharedInject = getSharedHookScripts().find(
+      (hook) => hook.name === "inject-subagent-context.py",
+    )?.content;
+    writeProjectFile(
+      path.join(".claude", "hooks", "inject-subagent-context.py"),
+      expectTemplateContent(sharedInject, "shared inject-subagent-context"),
+    );
+    const hookOutput = runPython(
+      path.join(".claude", "hooks", "inject-subagent-context.py"),
+      JSON.stringify({
+        tool_name: "Task",
+        tool_input: { subagent_type: "trellis-implement", prompt: "do work" },
+        cwd: tmpDir,
+        session_id: sessionId,
+      }),
+    );
+    const parsed = JSON.parse(hookOutput) as {
+      hookSpecificOutput?: { updatedInput?: { prompt?: string } };
+    };
+    return parsed.hookSpecificOutput?.updatedInput?.prompt ?? "";
+  }
+
+  it("[issue-441] jsonl entries render as an index (path + reason + size), no file bodies", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"src/spec-441.md","reason":"spec contract"}\n',
+    );
+    writeProjectFile("src/spec-441.md", "TOKEN_441_SPEC_BODY\n");
+    writeSessionContext("claude_ctx-441", ".trellis/tasks/issue-106");
+
+    const prompt = runClaudeImplementHook("ctx-441");
+
+    expect(prompt).toContain("## Curated Reference Index");
+    expect(prompt).toContain("NOT inlined");
+    expect(prompt).toContain("- src/spec-441.md (");
+    expect(prompt).toContain("KB) — spec contract");
+    expect(prompt).not.toContain("TOKEN_441_SPEC_BODY");
+  });
+
+  it("[issue-441] oversized prd.md is truncated at MAX_ARTIFACT_CHARS with a notice", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "prd.md"),
+      "x".repeat(25000) + "TOKEN_441_PRD_TAIL",
+    );
+    writeSessionContext("claude_ctx-441", ".trellis/tasks/issue-106");
+
+    const prompt = runClaudeImplementHook("ctx-441");
+
+    expect(prompt).toContain(
+      "... [truncated at 20000 chars — read .trellis/tasks/issue-106/prd.md for the full content]",
+    );
+    expect(prompt).not.toContain("TOKEN_441_PRD_TAIL");
+  });
+
+  it("[issue-441] manifests over 50 entries note the omitted rows", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    const rows =
+      Array.from({ length: 60 }, (_, i) =>
+        JSON.stringify({ file: `src/entry-${i}.md`, reason: `r${i}` }),
+      ).join("\n") + "\n";
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      rows,
+    );
+    writeSessionContext("claude_ctx-441", ".trellis/tasks/issue-106");
+
+    const prompt = runClaudeImplementHook("ctx-441");
+
+    expect(prompt).toContain("src/entry-49.md");
+    expect(prompt).not.toContain("src/entry-50.md");
+    expect(prompt).toContain(
+      "... [10 more curated entries omitted — read .trellis/tasks/issue-106/implement.jsonl for the full list]",
+    );
+  });
+
+  it("[issue-441] aggregate payload over MAX_TOTAL_CONTEXT_CHARS drops trailing sections with a notice", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    // Three artifacts at the 20000-char cap each exceed the 60000-char
+    // aggregate budget, forcing the trailing section(s) to be omitted.
+    for (const name of ["prd.md", "design.md", "implement.md"]) {
+      writeProjectFile(
+        path.join(".trellis", "tasks", "issue-106", name),
+        "y".repeat(21000),
+      );
+    }
+    writeSessionContext("claude_ctx-441", ".trellis/tasks/issue-106");
+
+    const prompt = runClaudeImplementHook("ctx-441");
+
+    expect(prompt).toContain(
+      "section(s) omitted — total context cap of 60000 chars reached",
+    );
+    expect(prompt).toContain("read the referenced files directly");
+  });
+
+  it("[issue-441] directory entries list .md files with sizes instead of contents", () => {
+    setupTaskRepo();
+    writeProjectFile(path.join(".git", "HEAD"), "ref: refs/heads/main\n");
+    writeProjectFile("docs/guides/a.md", "TOKEN_441_DIR_A\n");
+    writeProjectFile("docs/guides/b.md", "TOKEN_441_DIR_B\n");
+    writeProjectFile(
+      path.join(".trellis", "tasks", "issue-106", "implement.jsonl"),
+      '{"file":"docs/guides/","type":"directory","reason":"guides overview"}\n',
+    );
+    writeSessionContext("claude_ctx-441", ".trellis/tasks/issue-106");
+
+    const prompt = runClaudeImplementHook("ctx-441");
+
+    expect(prompt).toContain("- docs/guides/ (directory) — guides overview");
+    expect(prompt).toContain("- docs/guides/a.md (");
+    expect(prompt).toContain("- docs/guides/b.md (");
+    expect(prompt).not.toContain("TOKEN_441_DIR_A");
+    expect(prompt).not.toContain("TOKEN_441_DIR_B");
   });
 
   it("[init-context-removal] task.py validate treats seed-only jsonl as 0 errors", () => {

--- a/packages/cli/test/templates/opencode.test.ts
+++ b/packages/cli/test/templates/opencode.test.ts
@@ -628,9 +628,10 @@ describe("opencode inject-subagent-context (issue #264)", () => {
     );
   });
 
-  it("inlines JSONL-referenced spec content into the implement prompt", async () => {
+  it("renders JSONL-referenced specs as an index entry in the implement prompt", async () => {
     // Cover AC #1: "JSONL-referenced context" — the seed-only jsonl path
-    // is exercised above; this one verifies a curated entry is inlined.
+    // is exercised above; this one verifies a curated entry renders as an
+    // index line (path + reason + size), not an inlined body (#441).
     const specPath = join(dir, ".trellis", "spec", "demo.md");
     mkdirSync(join(dir, ".trellis", "spec"), { recursive: true });
     writeFileSync(specPath, "# Demo Spec\n\nUNIQUE_SPEC_MARKER_42");
@@ -653,9 +654,129 @@ describe("opencode inject-subagent-context (issue #264)", () => {
     );
 
     expect(output.args.prompt).toContain("<!-- trellis-hook-injected -->");
-    expect(output.args.prompt).toContain("=== .trellis/spec/demo.md ===");
-    expect(output.args.prompt).toContain("UNIQUE_SPEC_MARKER_42");
+    expect(output.args.prompt).toContain("## Curated Reference Index");
+    expect(output.args.prompt).toContain("- .trellis/spec/demo.md (");
+    expect(output.args.prompt).toContain("KB) — test");
+    expect(output.args.prompt).not.toContain("UNIQUE_SPEC_MARKER_42");
     expect(output.args.prompt).toContain("Demo PRD");
+  });
+
+  it("truncates oversized prd.md with a read-more notice (#441)", async () => {
+    writeFileSync(
+      join(dir, ".trellis", "tasks", "demo-task", "prd.md"),
+      "x".repeat(25000) + "TOKEN_OPENCODE_PRD_TAIL",
+    );
+    writeSessionFile(dir, "opencode_sole", ".trellis/tasks/demo-task");
+
+    const output: TaskToolOutput = {
+      args: {
+        subagent_type: "trellis-implement",
+        prompt: "do the implementation",
+      },
+    };
+
+    await hooks["tool.execute.before"](
+      { tool: "task", sessionID: "stranger" },
+      output,
+    );
+
+    expect(output.args.prompt).toContain(
+      "... [truncated at 20000 chars — read .trellis/tasks/demo-task/prd.md for the full content]",
+    );
+    expect(output.args.prompt).not.toContain("TOKEN_OPENCODE_PRD_TAIL");
+  });
+
+  it("notes manifest rows beyond the 50-entry cap as omitted (#441)", async () => {
+    const rows =
+      Array.from({ length: 60 }, (_, i) =>
+        JSON.stringify({ file: `src/entry-${i}.md`, reason: `r${i}` }),
+      ).join("\n") + "\n";
+    writeFileSync(
+      join(dir, ".trellis", "tasks", "demo-task", "implement.jsonl"),
+      rows,
+    );
+    writeSessionFile(dir, "opencode_sole", ".trellis/tasks/demo-task");
+
+    const output: TaskToolOutput = {
+      args: {
+        subagent_type: "trellis-implement",
+        prompt: "do the implementation",
+      },
+    };
+
+    await hooks["tool.execute.before"](
+      { tool: "task", sessionID: "stranger" },
+      output,
+    );
+
+    expect(output.args.prompt).toContain("src/entry-49.md");
+    expect(output.args.prompt).not.toContain("src/entry-50.md");
+    expect(output.args.prompt).toContain(
+      "... [10 more curated entries omitted — read implement.jsonl for the full list]",
+    );
+  });
+
+  it("drops trailing sections past the aggregate context budget with a notice (#441)", async () => {
+    // Three artifacts at the 20000-char cap each exceed the 60000-char
+    // aggregate budget, forcing the trailing section(s) to be omitted.
+    for (const name of ["prd.md", "design.md", "implement.md"]) {
+      writeFileSync(
+        join(dir, ".trellis", "tasks", "demo-task", name),
+        "y".repeat(21000),
+      );
+    }
+    writeSessionFile(dir, "opencode_sole", ".trellis/tasks/demo-task");
+
+    const output: TaskToolOutput = {
+      args: {
+        subagent_type: "trellis-implement",
+        prompt: "do the implementation",
+      },
+    };
+
+    await hooks["tool.execute.before"](
+      { tool: "task", sessionID: "stranger" },
+      output,
+    );
+
+    expect(output.args.prompt).toContain(
+      "section(s) omitted — total context cap of 60000 chars reached",
+    );
+  });
+
+  it("lists directory manifest entries as files with sizes, not contents (#441)", async () => {
+    mkdirSync(join(dir, "docs", "guides"), { recursive: true });
+    writeFileSync(join(dir, "docs", "guides", "a.md"), "TOKEN_OPENCODE_DIR_A");
+    writeFileSync(join(dir, "docs", "guides", "b.md"), "TOKEN_OPENCODE_DIR_B");
+    writeFileSync(
+      join(dir, ".trellis", "tasks", "demo-task", "implement.jsonl"),
+      JSON.stringify({
+        file: "docs/guides/",
+        type: "directory",
+        reason: "guides overview",
+      }) + "\n",
+    );
+    writeSessionFile(dir, "opencode_sole", ".trellis/tasks/demo-task");
+
+    const output: TaskToolOutput = {
+      args: {
+        subagent_type: "trellis-implement",
+        prompt: "do the implementation",
+      },
+    };
+
+    await hooks["tool.execute.before"](
+      { tool: "task", sessionID: "stranger" },
+      output,
+    );
+
+    expect(output.args.prompt).toContain(
+      "- docs/guides/ (directory) — guides overview",
+    );
+    expect(output.args.prompt).toContain("- docs/guides/a.md (");
+    expect(output.args.prompt).toContain("- docs/guides/b.md (");
+    expect(output.args.prompt).not.toContain("TOKEN_OPENCODE_DIR_A");
+    expect(output.args.prompt).not.toContain("TOKEN_OPENCODE_DIR_B");
   });
 
   it("mutates check prompt using Active task hint when runtime resolution fails", async () => {

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -38,6 +38,7 @@ interface PiExtensionInternals {
   ) => PiRunConfig;
   cmdHasTrellisCtx: (cmd: string) => boolean;
   shellQuote: (v: string) => string;
+  buildContext: (root: string, agent: string, key: string | null) => string;
   trellisExtension: (pi: {
     registerTool?: (tool: unknown) => void;
     registerShortcut?: (key: string, opts: unknown) => void;
@@ -56,6 +57,7 @@ export {
   resolveRunCfg,
   cmdHasTrellisCtx,
   shellQuote,
+  buildContext,
   trellisExtension,
 };
 `;
@@ -585,5 +587,119 @@ fallbackModels:
     expect(extension).toContain("isTrellisAgent(root, agentName)");
     expect(extension).toContain("npm:@tintinweb/pi-subagents");
     expect(extension).toContain("npm:pi-subagents");
+  });
+});
+
+describe("pi extension buildContext index semantics (#441)", () => {
+  // Curated jsonl manifests render as an INDEX (path + reason + metadata),
+  // task artifacts are truncated per-file, and the aggregate payload is
+  // capped with explicit omission notices.
+  function setupTaskRoot(): { root: string; key: string; taskDir: string } {
+    const root = createMinimalTrellisRoot();
+    const taskDir = join(root, ".trellis", "tasks", "demo-task");
+    mkdirSync(taskDir, { recursive: true });
+    mkdirSync(join(root, ".trellis", ".runtime", "sessions"), {
+      recursive: true,
+    });
+    writeFileSync(join(taskDir, "prd.md"), "# Demo PRD");
+    writeFileSync(join(taskDir, "implement.jsonl"), "");
+    writeFileSync(
+      join(root, ".trellis", ".runtime", "sessions", "pi_441.json"),
+      JSON.stringify({ current_task: ".trellis/tasks/demo-task" }),
+    );
+    return { root, key: "pi_441", taskDir };
+  }
+
+  it("renders curated jsonl entries as an index (path + reason + size), no file bodies", () => {
+    const { root, key, taskDir } = setupTaskRoot();
+    mkdirSync(join(root, ".trellis", "spec"), { recursive: true });
+    writeFileSync(join(root, ".trellis", "spec", "demo.md"), "TOKEN_PI_SPEC_BODY");
+    writeFileSync(
+      join(taskDir, "implement.jsonl"),
+      JSON.stringify({ file: ".trellis/spec/demo.md", reason: "spec contract" }) +
+        "\n",
+    );
+
+    const { buildContext } = loadExtensionInternals(root);
+    const ctx = buildContext(root, "trellis-implement", key);
+
+    expect(ctx).toContain("### Curated Reference Index");
+    expect(ctx).toContain("NOT inlined");
+    expect(ctx).toContain("- .trellis/spec/demo.md (");
+    expect(ctx).toContain("KB) — spec contract");
+    expect(ctx).not.toContain("TOKEN_PI_SPEC_BODY");
+  });
+
+  it("truncates oversized prd.md with a read-more notice", () => {
+    const { root, key, taskDir } = setupTaskRoot();
+    writeFileSync(
+      join(taskDir, "prd.md"),
+      "x".repeat(25000) + "TOKEN_PI_PRD_TAIL",
+    );
+
+    const { buildContext } = loadExtensionInternals(root);
+    const ctx = buildContext(root, "trellis-implement", key);
+
+    expect(ctx).toContain("... [truncated at 20000 chars — read");
+    expect(ctx).toContain("/prd.md for the full content]");
+    expect(ctx).not.toContain("TOKEN_PI_PRD_TAIL");
+  });
+
+  it("notes manifest rows beyond the 50-entry cap as omitted", () => {
+    const { root, key, taskDir } = setupTaskRoot();
+    const rows =
+      Array.from({ length: 60 }, (_, i) =>
+        JSON.stringify({ file: `src/entry-${i}.md`, reason: `r${i}` }),
+      ).join("\n") + "\n";
+    writeFileSync(join(taskDir, "implement.jsonl"), rows);
+
+    const { buildContext } = loadExtensionInternals(root);
+    const ctx = buildContext(root, "trellis-implement", key);
+
+    expect(ctx).toContain("src/entry-49.md");
+    expect(ctx).not.toContain("src/entry-50.md");
+    expect(ctx).toContain(
+      "... [10 more curated entries omitted — read implement.jsonl for the full list]",
+    );
+  });
+
+  it("drops trailing sections past the aggregate context budget with a notice", () => {
+    const { root, key, taskDir } = setupTaskRoot();
+    // Three artifacts at the 20000-char cap each exceed the 60000-char
+    // aggregate budget, forcing the trailing section(s) to be omitted.
+    for (const name of ["prd.md", "design.md", "implement.md"]) {
+      writeFileSync(join(taskDir, name), "y".repeat(21000));
+    }
+
+    const { buildContext } = loadExtensionInternals(root);
+    const ctx = buildContext(root, "trellis-implement", key);
+
+    expect(ctx).toContain(
+      "section(s) omitted — total context cap of 60000 chars reached",
+    );
+  });
+
+  it("lists directory manifest entries as files with sizes, not contents", () => {
+    const { root, key, taskDir } = setupTaskRoot();
+    mkdirSync(join(root, "docs", "guides"), { recursive: true });
+    writeFileSync(join(root, "docs", "guides", "a.md"), "TOKEN_PI_DIR_A");
+    writeFileSync(join(root, "docs", "guides", "b.md"), "TOKEN_PI_DIR_B");
+    writeFileSync(
+      join(taskDir, "implement.jsonl"),
+      JSON.stringify({
+        file: "docs/guides/",
+        type: "directory",
+        reason: "guides overview",
+      }) + "\n",
+    );
+
+    const { buildContext } = loadExtensionInternals(root);
+    const ctx = buildContext(root, "trellis-implement", key);
+
+    expect(ctx).toContain("- docs/guides/ (directory) — guides overview");
+    expect(ctx).toContain("- docs/guides/a.md (");
+    expect(ctx).toContain("- docs/guides/b.md (");
+    expect(ctx).not.toContain("TOKEN_PI_DIR_A");
+    expect(ctx).not.toContain("TOKEN_PI_DIR_B");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #441.

Sub-agent context injection eagerly inlined the **complete contents** of every file referenced by `implement.jsonl` / `check.jsonl`, plus full task artifacts, with no limits on file size, manifest size, or aggregate payload — a valid task with a few medium research documents could produce an unexpectedly large first model request. (In Pi this context can also land in the main-session system prompt before dispatch.)

## Fix

Consistently across all three injection sites — the shared Python hook (`inject-subagent-context.py`), the Pi extension (`buildContext()`), and the OpenCode plugin (`trellis-context.js`):

- **JSONL manifests are now indexes, not payload lists.** Each curated entry renders as `path (size) — reason`; directory entries list their `.md` files with sizes instead of inlining contents. A header tells the sub-agent to read referenced files itself before relying on them. The Pi extension now also surfaces each entry's `reason` (previously parsed but dropped).
- **Task artifacts stay inlined but capped**: `prd.md` / `design.md` / `implement.md` truncate at 20,000 chars each with a `read <path> for the full content` notice.
- **Shared caps** (identical constants in all three files): 50 manifest entries, 20 directory-listing files, 60,000 chars aggregate payload — overflows produce explicit omission notices instead of silent truncation.
- Missing referenced files now render as `(missing)` index rows instead of being silently dropped.
- Prompt wording (`build_implement_prompt` / `build_check_prompt` / Pi and OpenCode equivalents) and the hook's design-philosophy docstring updated to the index contract. The Codex `SubagentStart` path inherits the new behavior via the shared `get_*_context` functions.
- OpenCode dogfood copies (`.opencode/lib/`, `.opencode/plugins/`) re-synced byte-identical. The stale installed copies under `.claude/hooks/`, `.cursor/hooks/`, `.pi/extensions/` were already drifted before this PR and are intentionally untouched.

Sample rendering (identical across all three):

```
## Curated Reference Index

The references below were curated for this task. Their contents are NOT inlined here — read the files yourself with your file tools (Read/Glob/Grep) before relying on them.

- src/spec.md (3.2 KB) — API contract for the feature
- docs/guides/ (directory) — style guides
  - docs/guides/a.md (1.1 KB)
... [10 more curated entries omitted — read .trellis/tasks/<task>/implement.jsonl for the full list]
```

## Tests

- New `[issue-441]` cases in `regression.test.ts` (hook executed via subprocess), `opencode.test.ts`, and `pi.test.ts`: index rendering (path+reason+size, bodies absent), artifact truncation, manifest-entry overflow, aggregate overflow, directory listing.
- Updated the 3 Codex SubagentStart tests + the OpenCode inlining test that asserted full-body injection.
- `pnpm test`: 1448/1448; `pnpm lint:py`, `pnpm lint`, `pnpm typecheck`: clean.
- Manual sanity check: piped a Claude-style PreToolUse event into the hook against a fixture with curated entries + a 25k prd.md — output contains the index and truncation notice; file bodies and the prd tail confirmed absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added curated reference indexes for task specifications, showing referenced paths, reasons, file sizes, and directory listings.
  - Updated agent prompts to follow a clearer, ordered workflow for understanding specs, implementing, and checking.
- **Bug Fixes**
  - Prevented oversized task context from overwhelming sub-agent prompts by truncating large artifacts and omitting excess context with explicit notices.
  - Improved directory/manifest summaries so referenced content is accessed on demand rather than inlined, reducing prompt bloat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
