### PR TITLE
fix(cli): cap OpenCode sub-agent context injection (#441 follow-up)

### DIFF
--- a/.opencode/lib/trellis-context.js
+++ b/.opencode/lib/trellis-context.js
@@ -5,11 +5,12 @@
  * JSONL parsing, and context building capabilities.
  */
 
-import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync } from "fs"
 import { isAbsolute, join } from "path"
 import { platform } from "os"
 import { execSync } from "child_process"
 import { createHash } from "crypto"
+import { Buffer } from "buffer"
 import process from "process"
 
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
@@ -76,6 +77,227 @@ export function isTrellisSubagent(input) {
   if (!input || typeof input !== "object") return false
   const agent = typeof input.agent === "string" ? input.agent.trim() : ""
   return TRELLIS_SUBAGENT_RE.test(agent)
+}
+
+// ============================================================
+// Context Injection Limits (issue #441)
+//
+// Notice text and behavior mirrored byte-for-byte from the shared-hooks
+// Python sub-agent context injection hook and the Pi extension. Changing
+// wording here requires changing it there too.
+// ============================================================
+
+const DEFAULT_CONTEXT_INJECTION_LIMITS = {
+  max_file_bytes: 32768,
+  max_artifact_bytes: 65536,
+  max_total_bytes: 131072,
+}
+
+/**
+ * Truncate `buf` to at most `cap` bytes without splitting a UTF-8
+ * multi-byte sequence. `cap <= 0` means "no limit".
+ */
+function truncateUtf8(buf, cap) {
+  if (cap <= 0 || buf.length <= cap) return buf
+  let i = cap
+  // Back off over continuation bytes (10xxxxxx) to find the lead byte.
+  while (i > 0 && (buf[i - 1] & 0xc0) === 0x80) i--
+  if (i === 0) return Buffer.alloc(0)
+  const lead = buf[i - 1]
+  if (lead & 0x80) {
+    let seqLen = 1
+    if ((lead & 0xe0) === 0xc0) seqLen = 2
+    else if ((lead & 0xf0) === 0xe0) seqLen = 3
+    else if ((lead & 0xf8) === 0xf0) seqLen = 4
+    // Drop the lead byte too if its full sequence didn't fit.
+    if (i - 1 + seqLen > cap) i--
+  }
+  return buf.subarray(0, i)
+}
+
+function stripInlineComment(value) {
+  let inQuote = null
+  for (let idx = 0; idx < value.length; idx++) {
+    const ch = value[idx]
+    if (inQuote) {
+      if (ch === inQuote) inQuote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      inQuote = ch
+      continue
+    }
+    if (ch === "#" && (idx === 0 || /\s/.test(value[idx - 1]))) {
+      return value.slice(0, idx)
+    }
+  }
+  return value
+}
+
+function unquoteYaml(s) {
+  if (s.length >= 2 && s[0] === s[s.length - 1] && (s[0] === '"' || s[0] === "'")) {
+    return s.slice(1, -1)
+  }
+  return s
+}
+
+/**
+ * Line-based parser for ONLY the `context_injection:` block of
+ * `.trellis/config.yaml`. Not a general YAML parser — mirrors
+ * `common.config.get_context_injection_limits()` semantics for this
+ * section only (missing keys keep the default; invalid/negative values
+ * fall back to the default for that key with a debugLog warning).
+ */
+function readContextInjectionLimits(repoRoot) {
+  const limits = { ...DEFAULT_CONTEXT_INJECTION_LIMITS }
+  let text = null
+  try {
+    text = readFileSync(join(repoRoot, ".trellis", "config.yaml"), "utf-8")
+  } catch {
+    return limits
+  }
+  if (!text) return limits
+
+  let inSection = false
+  let sectionIndent = -1
+  for (const rawLine of text.split(/\r?\n/)) {
+    const trimmed = rawLine.trim()
+    if (!inSection) {
+      if (/^context_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+        inSection = true
+        sectionIndent = rawLine.length - rawLine.trimStart().length
+      }
+      continue
+    }
+    if (!trimmed || trimmed.startsWith("#")) continue
+    const indent = rawLine.length - rawLine.trimStart().length
+    if (indent <= sectionIndent) break
+    const m = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/)
+    if (!m) continue
+    const key = m[1]
+    if (!(key in limits)) continue
+    const raw = unquoteYaml(stripInlineComment(m[2]).trim()).trim()
+    if (!/^-?\d+$/.test(raw) || parseInt(raw, 10) < 0) {
+      // invalid/negative -> keep default (Python warns on stderr)
+      debugLog("context", `invalid context_injection.${key} value: ${raw}; using default ${limits[key]}`)
+      continue
+    }
+    limits[key] = parseInt(raw, 10)
+  }
+  return limits
+}
+
+/** Tracks the running total of bytes emitted into the sub-agent context. */
+class ContextBudget {
+  constructor(maxTotalBytes) {
+    this.maxTotalBytes = maxTotalBytes
+    this.used = 0
+  }
+
+  hasRoom(size) {
+    if (this.maxTotalBytes <= 0) return true
+    return this.used + size <= this.maxTotalBytes
+  }
+
+  add(size) {
+    this.used += size
+  }
+}
+
+function truncateNotice(path, cap) {
+  return `\n[Trellis: truncated at ${cap} bytes — read ${path} for the full content]`
+}
+
+function indexNotice(path, size, reason) {
+  return `[Trellis: not inlined (total context limit reached) — ${path} (${size} bytes): ${reason}]`
+}
+
+/**
+ * Return an inlined `=== header ===` block, or degrade to an index
+ * notice once the total context budget is exhausted.
+ */
+function budgetedBlock(budget, header, plainPath, content, reason, sizeForIndex) {
+  const block = `=== ${header} ===\n${content}`
+  const blockBytes = Buffer.byteLength(block, "utf-8")
+  if (!budget.hasRoom(blockBytes)) {
+    const notice = indexNotice(plainPath, sizeForIndex, reason)
+    budget.add(Buffer.byteLength(notice, "utf-8"))
+    return notice
+  }
+  budget.add(blockBytes)
+  return block
+}
+
+/** Read raw file bytes, return null if file doesn't exist. */
+function readFileBytes(basePath, filePath) {
+  const fullPath = isAbsolute(filePath) ? filePath : join(basePath, filePath)
+  try {
+    if (!statSync(fullPath).isFile()) return null
+  } catch {
+    return null
+  }
+  try {
+    return readFileSync(fullPath)
+  } catch {
+    return null
+  }
+}
+
+/** Read a JSONL-referenced file, apply the per-file cap, then budget it. */
+function materializeFile(basePath, filePath, reason, limits, budget) {
+  const data = readFileBytes(basePath, filePath)
+  if (data === null) return null
+
+  const size = data.length
+  const cap = limits.max_file_bytes
+  const truncated = truncateUtf8(data, cap)
+  let content = truncated.toString("utf-8")
+  if (truncated.length < size) content += truncateNotice(filePath, cap)
+
+  return budgetedBlock(budget, filePath, filePath, content, reason, size)
+}
+
+/**
+ * Read all .md files in a directory, applying the same per-file and
+ * total caps as a single-file JSONL entry.
+ */
+function materializeDirectory(basePath, dirPath, reason, limits, budget, maxFiles = 20) {
+  const blocks = []
+  const fullPath = isAbsolute(dirPath) ? dirPath : join(basePath, dirPath)
+
+  let files
+  try {
+    if (!statSync(fullPath).isDirectory()) return blocks
+    files = readdirSync(fullPath)
+      .filter(f => f.endsWith(".md") && statSync(join(fullPath, f)).isFile())
+      .sort()
+  } catch {
+    return blocks
+  }
+
+  for (const filename of files.slice(0, maxFiles)) {
+    const relativePath = join(dirPath, filename)
+    const block = materializeFile(basePath, relativePath, reason, limits, budget)
+    if (block) blocks.push(block)
+  }
+  return blocks
+}
+
+/**
+ * Read a task artifact (prd/design/implement.md), apply the per-artifact
+ * cap, then budget it.
+ */
+function materializeArtifact(basePath, filePath, headerLabel, reason, limits, budget) {
+  const data = readFileBytes(basePath, filePath)
+  if (data === null) return null
+
+  const size = data.length
+  const cap = limits.max_artifact_bytes
+  const truncated = truncateUtf8(data, cap)
+  let content = truncated.toString("utf-8")
+  if (truncated.length < size) content += truncateNotice(filePath, cap)
+
+  return budgetedBlock(budget, headerLabel, filePath, content, reason, size)
 }
 
 /**
@@ -282,44 +504,21 @@ export class TrellisContext {
   // JSONL Reading
   // ============================================================
 
-  readDirectoryMdFiles(dirPath, maxFiles = 20) {
-    const results = []
-    const fullPath = join(this.directory, dirPath)
-
-    if (!existsSync(fullPath)) {
-      return results
-    }
-
-    try {
-      const files = readdirSync(fullPath)
-        .filter(f => f.endsWith(".md"))
-        .sort()
-        .slice(0, maxFiles)
-
-      for (const filename of files) {
-        const filePath = join(dirPath, filename)
-        const content = this.readProjectFile(filePath)
-        if (content) {
-          results.push({ path: filePath, content })
-        }
-      }
-    } catch {
-      // Ignore directory read errors
-    }
-
-    return results
-  }
-
   /**
-   * Read a JSONL file and load referenced files/directories
+   * Read a JSONL file and materialize referenced files/directories into
+   * context blocks, applying per-file caps and the shared total budget
+   * (issue #441). Mirrors Python `_materialize_jsonl_entries`.
    * Supports:
    *   {"file": "path/to/file.md", "reason": "..."}
    *   {"file": "path/to/dir/", "type": "directory", "reason": "..."}
+   *
+   * Missing referenced files are skipped silently (Python `_materialize_file`
+   * returns None for them).
    */
-  readJsonlWithFiles(jsonlPath) {
-    const results = []
+  readJsonlWithFiles(jsonlPath, limits, budget) {
+    const blocks = []
     const content = this.readFile(jsonlPath)
-    if (!content) return results
+    if (!content) return blocks
 
     for (const line of content.split("\n")) {
       if (!line.trim()) continue
@@ -327,28 +526,25 @@ export class TrellisContext {
         const item = JSON.parse(line)
         const file = item.file || item.path
         const entryType = item.type || "file"
+        const reason = item.reason || "-"
 
         if (!file) continue
 
         if (entryType === "directory") {
-          const dirEntries = this.readDirectoryMdFiles(file)
-          results.push(...dirEntries)
+          blocks.push(...materializeDirectory(this.directory, file, reason, limits, budget))
         } else {
-          const fullPath = join(this.directory, file)
-          const fileContent = this.readFile(fullPath)
-          if (fileContent) {
-            results.push({ path: file, content: fileContent })
-          }
+          const block = materializeFile(this.directory, file, reason, limits, budget)
+          if (block) blocks.push(block)
         }
       } catch {
         // Ignore parse errors for individual lines
       }
     }
-    return results
+    return blocks
   }
 
-  buildContextFromEntries(entries) {
-    return entries.map(e => `=== ${e.path} ===\n${e.content}`).join("\n\n")
+  buildContextFromEntries(blocks) {
+    return blocks.join("\n\n")
   }
 }
 
@@ -379,3 +575,14 @@ export const contextCollector = new ContextCollector()
 
 // Export debug log for plugins
 export { debugLog }
+
+// Context injection limits (issue #441) — exported for plugins and tests
+export {
+  DEFAULT_CONTEXT_INJECTION_LIMITS,
+  truncateUtf8,
+  readContextInjectionLimits,
+  ContextBudget,
+  materializeFile,
+  materializeDirectory,
+  materializeArtifact,
+}

--- a/.opencode/plugins/inject-subagent-context.js
+++ b/.opencode/plugins/inject-subagent-context.js
@@ -8,7 +8,13 @@
 
 import { existsSync, readdirSync } from "fs"
 import { join } from "path"
-import { TrellisContext, debugLog } from "../lib/trellis-context.js"
+import {
+  TrellisContext,
+  debugLog,
+  readContextInjectionLimits,
+  ContextBudget,
+  materializeArtifact,
+} from "../lib/trellis-context.js"
 
 // Supported subagent types
 const AGENTS_ALL = ["implement", "check", "research"]
@@ -29,64 +35,112 @@ function extractActiveTaskHint(prompt) {
  * Get context for implement agent. `taskDir` may be relative
  * (`.trellis/tasks/foo`) or absolute; both are resolved via
  * `ctx.resolveTaskDir`.
+ *
+ * Read order (mirrors Python `get_implement_context`):
+ *   1. All files in implement.jsonl (spec/research manifests)
+ *   2. prd.md (requirements)
+ *   3. design.md if present (technical design)
+ *   4. implement.md if present (execution plan)
+ * All blocks share one total budget (issue #441).
  */
 function getImplementContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
+  const limits = readContextInjectionLimits(ctx.directory)
+  const budget = new ContextBudget(limits.max_total_bytes)
+
+  // 1. Read implement.jsonl
   const jsonlPath = join(taskDirFull, "implement.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const blocks = ctx.readJsonlWithFiles(jsonlPath, limits, budget)
+  if (blocks.length > 0) {
+    parts.push(ctx.buildContextFromEntries(blocks))
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
-  if (prd) {
-    parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
-  }
+  // 2. Requirements document
+  const prdBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/prd.md`,
+    `${taskDir}/prd.md (Requirements)`,
+    "Requirements document",
+    limits,
+    budget,
+  )
+  if (prdBlock) parts.push(prdBlock)
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
-  if (design) {
-    parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
-  }
+  // 3. Technical design for complex tasks
+  const designBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/design.md`,
+    `${taskDir}/design.md (Technical Design)`,
+    "Technical design document",
+    limits,
+    budget,
+  )
+  if (designBlock) parts.push(designBlock)
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
-  if (implementPlan) {
-    parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
-  }
+  // 4. Execution plan for complex tasks
+  const implementPlanBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/implement.md`,
+    `${taskDir}/implement.md (Execution Plan)`,
+    "Execution plan document",
+    limits,
+    budget,
+  )
+  if (implementPlanBlock) parts.push(implementPlanBlock)
 
   return parts.join("\n\n")
 }
 
 /**
  * Get context for check agent. `taskDir` may be relative or absolute.
+ * Same read order and shared budget as the implement context.
  */
 function getCheckContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
+  const limits = readContextInjectionLimits(ctx.directory)
+  const budget = new ContextBudget(limits.max_total_bytes)
+
   const jsonlPath = join(taskDirFull, "check.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const blocks = ctx.readJsonlWithFiles(jsonlPath, limits, budget)
+  if (blocks.length > 0) {
+    parts.push(ctx.buildContextFromEntries(blocks))
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
-  if (prd) {
-    parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
-  }
+  const prdBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/prd.md`,
+    `${taskDir}/prd.md (Requirements)`,
+    "Requirements document",
+    limits,
+    budget,
+  )
+  if (prdBlock) parts.push(prdBlock)
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
-  if (design) {
-    parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
-  }
+  const designBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/design.md`,
+    `${taskDir}/design.md (Technical Design)`,
+    "Technical design document",
+    limits,
+    budget,
+  )
+  if (designBlock) parts.push(designBlock)
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
-  if (implementPlan) {
-    parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
-  }
+  const implementPlanBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/implement.md`,
+    `${taskDir}/implement.md (Execution Plan)`,
+    "Execution plan document",
+    limits,
+    budget,
+  )
+  if (implementPlanBlock) parts.push(implementPlanBlock)
 
   return parts.join("\n\n")
 }

--- a/packages/cli/src/templates/opencode/lib/trellis-context.js
+++ b/packages/cli/src/templates/opencode/lib/trellis-context.js
@@ -5,11 +5,12 @@
  * JSONL parsing, and context building capabilities.
  */
 
-import { existsSync, readFileSync, appendFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync } from "fs"
 import { isAbsolute, join } from "path"
 import { platform } from "os"
 import { execSync } from "child_process"
 import { createHash } from "crypto"
+import { Buffer } from "buffer"
 import process from "process"
 
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
@@ -76,6 +77,227 @@ export function isTrellisSubagent(input) {
   if (!input || typeof input !== "object") return false
   const agent = typeof input.agent === "string" ? input.agent.trim() : ""
   return TRELLIS_SUBAGENT_RE.test(agent)
+}
+
+// ============================================================
+// Context Injection Limits (issue #441)
+//
+// Notice text and behavior mirrored byte-for-byte from the shared-hooks
+// Python sub-agent context injection hook and the Pi extension. Changing
+// wording here requires changing it there too.
+// ============================================================
+
+const DEFAULT_CONTEXT_INJECTION_LIMITS = {
+  max_file_bytes: 32768,
+  max_artifact_bytes: 65536,
+  max_total_bytes: 131072,
+}
+
+/**
+ * Truncate `buf` to at most `cap` bytes without splitting a UTF-8
+ * multi-byte sequence. `cap <= 0` means "no limit".
+ */
+function truncateUtf8(buf, cap) {
+  if (cap <= 0 || buf.length <= cap) return buf
+  let i = cap
+  // Back off over continuation bytes (10xxxxxx) to find the lead byte.
+  while (i > 0 && (buf[i - 1] & 0xc0) === 0x80) i--
+  if (i === 0) return Buffer.alloc(0)
+  const lead = buf[i - 1]
+  if (lead & 0x80) {
+    let seqLen = 1
+    if ((lead & 0xe0) === 0xc0) seqLen = 2
+    else if ((lead & 0xf0) === 0xe0) seqLen = 3
+    else if ((lead & 0xf8) === 0xf0) seqLen = 4
+    // Drop the lead byte too if its full sequence didn't fit.
+    if (i - 1 + seqLen > cap) i--
+  }
+  return buf.subarray(0, i)
+}
+
+function stripInlineComment(value) {
+  let inQuote = null
+  for (let idx = 0; idx < value.length; idx++) {
+    const ch = value[idx]
+    if (inQuote) {
+      if (ch === inQuote) inQuote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      inQuote = ch
+      continue
+    }
+    if (ch === "#" && (idx === 0 || /\s/.test(value[idx - 1]))) {
+      return value.slice(0, idx)
+    }
+  }
+  return value
+}
+
+function unquoteYaml(s) {
+  if (s.length >= 2 && s[0] === s[s.length - 1] && (s[0] === '"' || s[0] === "'")) {
+    return s.slice(1, -1)
+  }
+  return s
+}
+
+/**
+ * Line-based parser for ONLY the `context_injection:` block of
+ * `.trellis/config.yaml`. Not a general YAML parser — mirrors
+ * `common.config.get_context_injection_limits()` semantics for this
+ * section only (missing keys keep the default; invalid/negative values
+ * fall back to the default for that key with a debugLog warning).
+ */
+function readContextInjectionLimits(repoRoot) {
+  const limits = { ...DEFAULT_CONTEXT_INJECTION_LIMITS }
+  let text = null
+  try {
+    text = readFileSync(join(repoRoot, ".trellis", "config.yaml"), "utf-8")
+  } catch {
+    return limits
+  }
+  if (!text) return limits
+
+  let inSection = false
+  let sectionIndent = -1
+  for (const rawLine of text.split(/\r?\n/)) {
+    const trimmed = rawLine.trim()
+    if (!inSection) {
+      if (/^context_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+        inSection = true
+        sectionIndent = rawLine.length - rawLine.trimStart().length
+      }
+      continue
+    }
+    if (!trimmed || trimmed.startsWith("#")) continue
+    const indent = rawLine.length - rawLine.trimStart().length
+    if (indent <= sectionIndent) break
+    const m = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/)
+    if (!m) continue
+    const key = m[1]
+    if (!(key in limits)) continue
+    const raw = unquoteYaml(stripInlineComment(m[2]).trim()).trim()
+    if (!/^-?\d+$/.test(raw) || parseInt(raw, 10) < 0) {
+      // invalid/negative -> keep default (Python warns on stderr)
+      debugLog("context", `invalid context_injection.${key} value: ${raw}; using default ${limits[key]}`)
+      continue
+    }
+    limits[key] = parseInt(raw, 10)
+  }
+  return limits
+}
+
+/** Tracks the running total of bytes emitted into the sub-agent context. */
+class ContextBudget {
+  constructor(maxTotalBytes) {
+    this.maxTotalBytes = maxTotalBytes
+    this.used = 0
+  }
+
+  hasRoom(size) {
+    if (this.maxTotalBytes <= 0) return true
+    return this.used + size <= this.maxTotalBytes
+  }
+
+  add(size) {
+    this.used += size
+  }
+}
+
+function truncateNotice(path, cap) {
+  return `\n[Trellis: truncated at ${cap} bytes — read ${path} for the full content]`
+}
+
+function indexNotice(path, size, reason) {
+  return `[Trellis: not inlined (total context limit reached) — ${path} (${size} bytes): ${reason}]`
+}
+
+/**
+ * Return an inlined `=== header ===` block, or degrade to an index
+ * notice once the total context budget is exhausted.
+ */
+function budgetedBlock(budget, header, plainPath, content, reason, sizeForIndex) {
+  const block = `=== ${header} ===\n${content}`
+  const blockBytes = Buffer.byteLength(block, "utf-8")
+  if (!budget.hasRoom(blockBytes)) {
+    const notice = indexNotice(plainPath, sizeForIndex, reason)
+    budget.add(Buffer.byteLength(notice, "utf-8"))
+    return notice
+  }
+  budget.add(blockBytes)
+  return block
+}
+
+/** Read raw file bytes, return null if file doesn't exist. */
+function readFileBytes(basePath, filePath) {
+  const fullPath = isAbsolute(filePath) ? filePath : join(basePath, filePath)
+  try {
+    if (!statSync(fullPath).isFile()) return null
+  } catch {
+    return null
+  }
+  try {
+    return readFileSync(fullPath)
+  } catch {
+    return null
+  }
+}
+
+/** Read a JSONL-referenced file, apply the per-file cap, then budget it. */
+function materializeFile(basePath, filePath, reason, limits, budget) {
+  const data = readFileBytes(basePath, filePath)
+  if (data === null) return null
+
+  const size = data.length
+  const cap = limits.max_file_bytes
+  const truncated = truncateUtf8(data, cap)
+  let content = truncated.toString("utf-8")
+  if (truncated.length < size) content += truncateNotice(filePath, cap)
+
+  return budgetedBlock(budget, filePath, filePath, content, reason, size)
+}
+
+/**
+ * Read all .md files in a directory, applying the same per-file and
+ * total caps as a single-file JSONL entry.
+ */
+function materializeDirectory(basePath, dirPath, reason, limits, budget, maxFiles = 20) {
+  const blocks = []
+  const fullPath = isAbsolute(dirPath) ? dirPath : join(basePath, dirPath)
+
+  let files
+  try {
+    if (!statSync(fullPath).isDirectory()) return blocks
+    files = readdirSync(fullPath)
+      .filter(f => f.endsWith(".md") && statSync(join(fullPath, f)).isFile())
+      .sort()
+  } catch {
+    return blocks
+  }
+
+  for (const filename of files.slice(0, maxFiles)) {
+    const relativePath = join(dirPath, filename)
+    const block = materializeFile(basePath, relativePath, reason, limits, budget)
+    if (block) blocks.push(block)
+  }
+  return blocks
+}
+
+/**
+ * Read a task artifact (prd/design/implement.md), apply the per-artifact
+ * cap, then budget it.
+ */
+function materializeArtifact(basePath, filePath, headerLabel, reason, limits, budget) {
+  const data = readFileBytes(basePath, filePath)
+  if (data === null) return null
+
+  const size = data.length
+  const cap = limits.max_artifact_bytes
+  const truncated = truncateUtf8(data, cap)
+  let content = truncated.toString("utf-8")
+  if (truncated.length < size) content += truncateNotice(filePath, cap)
+
+  return budgetedBlock(budget, headerLabel, filePath, content, reason, size)
 }
 
 /**
@@ -282,44 +504,21 @@ export class TrellisContext {
   // JSONL Reading
   // ============================================================
 
-  readDirectoryMdFiles(dirPath, maxFiles = 20) {
-    const results = []
-    const fullPath = join(this.directory, dirPath)
-
-    if (!existsSync(fullPath)) {
-      return results
-    }
-
-    try {
-      const files = readdirSync(fullPath)
-        .filter(f => f.endsWith(".md"))
-        .sort()
-        .slice(0, maxFiles)
-
-      for (const filename of files) {
-        const filePath = join(dirPath, filename)
-        const content = this.readProjectFile(filePath)
-        if (content) {
-          results.push({ path: filePath, content })
-        }
-      }
-    } catch {
-      // Ignore directory read errors
-    }
-
-    return results
-  }
-
   /**
-   * Read a JSONL file and load referenced files/directories
+   * Read a JSONL file and materialize referenced files/directories into
+   * context blocks, applying per-file caps and the shared total budget
+   * (issue #441). Mirrors Python `_materialize_jsonl_entries`.
    * Supports:
    *   {"file": "path/to/file.md", "reason": "..."}
    *   {"file": "path/to/dir/", "type": "directory", "reason": "..."}
+   *
+   * Missing referenced files are skipped silently (Python `_materialize_file`
+   * returns None for them).
    */
-  readJsonlWithFiles(jsonlPath) {
-    const results = []
+  readJsonlWithFiles(jsonlPath, limits, budget) {
+    const blocks = []
     const content = this.readFile(jsonlPath)
-    if (!content) return results
+    if (!content) return blocks
 
     for (const line of content.split("\n")) {
       if (!line.trim()) continue
@@ -327,28 +526,25 @@ export class TrellisContext {
         const item = JSON.parse(line)
         const file = item.file || item.path
         const entryType = item.type || "file"
+        const reason = item.reason || "-"
 
         if (!file) continue
 
         if (entryType === "directory") {
-          const dirEntries = this.readDirectoryMdFiles(file)
-          results.push(...dirEntries)
+          blocks.push(...materializeDirectory(this.directory, file, reason, limits, budget))
         } else {
-          const fullPath = join(this.directory, file)
-          const fileContent = this.readFile(fullPath)
-          if (fileContent) {
-            results.push({ path: file, content: fileContent })
-          }
+          const block = materializeFile(this.directory, file, reason, limits, budget)
+          if (block) blocks.push(block)
         }
       } catch {
         // Ignore parse errors for individual lines
       }
     }
-    return results
+    return blocks
   }
 
-  buildContextFromEntries(entries) {
-    return entries.map(e => `=== ${e.path} ===\n${e.content}`).join("\n\n")
+  buildContextFromEntries(blocks) {
+    return blocks.join("\n\n")
   }
 }
 
@@ -379,3 +575,14 @@ export const contextCollector = new ContextCollector()
 
 // Export debug log for plugins
 export { debugLog }
+
+// Context injection limits (issue #441) — exported for plugins and tests
+export {
+  DEFAULT_CONTEXT_INJECTION_LIMITS,
+  truncateUtf8,
+  readContextInjectionLimits,
+  ContextBudget,
+  materializeFile,
+  materializeDirectory,
+  materializeArtifact,
+}

--- a/packages/cli/src/templates/opencode/plugins/inject-subagent-context.js
+++ b/packages/cli/src/templates/opencode/plugins/inject-subagent-context.js
@@ -8,7 +8,13 @@
 
 import { existsSync, readdirSync } from "fs"
 import { join } from "path"
-import { TrellisContext, debugLog } from "../lib/trellis-context.js"
+import {
+  TrellisContext,
+  debugLog,
+  readContextInjectionLimits,
+  ContextBudget,
+  materializeArtifact,
+} from "../lib/trellis-context.js"
 
 // Supported subagent types
 const AGENTS_ALL = ["implement", "check", "research"]
@@ -29,64 +35,112 @@ function extractActiveTaskHint(prompt) {
  * Get context for implement agent. `taskDir` may be relative
  * (`.trellis/tasks/foo`) or absolute; both are resolved via
  * `ctx.resolveTaskDir`.
+ *
+ * Read order (mirrors Python `get_implement_context`):
+ *   1. All files in implement.jsonl (spec/research manifests)
+ *   2. prd.md (requirements)
+ *   3. design.md if present (technical design)
+ *   4. implement.md if present (execution plan)
+ * All blocks share one total budget (issue #441).
  */
 function getImplementContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
+  const limits = readContextInjectionLimits(ctx.directory)
+  const budget = new ContextBudget(limits.max_total_bytes)
+
+  // 1. Read implement.jsonl
   const jsonlPath = join(taskDirFull, "implement.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const blocks = ctx.readJsonlWithFiles(jsonlPath, limits, budget)
+  if (blocks.length > 0) {
+    parts.push(ctx.buildContextFromEntries(blocks))
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
-  if (prd) {
-    parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
-  }
+  // 2. Requirements document
+  const prdBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/prd.md`,
+    `${taskDir}/prd.md (Requirements)`,
+    "Requirements document",
+    limits,
+    budget,
+  )
+  if (prdBlock) parts.push(prdBlock)
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
-  if (design) {
-    parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
-  }
+  // 3. Technical design for complex tasks
+  const designBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/design.md`,
+    `${taskDir}/design.md (Technical Design)`,
+    "Technical design document",
+    limits,
+    budget,
+  )
+  if (designBlock) parts.push(designBlock)
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
-  if (implementPlan) {
-    parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
-  }
+  // 4. Execution plan for complex tasks
+  const implementPlanBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/implement.md`,
+    `${taskDir}/implement.md (Execution Plan)`,
+    "Execution plan document",
+    limits,
+    budget,
+  )
+  if (implementPlanBlock) parts.push(implementPlanBlock)
 
   return parts.join("\n\n")
 }
 
 /**
  * Get context for check agent. `taskDir` may be relative or absolute.
+ * Same read order and shared budget as the implement context.
  */
 function getCheckContext(ctx, taskDir) {
   const parts = []
   const taskDirFull = ctx.resolveTaskDir(taskDir)
   if (!taskDirFull) return ""
 
+  const limits = readContextInjectionLimits(ctx.directory)
+  const budget = new ContextBudget(limits.max_total_bytes)
+
   const jsonlPath = join(taskDirFull, "check.jsonl")
-  const entries = ctx.readJsonlWithFiles(jsonlPath)
-  if (entries.length > 0) {
-    parts.push(ctx.buildContextFromEntries(entries))
+  const blocks = ctx.readJsonlWithFiles(jsonlPath, limits, budget)
+  if (blocks.length > 0) {
+    parts.push(ctx.buildContextFromEntries(blocks))
   }
 
-  const prd = ctx.readFile(join(taskDirFull, "prd.md"))
-  if (prd) {
-    parts.push(`=== ${taskDir}/prd.md (Requirements) ===\n${prd}`)
-  }
+  const prdBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/prd.md`,
+    `${taskDir}/prd.md (Requirements)`,
+    "Requirements document",
+    limits,
+    budget,
+  )
+  if (prdBlock) parts.push(prdBlock)
 
-  const design = ctx.readFile(join(taskDirFull, "design.md"))
-  if (design) {
-    parts.push(`=== ${taskDir}/design.md (Technical Design) ===\n${design}`)
-  }
+  const designBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/design.md`,
+    `${taskDir}/design.md (Technical Design)`,
+    "Technical design document",
+    limits,
+    budget,
+  )
+  if (designBlock) parts.push(designBlock)
 
-  const implementPlan = ctx.readFile(join(taskDirFull, "implement.md"))
-  if (implementPlan) {
-    parts.push(`=== ${taskDir}/implement.md (Execution Plan) ===\n${implementPlan}`)
-  }
+  const implementPlanBlock = materializeArtifact(
+    ctx.directory,
+    `${taskDir}/implement.md`,
+    `${taskDir}/implement.md (Execution Plan)`,
+    "Execution plan document",
+    limits,
+    budget,
+  )
+  if (implementPlanBlock) parts.push(implementPlanBlock)
 
   return parts.join("\n\n")
 }

--- a/packages/cli/test/templates/opencode.test.ts
+++ b/packages/cli/test/templates/opencode.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   contextCollector,
   isTrellisSubagent,
+  readContextInjectionLimits,
   TrellisContext,
+  truncateUtf8,
 } from "../../src/templates/opencode/lib/trellis-context.js";
 import {
   buildSessionContext,
@@ -812,5 +814,309 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
 
     expect(parts[0].text).toContain("<workflow-state>");
     expect(parts[0].text).toContain("user prompt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #441 — sub-agent context injection limits
+// ---------------------------------------------------------------------------
+
+describe("opencode context injection limits (issue #441)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = setupTrellisProject();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeConfig(yaml: string): void {
+    writeFileSync(join(dir, ".trellis", "config.yaml"), yaml, "utf-8");
+  }
+
+  function writeJsonlEntries(entries: Record<string, string>[]): void {
+    writeFileSync(
+      join(dir, ".trellis", "tasks", "demo-task", "implement.jsonl"),
+      entries.map(e => JSON.stringify(e)).join("\n") + "\n",
+      "utf-8",
+    );
+  }
+
+  async function runImplementHook(): Promise<string> {
+    writeSessionFile(dir, "opencode_sole", ".trellis/tasks/demo-task");
+    const hooks = (await injectSubagentContextPlugin({
+      directory: dir,
+      platform: "linux",
+      env: {},
+    })) as TaskToolHooks;
+    const output: TaskToolOutput = {
+      args: {
+        subagent_type: "trellis-implement",
+        prompt: "do the implementation",
+      },
+    };
+    await hooks["tool.execute.before"](
+      { tool: "task", sessionID: "stranger" },
+      output,
+    );
+    return output.args.prompt ?? "";
+  }
+
+  describe("truncateUtf8", () => {
+    it("leaves data untouched when cap is 0 (unlimited)", () => {
+      const data = Buffer.from("X".repeat(1000));
+      expect(truncateUtf8(data, 0)).toEqual(data);
+    });
+
+    it("leaves data untouched when data is at or under the cap", () => {
+      const data = Buffer.from("hello world");
+      expect(truncateUtf8(data, data.length)).toEqual(data);
+      expect(truncateUtf8(data, data.length + 5)).toEqual(data);
+    });
+
+    it("truncates ASCII data exactly at the cap (1 byte over cap)", () => {
+      const data = Buffer.from("abcdefghij"); // 10 bytes
+      expect(truncateUtf8(data, 9)).toEqual(Buffer.from("abcdefghi"));
+    });
+
+    it("never splits a 2-byte UTF-8 sequence at the boundary (café)", () => {
+      const data = Buffer.from("café", "utf-8");
+      for (let cap = 0; cap <= data.length; cap++) {
+        // Buffer#toString replaces invalid sequences with U+FFFD; a correct
+        // cut never produces one.
+        expect(truncateUtf8(data, cap).toString("utf-8")).not.toContain("�");
+      }
+      expect(truncateUtf8(data, 4).toString("utf-8")).toBe("caf");
+    });
+
+    it("never splits a 3-byte UTF-8 sequence at the boundary (euro sign)", () => {
+      const data = Buffer.from("x€", "utf-8"); // x + 3-byte euro sign
+      for (let cap = 0; cap <= data.length; cap++) {
+        expect(truncateUtf8(data, cap).toString("utf-8")).not.toContain("�");
+      }
+    });
+  });
+
+  describe("readContextInjectionLimits", () => {
+    it("returns built-in defaults when config.yaml is absent", () => {
+      expect(readContextInjectionLimits(dir)).toEqual({
+        max_file_bytes: 32768,
+        max_artifact_bytes: 65536,
+        max_total_bytes: 131072,
+      });
+    });
+
+    it("returns built-in defaults when config.yaml has no context_injection section", () => {
+      writeConfig("session_auto_commit: true\n");
+      expect(readContextInjectionLimits(dir)).toEqual({
+        max_file_bytes: 32768,
+        max_artifact_bytes: 65536,
+        max_total_bytes: 131072,
+      });
+    });
+
+    it("applies explicit overrides for all three keys", () => {
+      writeConfig(
+        [
+          "context_injection:",
+          "  max_file_bytes: 100",
+          "  max_artifact_bytes: 200",
+          "  max_total_bytes: 300",
+        ].join("\n"),
+      );
+      expect(readContextInjectionLimits(dir)).toEqual({
+        max_file_bytes: 100,
+        max_artifact_bytes: 200,
+        max_total_bytes: 300,
+      });
+    });
+
+    it("0 means unlimited and is preserved as-is (not replaced by default)", () => {
+      writeConfig(["context_injection:", "  max_total_bytes: 0"].join("\n"));
+      expect(readContextInjectionLimits(dir).max_total_bytes).toBe(0);
+    });
+
+    it("falls back to default for a negative value", () => {
+      writeConfig(["context_injection:", "  max_file_bytes: -5"].join("\n"));
+      expect(readContextInjectionLimits(dir).max_file_bytes).toBe(32768);
+    });
+
+    it("falls back to default for a non-integer value", () => {
+      writeConfig(
+        ["context_injection:", "  max_artifact_bytes: not-a-number"].join("\n"),
+      );
+      expect(readContextInjectionLimits(dir).max_artifact_bytes).toBe(65536);
+    });
+  });
+
+  describe("inject-subagent-context plugin", () => {
+    it("inlines under-cap content unchanged with no notices (golden)", async () => {
+      writeFileSync(join(dir, "small.md"), "small spec content\n", "utf-8");
+      writeJsonlEntries([{ file: "small.md", reason: "r" }]);
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain("=== small.md ===\nsmall spec content");
+      expect(prompt).toContain(
+        "=== .trellis/tasks/demo-task/prd.md (Requirements) ===\n# Demo PRD",
+      );
+      expect(prompt).not.toContain("[Trellis: truncated");
+      expect(prompt).not.toContain("[Trellis: not inlined");
+    });
+
+    it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", async () => {
+      writeFileSync(join(dir, "big.txt"), "A".repeat(2 * 1024 * 1024), "utf-8");
+      writeJsonlEntries([{ file: "big.txt", reason: "big" }]);
+
+      const prompt = await runImplementHook();
+
+      expect(Buffer.byteLength(prompt, "utf-8")).toBeLessThanOrEqual(
+        128 * 1024 + 4096, // total cap + slack for the prompt template/notices
+      );
+      expect(prompt).toContain(
+        "[Trellis: truncated at 32768 bytes — read big.txt for the full content]",
+      );
+    });
+
+    it("never splits a multi-byte UTF-8 sequence at the 32768-byte cut point", async () => {
+      // 32767 ASCII bytes + Chinese text: the default cap lands inside the
+      // first 3-byte character and must back off, not emit mojibake.
+      writeFileSync(
+        join(dir, "zh.md"),
+        "a".repeat(32767) + "中文内容",
+        "utf-8",
+      );
+      writeJsonlEntries([{ file: "zh.md", reason: "zh" }]);
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).not.toContain("�");
+      expect(prompt).toContain(
+        "a".repeat(32767) +
+          "\n[Trellis: truncated at 32768 bytes — read zh.md for the full content]",
+      );
+    });
+
+    it("truncates an oversized artifact (prd.md) at max_artifact_bytes", async () => {
+      writeFileSync(
+        join(dir, ".trellis", "tasks", "demo-task", "prd.md"),
+        "P".repeat(100000),
+        "utf-8",
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain("P".repeat(65536));
+      expect(prompt).not.toContain("P".repeat(65537));
+      expect(prompt).toContain(
+        "[Trellis: truncated at 65536 bytes — read .trellis/tasks/demo-task/prd.md for the full content]",
+      );
+    });
+
+    it("degrades to an index line once the total budget is exhausted (3 files)", async () => {
+      writeFileSync(join(dir, "f1.txt"), "1".repeat(50), "utf-8");
+      writeFileSync(join(dir, "f2.txt"), "2".repeat(50), "utf-8");
+      writeFileSync(join(dir, "f3.txt"), "3".repeat(50), "utf-8");
+      writeJsonlEntries([
+        { file: "f1.txt", reason: "first" },
+        { file: "f2.txt", reason: "second" },
+        { file: "f3.txt", reason: "third" },
+      ]);
+      writeConfig(
+        [
+          "context_injection:",
+          "  max_file_bytes: 0",
+          "  max_artifact_bytes: 0",
+          "  max_total_bytes: 120", // fits f1 fully, degrades f2/f3
+        ].join("\n"),
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain("=== f1.txt ===\n" + "1".repeat(50));
+      expect(prompt).toContain(
+        "[Trellis: not inlined (total context limit reached) — f2.txt (50 bytes): second]",
+      );
+      expect(prompt).toContain(
+        "[Trellis: not inlined (total context limit reached) — f3.txt (50 bytes): third]",
+      );
+      expect(prompt).not.toContain("=== f2.txt ===");
+      expect(prompt).not.toContain("=== f3.txt ===");
+    });
+
+    it("honors a max_file_bytes override from .trellis/config.yaml", async () => {
+      writeFileSync(join(dir, "ref.md"), "R".repeat(100), "utf-8");
+      writeJsonlEntries([{ file: "ref.md", reason: "ref" }]);
+      writeConfig(["context_injection:", "  max_file_bytes: 10"].join("\n"));
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(
+        "[Trellis: truncated at 10 bytes — read ref.md for the full content]",
+      );
+      expect(prompt).not.toContain("R".repeat(11));
+    });
+
+    it("max_file_bytes: 0 and max_total_bytes: 0 restore fully unlimited inlining", async () => {
+      const bigContent = "Z".repeat(40000); // over the 32768 default file cap
+      writeFileSync(join(dir, "big.txt"), bigContent, "utf-8");
+      writeJsonlEntries([{ file: "big.txt", reason: "big" }]);
+      writeConfig(
+        [
+          "context_injection:",
+          "  max_file_bytes: 0",
+          "  max_total_bytes: 0",
+        ].join("\n"),
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain("=== big.txt ===\n" + bigContent);
+      expect(prompt).not.toContain("[Trellis: truncated");
+      expect(prompt).not.toContain("[Trellis: not inlined");
+    });
+
+    it("invalid config values fall back to the default cap", async () => {
+      writeFileSync(join(dir, "big.txt"), "A".repeat(40000), "utf-8");
+      writeJsonlEntries([{ file: "big.txt", reason: "big" }]);
+      writeConfig(
+        ["context_injection:", "  max_file_bytes: not-a-number"].join("\n"),
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(
+        "[Trellis: truncated at 32768 bytes — read big.txt for the full content]",
+      );
+    });
+
+    it("directory entries respect the per-file cap and only inline .md files", async () => {
+      mkdirSync(join(dir, "refdir"), { recursive: true });
+      writeFileSync(join(dir, "refdir", "a.md"), "A".repeat(1000), "utf-8");
+      writeFileSync(join(dir, "refdir", "b.md"), "B".repeat(1000), "utf-8");
+      writeFileSync(join(dir, "refdir", "c.txt"), "IGNORED_TXT_CONTENT", "utf-8");
+      writeJsonlEntries([
+        { file: "refdir/", type: "directory", reason: "reference dir" },
+      ]);
+      writeConfig(
+        [
+          "context_injection:",
+          "  max_file_bytes: 10",
+          "  max_total_bytes: 0",
+        ].join("\n"),
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(
+        "[Trellis: truncated at 10 bytes — read refdir/a.md for the full content]",
+      );
+      expect(prompt).toContain(
+        "[Trellis: truncated at 10 bytes — read refdir/b.md for the full content]",
+      );
+      expect(prompt).not.toContain("IGNORED_TXT_CONTENT");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #441: `ea399def` capped sub-agent context injection for the shared Python hook and the Pi extension, but the **OpenCode plugin still eagerly inlines** every `implement.jsonl` / `check.jsonl` referenced file plus full task artifacts (`prd.md` / `design.md` / `implement.md`), with no limits.

This PR ports the same cap/degrade semantics to the OpenCode plugin (`lib/trellis-context.js` + `plugins/inject-subagent-context.js`), with byte-for-byte identical notice wording:

- **UTF-8-safe truncation** — per jsonl-referenced file at 32768 bytes, per task artifact at 65536 bytes, never splitting a multi-byte sequence; each truncated block carries the standard notice: `[Trellis: truncated at {cap} bytes — read {path} for the full content]`
- **Total budget** — 131072 bytes for the whole payload; overflow degrades remaining blocks to index lines: `[Trellis: not inlined (total context limit reached) — {path} ({size} bytes): {reason}]`
- **Configurable** — limits are read from the `context_injection:` section of `.trellis/config.yaml` (`0` = unlimited; invalid/negative values fall back to defaults with a `debugLog` warning), parsed dependency-free (the lib stays zero-dependency, mirroring the Python `parse_simple_yaml` approach)
- **Same ordering as the Python hook** — jsonl entries first, then prd → design → implement, all sharing one budget; directory entries materialize each `.md` file (max 20) under the same caps; missing referenced files are skipped
- **Dogfood copies** `.opencode/lib/` + `.opencode/plugins/` re-synced byte-identical

## Tests

19 new cases in `opencode.test.ts`:

- `truncateUtf8` edge cuts: 2-byte (café) and 3-byte (€/Chinese) boundaries produce no U+FFFD
- config parsing: defaults, override, `0` = unlimited, invalid/negative → default
- hook-level behavior mirroring the maintainer's integration test: small-file inline, per-file truncation, per-artifact truncation, total-budget degrade with exact index notices, config override honored, directory entries under caps

## Verification

- `pnpm test`: **1492/1492** (64 files)
- `pnpm lint`, `pnpm typecheck`: clean
- Dogfood `diff`: byte-identical
- Manual sanity check against a tmp fixture (oversized Chinese-text files): exact notices present, no split UTF-8

Supersedes #454 (the pre-`ea399def` pure-index approach).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable context-injection limits for individual files, artifacts, and total prompt size.
  - Supports UTF-8-safe truncation with clear notices when content is capped.
  - Allows limits to be customized through configuration, including unlimited values.
  - Automatically falls back to concise index information when the context budget is exhausted.
  - Applies consistent budgeting when injecting requirements, designs, and implementation plans.

- **Bug Fixes**
  - Missing referenced files are now skipped without interrupting context generation.

- **Tests**
  - Added coverage for limits, truncation, configuration handling, and directory content filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->