### PR TITLE
feat: compose method skills within Trellis roles

### DIFF
--- a/.trellis/scripts/common/git_context.py
+++ b/.trellis/scripts/common/git_context.py
@@ -27,6 +27,11 @@ from .packages_context import (
     get_context_packages_text,
     get_context_packages_json,
 )
+from .method_skills import (
+    METHOD_SLOTS,
+    get_method_skills_text,
+    resolve_method_skills,
+)
 from .trellis_config import read_trellis_config
 from .workflow_phase import (
     filter_platform,
@@ -57,9 +62,19 @@ def main() -> None:
     parser.add_argument(
         "--mode",
         "-m",
-        choices=["default", "record", "packages", "phase"],
+        choices=[
+            "default",
+            "record",
+            "packages",
+            "phase",
+            "method-skills",
+        ],
         default="default",
-        help="Output mode: default (full context), record (for record-session), packages (package info only), phase (workflow step extraction)",
+        help=(
+            "Output mode: default (full context), record (for record-session), "
+            "packages (package info only), phase (workflow step extraction), "
+            "method-skills (resolved methods for a workflow role)"
+        ),
     )
     parser.add_argument(
         "--step",
@@ -68,6 +83,11 @@ def main() -> None:
     parser.add_argument(
         "--platform",
         help="Platform name for --mode phase, e.g. cursor, claude-code. Filters platform-tagged blocks.",
+    )
+    parser.add_argument(
+        "--slot",
+        choices=METHOD_SLOTS,
+        help="Workflow role for --mode method-skills.",
     )
 
     args = parser.parse_args()
@@ -95,6 +115,19 @@ def main() -> None:
             )
             content = filter_platform(content, effective)
         print(content, end="")
+    elif args.mode == "method-skills":
+        if not args.slot:
+            parser.error("--slot is required for --mode method-skills")
+        if args.json:
+            print(
+                json.dumps(
+                    resolve_method_skills(args.slot),
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            print(get_method_skills_text(args.slot))
     else:
         if args.json:
             output_json()

--- a/.trellis/scripts/common/method_skills.py
+++ b/.trellis/scripts/common/method_skills.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Resolve optional method skills for Trellis workflow roles."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PureWindowsPath
+from typing import TypedDict
+
+from .config import _load_config
+from .paths import get_repo_root
+
+
+METHOD_SLOTS = ("brainstorm", "implement", "check", "debug")
+GLOBAL_METHOD_PREFIX = "global:"
+GLOBAL_METHOD_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class ResolvedMethod(TypedDict):
+    reference: str
+    path: str
+
+
+class MethodDiagnostic(TypedDict):
+    reference: str
+    code: str
+    message: str
+
+
+class MethodSkillsResult(TypedDict):
+    slot: str
+    methods: list[ResolvedMethod]
+    diagnostics: list[MethodDiagnostic]
+
+
+def _diagnostic(reference: str, code: str, message: str) -> MethodDiagnostic:
+    return {"reference": reference, "code": code, "message": message}
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _method_skill_path(
+    reference: str,
+    repo_root: Path,
+) -> tuple[Path | None, MethodDiagnostic | None]:
+    """Validate a method reference and return its canonical SKILL.md path."""
+    if reference.startswith(GLOBAL_METHOD_PREFIX):
+        name = reference.removeprefix(GLOBAL_METHOD_PREFIX)
+        if not GLOBAL_METHOD_NAME.fullmatch(name):
+            return None, _diagnostic(
+                reference,
+                "invalid-global-name",
+                "global method names may contain only letters, numbers, dots, underscores, and hyphens",
+            )
+        try:
+            boundary_root = (Path.home() / ".agents" / "skills").resolve()
+            skill_dir = (boundary_root / name).resolve()
+        except (OSError, RuntimeError):
+            return None, _diagnostic(
+                reference,
+                "skill-not-found",
+                "method skill path could not be resolved",
+            )
+        if not _is_within(skill_dir, boundary_root):
+            return None, _diagnostic(
+                reference,
+                "outside-global-root",
+                "global method references must stay within ~/.agents/skills",
+            )
+    else:
+        reference_path = Path(reference)
+        if reference_path.is_absolute() or PureWindowsPath(reference).is_absolute():
+            return None, _diagnostic(
+                reference,
+                "outside-project",
+                "project-local method references must be relative to the project root",
+            )
+        try:
+            skill_dir = (repo_root / reference_path).resolve()
+        except (OSError, RuntimeError):
+            return None, _diagnostic(
+                reference,
+                "skill-not-found",
+                "method skill path could not be resolved",
+            )
+        if not _is_within(skill_dir, repo_root):
+            return None, _diagnostic(
+                reference,
+                "outside-project",
+                "project-local method references must stay within the project root",
+            )
+        boundary_root = repo_root
+
+    try:
+        skill_path = (skill_dir / "SKILL.md").resolve()
+    except (OSError, RuntimeError):
+        return None, _diagnostic(
+            reference,
+            "skill-not-found",
+            "method skill path could not be resolved",
+        )
+    if not _is_within(skill_path, boundary_root):
+        code = (
+            "outside-global-root"
+            if reference.startswith(GLOBAL_METHOD_PREFIX)
+            else "outside-project"
+        )
+        message = (
+            "global method references must stay within ~/.agents/skills"
+            if reference.startswith(GLOBAL_METHOD_PREFIX)
+            else "project-local method references must stay within the project root"
+        )
+        return None, _diagnostic(reference, code, message)
+    if not skill_dir.is_dir() or not skill_path.is_file():
+        return None, _diagnostic(
+            reference,
+            "skill-not-found",
+            "method reference must identify a directory containing SKILL.md",
+        )
+    if not os.access(skill_path, os.R_OK):
+        return None, _diagnostic(
+            reference,
+            "skill-unreadable",
+            "method SKILL.md is not readable",
+        )
+    return skill_path, None
+
+
+def resolve_method_skills(
+    slot: str,
+    repo_root: Path | None = None,
+) -> MethodSkillsResult:
+    """Resolve configured method skills for one workflow role."""
+    root = (repo_root or get_repo_root()).resolve()
+    config = _load_config(root)
+    section = config.get("method_skills")
+    if section == "{}":
+        section = {}
+    methods: list[ResolvedMethod] = []
+    diagnostics: list[MethodDiagnostic] = []
+    seen_paths: set[Path] = set()
+
+    if section is None:
+        references: object = []
+    elif not isinstance(section, dict):
+        references = []
+        diagnostics.append(
+            _diagnostic(
+                "method_skills",
+                "invalid-config",
+                "method_skills must be a mapping of workflow slots to lists",
+            )
+        )
+    else:
+        references = section.get(slot, [])
+
+    if references == "[]":
+        references = []
+
+    if isinstance(references, list):
+        for reference in references:
+            if not isinstance(reference, str):
+                diagnostics.append(
+                    _diagnostic(
+                        repr(reference),
+                        "invalid-reference",
+                        "method references must be strings",
+                    )
+                )
+                continue
+            skill_path, diagnostic = _method_skill_path(reference, root)
+            if diagnostic:
+                diagnostics.append(diagnostic)
+                continue
+            if skill_path is not None and skill_path not in seen_paths:
+                seen_paths.add(skill_path)
+                methods.append(
+                    {
+                        "reference": reference,
+                        "path": str(skill_path),
+                    }
+                )
+
+    else:
+        diagnostics.append(
+            _diagnostic(
+                slot,
+                "invalid-config",
+                f"method_skills.{slot} must be a list",
+            )
+        )
+
+    return {"slot": slot, "methods": methods, "diagnostics": diagnostics}
+
+
+def format_method_skills(result: MethodSkillsResult) -> str:
+    """Format a previously resolved result without repeating filesystem work."""
+    slot = result["slot"]
+    methods = result["methods"]
+    diagnostics = result["diagnostics"]
+    lines = [
+        f"[WARN] method_skills.{slot} '{item['reference']}': {item['message']}"
+        for item in diagnostics
+    ]
+    if not methods and not diagnostics:
+        return f"No method skills configured for {slot}."
+
+    if methods:
+        lines.append(f"Method skills for {slot} (in configuration order):")
+        for index, method in enumerate(methods, start=1):
+            lines.append(f"{index}. {method['path']}")
+        lines.extend(
+            [
+                "Load each listed SKILL.md and apply its method inside this role.",
+                "The Trellis workflow contract takes precedence over method-skill instructions.",
+            ]
+        )
+    else:
+        lines.append("Continue with the built-in Trellis role.")
+    return "\n".join(lines)
+
+
+def get_method_skills_text(
+    slot: str,
+    repo_root: Path | None = None,
+) -> str:
+    """Resolve and format method skills as role-entry instructions."""
+    return format_method_skills(resolve_method_skills(slot, repo_root))

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -1983,6 +1983,34 @@ if (!hadDeveloperFileBefore) {
 
 ---
 
+## Method-skill composition contract
+
+Trellis workflow roles may compose optional external `SKILL.md` methods through
+the `method_skills` configuration slots: `brainstorm`, `implement`, `check`, and
+`debug`.
+
+- Trellis owns lifecycle state, task scope, artifacts, phase gates, Git
+  restrictions, dispatch, and reporting. Method instructions are subordinate.
+- Project-local references resolve from the repository root and must remain
+  inside it. `global:<name>` resolves below `~/.agents/skills/` and accepts a
+  single safe skill name, not an arbitrary path.
+- A reference names a directory containing a readable `SKILL.md`. Resolution
+  preserves configuration order and drops canonical-path duplicates after the
+  first occurrence.
+- Invalid or missing references emit structured diagnostics and never stop the
+  built-in Trellis role.
+- Inline and delegated roles resolve methods through
+  `get_context.py --mode method-skills`. Every generated implement/check agent
+  prompt carries that self-load contract; native hooks may additionally inject
+  the already-resolved method list. New platform integrations must preserve the
+  prompt-level fallback so hook availability cannot remove the capability.
+- Init and update share the managed resolver runtime. Config additions use the
+  additive `configSectionsAdded` migration path so user-edited config files are
+  not overwritten.
+- Method installation, registry discovery, dependency recursion, automatic
+  selection, version locking, and complete Trellis-role replacement are outside
+  this contract.
+
 ## Reference PRs
 
 | PR                            | Platform         | Pattern                                        | Notes                                                                                          |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ Trellis runs a 4-phase loop with auto-invoked skills and sub-agents:
 3. **Verify** — a `trellis-check` sub-agent reviews the diff against specs and runs lint, type-check, and tests, self-fixing where it can.
 4. **Finish** — a final check runs, then `trellis-update-spec` promotes new learnings back into `.trellis/spec/` so the next session starts smarter.
 
+## Compose Method Skills
+
+Trellis can apply compatible Agent Skills inside a workflow role without replacing that role. For example, Trellis can keep ownership of planning artifacts while `grilling` supplies the questioning method, or keep implementation scope and Git restrictions while `tdd` supplies the coding method.
+
+Configure existing project-local or global skill directories in `.trellis/config.yaml`:
+
+```yaml
+method_skills:
+  brainstorm:
+    - global:grilling
+  implement:
+    - global:tdd
+    - global:codebase-design
+  check:
+    - global:code-review
+  debug:
+    - global:diagnosing-bugs
+```
+
+Project-local references are relative to the repository root. `global:<name>` resolves to `~/.agents/skills/<name>/SKILL.md`. Methods run in configuration order, Trellis workflow rules take precedence, and invalid references warn before the built-in role continues. Trellis reads existing skills only; it does not install or update them.
+
 ## Resources
 
 | Need                            | Link                                                                           |

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,6 +84,27 @@ Trellis 内部运行一个 4 阶段循环，skill 与子代理均由系统自动
 3. **Verify（验证）** —— `trellis-check` 子代理基于 diff 对照 Spec 逐项核查，并运行 lint、type-check 与测试，在能力范围内自动修复。
 4. **Finish（收尾）** —— 执行最终检查后，`trellis-update-spec` 将本轮新增的认知沉淀回 `.trellis/spec/`，为下一次会话积累上下文。
 
+## 组合方法型 Skills
+
+Trellis 可以在不替换工作流角色的前提下，将兼容的 Agent Skills 组合进角色内部。例如，Trellis 继续负责规划产物，而由 `grilling` 提供提问方法；Trellis 继续约束实现范围和 Git 操作，而由 `tdd` 提供编码方法。
+
+在 `.trellis/config.yaml` 中配置已经存在的项目级或全局 skill 目录：
+
+```yaml
+method_skills:
+  brainstorm:
+    - global:grilling
+  implement:
+    - global:tdd
+    - global:codebase-design
+  check:
+    - global:code-review
+  debug:
+    - global:diagnosing-bugs
+```
+
+项目级引用相对于仓库根目录解析；`global:<name>` 解析为 `~/.agents/skills/<name>/SKILL.md`。方法按配置顺序执行，Trellis 工作流规则始终优先；无效引用会给出警告，然后继续使用内置角色。Trellis 只读取已有 skills，不负责安装或升级它们。
+
 ## 资源
 
 | 需求 | 链接 |

--- a/packages/cli/src/configurators/claude.ts
+++ b/packages/cli/src/configurators/claude.ts
@@ -2,7 +2,10 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { AI_TOOLS } from "../types/ai-tools.js";
 import { getClaudeTemplatePath } from "../templates/extract.js";
-import { getStatuslineHook } from "../templates/claude/index.js";
+import {
+  getAllAgents,
+  getStatuslineHook,
+} from "../templates/claude/index.js";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
 import {
   resolvePlaceholders,
@@ -13,6 +16,8 @@ import {
   writeSharedHooks,
   replacePythonCommandLiterals,
   type PlatformConfigureOptions,
+  applyMethodSkillsPreludeMarkdown,
+  writeAgents,
 } from "./shared.js";
 
 const EXCLUDE_PATTERNS = [
@@ -113,8 +118,15 @@ export async function configureClaude(
   await copyDirFiltered(
     sourcePath,
     destPath,
-    ["commands", "hooks"],
+    ["commands", "hooks", "agents"],
     withStatusline,
+  );
+
+  // Render role agents through the same method-skill composer used by update
+  // collection so init and update stay byte-identical.
+  await writeAgents(
+    path.join(destPath, "agents"),
+    applyMethodSkillsPreludeMarkdown(getAllAgents()),
   );
 
   // Shared hook scripts (same source as 7 other platforms)

--- a/packages/cli/src/configurators/codebuddy.ts
+++ b/packages/cli/src/configurators/codebuddy.ts
@@ -9,6 +9,7 @@ import {
   writeSkills,
   writeAgents,
   writeSharedHooks,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 import {
   getAllAgents,
@@ -40,7 +41,10 @@ export async function configureCodebuddy(cwd: string): Promise<void> {
     resolveSkills(ctx),
     resolveBundledSkills(ctx),
   );
-  await writeAgents(path.join(configRoot, "agents"), getAllAgents());
+  await writeAgents(
+    path.join(configRoot, "agents"),
+    applyMethodSkillsPreludeMarkdown(getAllAgents()),
+  );
   await writeSharedHooks(path.join(configRoot, "hooks"), "codebuddy");
 
   const settings = getSettingsTemplate();

--- a/packages/cli/src/configurators/codex.ts
+++ b/packages/cli/src/configurators/codex.ts
@@ -15,6 +15,7 @@ import {
   writeSkills,
   writeSharedHooks,
   replacePythonCommandLiterals,
+  applyMethodSkillsPreludeToml,
 } from "./shared.js";
 
 /**
@@ -59,7 +60,7 @@ export async function configureCodex(cwd: string): Promise<void> {
   // Native Codex SubagentStart hooks push role-specific context. Each agent
   // also carries a marker-gated pull fallback for untrusted or unavailable
   // hooks, so install the source profiles without an unconditional prelude.
-  for (const agent of getAllAgents()) {
+  for (const agent of applyMethodSkillsPreludeToml(getAllAgents())) {
     await writeFile(
       path.join(codexAgentsRoot, `${agent.name}.toml`),
       replacePythonCommandLiterals(agent.content),

--- a/packages/cli/src/configurators/cursor.ts
+++ b/packages/cli/src/configurators/cursor.ts
@@ -9,6 +9,7 @@ import {
   writeSkills,
   writeAgents,
   writeSharedHooks,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 import { getAllAgents, getHooksConfig } from "../templates/cursor/index.js";
 
@@ -39,7 +40,10 @@ export async function configureCursor(cwd: string): Promise<void> {
     resolveSkills(ctx),
     resolveBundledSkills(ctx),
   );
-  await writeAgents(path.join(configRoot, "agents"), getAllAgents());
+  await writeAgents(
+    path.join(configRoot, "agents"),
+    applyMethodSkillsPreludeMarkdown(getAllAgents()),
+  );
   await writeSharedHooks(path.join(configRoot, "hooks"), "cursor");
 
   // Hooks config (separate file, not settings.json)

--- a/packages/cli/src/configurators/droid.ts
+++ b/packages/cli/src/configurators/droid.ts
@@ -9,6 +9,7 @@ import {
   writeSkills,
   writeAgents,
   writeSharedHooks,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 import { getAllDroids, getSettingsTemplate } from "../templates/droid/index.js";
 
@@ -37,7 +38,10 @@ export async function configureDroid(cwd: string): Promise<void> {
     resolveSkills(ctx),
     resolveBundledSkills(ctx),
   );
-  await writeAgents(path.join(configRoot, "droids"), getAllDroids());
+  await writeAgents(
+    path.join(configRoot, "droids"),
+    applyMethodSkillsPreludeMarkdown(getAllDroids()),
+  );
   await writeSharedHooks(path.join(configRoot, "hooks"), "droid");
 
   const settings = getSettingsTemplate();

--- a/packages/cli/src/configurators/index.ts
+++ b/packages/cli/src/configurators/index.ts
@@ -51,6 +51,9 @@ import {
   resolveSkillsNeutral,
   wrapWithCommandFrontmatter,
   collectSkillTemplates,
+  applyMethodSkillsPreludeJson,
+  applyMethodSkillsPreludeMarkdown,
+  applyMethodSkillsPreludeToml,
   applyPullBasedPreludeMarkdown,
   normalizeCopilotMarkdownAgents,
   type PlatformConfigureOptions,
@@ -178,7 +181,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
         (n) => `.claude/commands/trellis/${n}.md`,
         ".claude/skills",
       );
-      for (const agent of getClaudeAgents()) {
+      for (const agent of applyMethodSkillsPreludeMarkdown(getClaudeAgents())) {
         files.set(`.claude/agents/${agent.name}.md`, agent.content);
       }
       for (const [k, v] of collectSharedHooks(".claude/hooks", "claude")) {
@@ -200,7 +203,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
         (n) => `.cursor/commands/trellis-${n}.md`,
         ".cursor/skills",
       );
-      for (const agent of getCursorAgents()) {
+      for (const agent of applyMethodSkillsPreludeMarkdown(getCursorAgents())) {
         files.set(`.cursor/agents/${agent.name}.md`, agent.content);
       }
       for (const [k, v] of collectSharedHooks(".cursor/hooks", "cursor")) {
@@ -232,7 +235,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       for (const skill of getCodexPlatformSkills()) {
         files.set(`.codex/skills/${skill.name}/SKILL.md`, skill.content);
       }
-      for (const agent of getCodexAgents()) {
+      for (const agent of applyMethodSkillsPreludeToml(getCodexAgents())) {
         files.set(`.codex/agents/${agent.name}.toml`, agent.content);
       }
       for (const hook of getCodexHooks()) {
@@ -272,7 +275,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
       )) {
         files.set(filePath, content);
       }
-      for (const agent of getKiroAgents()) {
+      for (const agent of applyMethodSkillsPreludeJson(getKiroAgents())) {
         files.set(
           `.kiro/agents/${agent.name}.json`,
           resolvePlaceholders(agent.content),
@@ -374,7 +377,9 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
         (n) => `.codebuddy/commands/trellis/${n}.md`,
         ".codebuddy/skills",
       );
-      for (const agent of getCodebuddyAgents()) {
+      for (const agent of applyMethodSkillsPreludeMarkdown(
+        getCodebuddyAgents(),
+      )) {
         files.set(`.codebuddy/agents/${agent.name}.md`, agent.content);
       }
       for (const [k, v] of collectSharedHooks(
@@ -440,7 +445,7 @@ const PLATFORM_FUNCTIONS: Record<AITool, PlatformFunctions> = {
         (n) => `.factory/commands/trellis/${n}.md`,
         ".factory/skills",
       );
-      for (const droid of getDroidDroids()) {
+      for (const droid of applyMethodSkillsPreludeMarkdown(getDroidDroids())) {
         files.set(`.factory/droids/${droid.name}.md`, droid.content);
       }
       for (const [k, v] of collectSharedHooks(".factory/hooks", "droid")) {

--- a/packages/cli/src/configurators/kiro.ts
+++ b/packages/cli/src/configurators/kiro.ts
@@ -7,6 +7,7 @@ import {
   writeSkills,
   writeAgents,
   writeSharedHooks,
+  applyMethodSkillsPreludeJson,
 } from "./shared.js";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
 import { getAllAgents, getIdeHooks } from "../templates/kiro/index.js";
@@ -31,7 +32,7 @@ export async function configureKiro(cwd: string): Promise<void> {
   );
 
   // Agents (JSON format, with {{PYTHON_CMD}} resolved)
-  const agents = getAllAgents().map((a) => ({
+  const agents = applyMethodSkillsPreludeJson(getAllAgents()).map((a) => ({
     ...a,
     content: resolvePlaceholders(a.content),
   }));

--- a/packages/cli/src/configurators/omp.ts
+++ b/packages/cli/src/configurators/omp.ts
@@ -10,6 +10,7 @@ import {
   wrapWithOmpFrontmatter,
   writeAgents,
   writeSkills,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 import { getAllAgents, getExtensionTemplate } from "../templates/omp/index.js";
 
@@ -40,7 +41,7 @@ export function collectOmpTemplates(): Map<string, string> {
   }
 
   // Agents (class-1: no pull-based prelude)
-  for (const agent of getAllAgents()) {
+  for (const agent of applyMethodSkillsPreludeMarkdown(getAllAgents())) {
     files.set(`.omp/agents/${agent.name}.md`, agent.content);
   }
 
@@ -79,7 +80,10 @@ export async function configureOmp(cwd: string): Promise<void> {
   );
 
   // Agents (class-1: no applyPullBasedPreludeMarkdown)
-  await writeAgents(path.join(configRoot, "agents"), getAllAgents());
+  await writeAgents(
+    path.join(configRoot, "agents"),
+    applyMethodSkillsPreludeMarkdown(getAllAgents()),
+  );
 
   // Extension
   ensureDir(path.join(configRoot, "extensions", "trellis"));

--- a/packages/cli/src/configurators/opencode.ts
+++ b/packages/cli/src/configurators/opencode.ts
@@ -10,6 +10,8 @@ import {
   resolveBundledSkills,
   resolveCommands,
   resolveSkills,
+  detectSubAgentType,
+  injectMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 
 /**
@@ -61,7 +63,13 @@ function walkOpenCodeTemplateDir(): Map<string, string> {
         if (relEntry === "commands") continue;
         walk(relEntry);
       } else {
-        const content = readFileSync(absEntry, "utf-8");
+        let content = readFileSync(absEntry, "utf-8");
+        if (toPosix(relEntry).startsWith("agents/")) {
+          const agentType = detectSubAgentType(entry);
+          if (agentType) {
+            content = injectMethodSkillsPreludeMarkdown(content, agentType);
+          }
+        }
         // Map keys are logical paths used as cross-platform hash keys / lookup
         // keys downstream. Always POSIX, regardless of host OS.
         files.set(

--- a/packages/cli/src/configurators/reasonix.ts
+++ b/packages/cli/src/configurators/reasonix.ts
@@ -20,6 +20,7 @@ import {
   resolveAllAsSkills,
   resolveBundledSkills,
   writeSkills,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 
 /**
@@ -32,7 +33,8 @@ export function collectReasonixTemplates(): Map<string, string> {
   const files = new Map<string, string>();
 
   // Subagent skill names that replace common-skill equivalents.
-  const agentNames = new Set(getAllAgents().map((a) => a.name));
+  const agents = applyMethodSkillsPreludeMarkdown(getAllAgents());
+  const agentNames = new Set(agents.map((a) => a.name));
 
   // Workflow skills filtered to avoid collision with subagent skills.
   const skills = resolveAllAsSkills(ctx).filter((s) => !agentNames.has(s.name));
@@ -47,7 +49,7 @@ export function collectReasonixTemplates(): Map<string, string> {
 
   // Subagent skills (trellis-implement, trellis-check) — written with
   // runAs: subagent frontmatter for isolated subagent loops.
-  for (const agent of getAllAgents()) {
+  for (const agent of agents) {
     files.set(`.reasonix/skills/${agent.name}/SKILL.md`, agent.content);
   }
 
@@ -64,14 +66,15 @@ export async function configureReasonix(cwd: string): Promise<void> {
   const skillsRoot = path.join(cwd, config.configDir, "skills");
 
   // Subagent skill names that replace common-skill equivalents.
-  const agentNames = new Set(getAllAgents().map((a) => a.name));
+  const agents = applyMethodSkillsPreludeMarkdown(getAllAgents());
+  const agentNames = new Set(agents.map((a) => a.name));
 
   // Write workflow skills, filtering out any that have subagent equivalents.
   const skills = resolveAllAsSkills(ctx).filter((s) => !agentNames.has(s.name));
   await writeSkills(skillsRoot, skills, resolveBundledSkills(ctx));
 
   // Subagent skills with runAs: subagent frontmatter
-  for (const agent of getAllAgents()) {
+  for (const agent of agents) {
     const agentDir = path.join(skillsRoot, agent.name);
     ensureDir(agentDir);
     await writeFile(path.join(agentDir, "SKILL.md"), agent.content);

--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -583,6 +583,21 @@ export async function writeSharedHooks(
 
 export type SubAgentType = "implement" | "check";
 
+/** Build the standard optional method-skills role-entry block. */
+export function buildMethodSkillsPrelude(agentType: SubAgentType): string {
+  return replacePythonCommandLiterals(`## Optional Method Skills
+
+At role entry, run \`python3 ./.trellis/scripts/get_context.py --mode method-skills --slot ${agentType}\`.
+
+If the command lists method skills, load each listed \`SKILL.md\` in order before performing the role. The first method is primary and later methods are supporting.
+
+The Trellis workflow contract takes precedence over method-skill instructions, including task scope, artifacts, Git constraints, and reporting. If no methods are configured, continue with the built-in role unchanged.
+
+---
+
+`);
+}
+
 /** Build the standard "load Trellis context first" prelude block. */
 export function buildPullBasedPrelude(agentType: SubAgentType): string {
   // JSONL filenames stay as implement.jsonl / check.jsonl — they are internal
@@ -617,12 +632,7 @@ If the resolved task path has no \`prd.md\`, ask the user what to work on; do NO
 `);
 }
 
-/** Insert prelude into a markdown agent definition (after YAML frontmatter). */
-export function injectPullBasedPreludeMarkdown(
-  content: string,
-  agentType: SubAgentType,
-): string {
-  const prelude = buildPullBasedPrelude(agentType);
+function injectPreludeMarkdown(content: string, prelude: string): string {
   const sections = splitMarkdownFrontmatter(content);
 
   if (!sections) {
@@ -634,18 +644,67 @@ export function injectPullBasedPreludeMarkdown(
   return `${head}\n\n${prelude}${tailTrimmed}`;
 }
 
-/** Insert prelude into a TOML agent (codex `developer_instructions`). */
-export function injectPullBasedPreludeToml(
+/** Insert prelude into a markdown agent definition (after YAML frontmatter). */
+export function injectPullBasedPreludeMarkdown(
   content: string,
   agentType: SubAgentType,
 ): string {
-  const prelude = buildPullBasedPrelude(agentType);
+  const prelude =
+    buildPullBasedPrelude(agentType) + buildMethodSkillsPrelude(agentType);
+  return injectPreludeMarkdown(content, prelude);
+}
+
+/** Insert only the method-skills block into a markdown agent definition. */
+export function injectMethodSkillsPreludeMarkdown(
+  content: string,
+  agentType: SubAgentType,
+): string {
+  return injectPreludeMarkdown(content, buildMethodSkillsPrelude(agentType));
+}
+
+function injectPreludeToml(content: string, prelude: string): string {
   // Match: developer_instructions = """  followed by newline
   const re = /(developer_instructions\s*=\s*""")(\r?\n)/;
   if (!re.test(content)) {
     return content;
   }
   return content.replace(re, `$1$2${prelude}`);
+}
+
+/** Insert prelude into a TOML agent (codex `developer_instructions`). */
+export function injectPullBasedPreludeToml(
+  content: string,
+  agentType: SubAgentType,
+): string {
+  const prelude =
+    buildPullBasedPrelude(agentType) + buildMethodSkillsPrelude(agentType);
+  return injectPreludeToml(content, prelude);
+}
+
+/** Insert only the method-skills block into a TOML agent definition. */
+export function injectMethodSkillsPreludeToml(
+  content: string,
+  agentType: SubAgentType,
+): string {
+  return injectPreludeToml(content, buildMethodSkillsPrelude(agentType));
+}
+
+/** Insert the method-skills block into a JSON agent's prompt field. */
+export function injectMethodSkillsPreludeJson(
+  content: string,
+  agentType: SubAgentType,
+): string {
+  let agent: Record<string, unknown>;
+  try {
+    agent = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return content;
+  }
+  if (typeof agent.prompt !== "string") {
+    return content;
+  }
+  agent.prompt = buildMethodSkillsPrelude(agentType) + agent.prompt;
+  return `${JSON.stringify(agent, null, 2)}\n`;
 }
 
 /** Best-effort detect agent type from filename ("trellis-implement.md" → "implement").
@@ -697,6 +756,19 @@ export function applyPullBasedPreludeMarkdown(
     return {
       ...a,
       content: injectPullBasedPreludeMarkdown(a.content, t),
+    };
+  });
+}
+
+export function applyMethodSkillsPreludeMarkdown(
+  agents: readonly AgentContent[],
+): AgentContent[] {
+  return agents.map((agent) => {
+    const agentType = detectSubAgentType(agent.name);
+    if (!agentType) return { ...agent };
+    return {
+      ...agent,
+      content: injectMethodSkillsPreludeMarkdown(agent.content, agentType),
     };
   });
 }
@@ -783,6 +855,32 @@ export function applyPullBasedPreludeToml(
     return {
       ...a,
       content: injectPullBasedPreludeToml(a.content, t),
+    };
+  });
+}
+
+export function applyMethodSkillsPreludeToml(
+  agents: readonly AgentContent[],
+): AgentContent[] {
+  return agents.map((agent) => {
+    const agentType = detectSubAgentType(agent.name);
+    if (!agentType) return { ...agent };
+    return {
+      ...agent,
+      content: injectMethodSkillsPreludeToml(agent.content, agentType),
+    };
+  });
+}
+
+export function applyMethodSkillsPreludeJson(
+  agents: readonly AgentContent[],
+): AgentContent[] {
+  return agents.map((agent) => {
+    const agentType = detectSubAgentType(agent.name);
+    if (!agentType) return { ...agent };
+    return {
+      ...agent,
+      content: injectMethodSkillsPreludeJson(agent.content, agentType),
     };
   });
 }

--- a/packages/cli/src/configurators/zcode.ts
+++ b/packages/cli/src/configurators/zcode.ts
@@ -26,6 +26,7 @@ import {
   writeSkills,
   writeAgents,
   writeSharedHooks,
+  applyMethodSkillsPreludeMarkdown,
 } from "./shared.js";
 
 /** Shared hooks directory written for ZCode (mirrors the configure path). */
@@ -55,7 +56,7 @@ export function collectZcodeTemplates(): Map<string, string> {
   }
 
   // 3. Sub-agents → .zcode/agents/ (hook-inject; templates carry fallback).
-  for (const agent of getAllAgents()) {
+  for (const agent of applyMethodSkillsPreludeMarkdown(getAllAgents())) {
     files.set(`.zcode/agents/${agent.name}.md`, agent.content);
   }
 
@@ -99,7 +100,10 @@ export async function configureZcode(cwd: string): Promise<void> {
   }
 
   // 3. Sub-agents → .zcode/agents/ (hook-inject; templates carry fallback).
-  await writeAgents(path.join(zcodeRoot, "agents"), getAllAgents());
+  await writeAgents(
+    path.join(zcodeRoot, "agents"),
+    applyMethodSkillsPreludeMarkdown(getAllAgents()),
+  );
 
   // 4. Shared hooks → .zcode/hooks/
   await writeSharedHooks(path.join(zcodeRoot, "hooks"), "zcode");

--- a/packages/cli/src/migrations/manifests/0.6.9.json
+++ b/packages/cli/src/migrations/manifests/0.6.9.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.6.9",
+  "description": "Compose optional project-local and global method skills inside Trellis workflow roles.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Enhancements:**\n- feat(workflow): add optional method-skills composition for brainstorm, implement, check, and debug roles. Trellis keeps lifecycle ownership while compatible SKILL.md methods provide reusable procedures.",
+  "migrations": [],
+  "configSectionsAdded": [
+    {
+      "file": ".trellis/config.yaml",
+      "sentinel": "method_skills:",
+      "sectionHeading": "Method Skills"
+    }
+  ],
+  "notes": "Run `trellis update` to refresh generated runtime and role files. Existing config.yaml files receive the optional commented method-skills section additively."
+}

--- a/packages/cli/src/templates/common/skills/before-dev.md
+++ b/packages/cli/src/templates/common/skills/before-dev.md
@@ -1,5 +1,17 @@
 Read the relevant development guidelines before starting your task.
 
+## Optional Method Skills
+
+At role entry, run:
+
+```bash
+{{PYTHON_CMD}} ./.trellis/scripts/get_context.py --mode method-skills --slot implement
+```
+
+If the command lists method skills, load each listed `SKILL.md` in order and apply those methods while implementing. The first method is primary; later methods are supporting.
+
+The Trellis workflow contract takes precedence over method-skill instructions. Trellis continues to own task scope, artifacts, Git restrictions, dispatch, and reporting. If no methods are configured, continue with the built-in role unchanged.
+
 Execute these steps:
 
 1. **Read current task artifacts**:

--- a/packages/cli/src/templates/common/skills/brainstorm.md
+++ b/packages/cli/src/templates/common/skills/brainstorm.md
@@ -18,6 +18,18 @@ Do not ask the user to confirm facts that the repository can answer. Ask only fo
 
 Repository evidence establishes current behavior and technical constraints. The user's intended behavior, feature scope boundaries, and UX preferences are never answerable by repository evidence alone, even when an existing pattern exists; existing patterns are options and recommendation evidence, not decisions.
 
+## Optional Method Skills
+
+At role entry, run:
+
+```bash
+{{PYTHON_CMD}} ./.trellis/scripts/get_context.py --mode method-skills --slot brainstorm
+```
+
+If the command lists method skills, load each listed `SKILL.md` in order and use those methods while following the Planning Flow below. The first method is primary; later methods are supporting.
+
+The Trellis workflow contract takes precedence over method-skill instructions. Trellis continues to own task state, planning artifacts, phase gates, and implementation authorization. If no methods are configured, continue with the built-in flow unchanged.
+
 ---
 
 Use this skill during Phase 1 planning to turn the user's request into clear requirements and planning artifacts.

--- a/packages/cli/src/templates/common/skills/break-loop.md
+++ b/packages/cli/src/templates/common/skills/break-loop.md
@@ -2,6 +2,18 @@
 
 When debug is complete, use this for deep analysis to break the "fix bug -> forget -> repeat" cycle.
 
+## Optional Method Skills
+
+At role entry, run:
+
+```bash
+{{PYTHON_CMD}} ./.trellis/scripts/get_context.py --mode method-skills --slot debug
+```
+
+If the command lists method skills, load each listed `SKILL.md` in order and apply those methods during diagnosis. The first method is primary; later methods are supporting.
+
+The Trellis workflow contract takes precedence over method-skill instructions. Trellis continues to own recovery scope, lifecycle state, knowledge capture, and reporting. If no methods are configured, continue with the built-in role unchanged.
+
 ---
 
 ## Analysis Framework

--- a/packages/cli/src/templates/common/skills/check.md
+++ b/packages/cli/src/templates/common/skills/check.md
@@ -2,6 +2,18 @@
 
 Comprehensive quality verification for recently written code. Combines spec compliance, cross-layer safety, and pre-commit checks.
 
+## Optional Method Skills
+
+At role entry, run:
+
+```bash
+{{PYTHON_CMD}} ./.trellis/scripts/get_context.py --mode method-skills --slot check
+```
+
+If the command lists method skills, load each listed `SKILL.md` in order and apply those methods while checking. The first method is primary; later methods are supporting.
+
+The Trellis workflow contract takes precedence over method-skill instructions. Trellis continues to own verification scope, completion gates, spec sync, and reporting. If no methods are configured, continue with the built-in role unchanged.
+
 ---
 
 ## Step 1: Identify What Changed

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -455,6 +455,32 @@ def _materialize_artifact(
     return _budgeted_block(budget, header_label, file_path, content, reason, size)
 
 
+def get_method_skills_context(repo_root: str, slot: str) -> str:
+    """Return optional method-skill instructions for a workflow role."""
+    scripts_dir = Path(repo_root) / DIR_WORKFLOW / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    try:
+        from common.method_skills import (  # type: ignore[import-not-found]
+            format_method_skills,
+            resolve_method_skills,
+        )
+
+        result = resolve_method_skills(slot, Path(repo_root))
+        if not result["methods"] and not result["diagnostics"]:
+            return ""
+        return (
+            f"=== Method Skills ({slot}) ===\n"
+            f"{format_method_skills(result)}"
+        )
+    except (ImportError, OSError, RuntimeError) as error:
+        return (
+            f"=== Method Skills ({slot}) ===\n"
+            f"[WARN] method_skills.{slot}: unable to load configured methods: {error}\n"
+            "Continue with the built-in Trellis role."
+        )
+
+
 def get_implement_context(repo_root: str, task_dir: str) -> str:
     """
     Complete context for Implement Agent
@@ -468,6 +494,10 @@ def get_implement_context(repo_root: str, task_dir: str) -> str:
     limits = _get_limits(repo_root)
     budget = _Budget(limits["max_total_bytes"])
     context_parts = []
+
+    method_context = get_method_skills_context(repo_root, "implement")
+    if method_context:
+        context_parts.append(method_context)
 
     # 1. Read implement.jsonl
     base_context = get_agent_context(repo_root, task_dir, "implement", limits, budget)
@@ -520,6 +550,10 @@ def get_check_context(repo_root: str, task_dir: str) -> str:
     limits = _get_limits(repo_root)
     budget = _Budget(limits["max_total_bytes"])
     context_parts = []
+
+    method_context = get_method_skills_context(repo_root, "check")
+    if method_context:
+        context_parts.append(method_context)
 
     base_context = get_agent_context(repo_root, task_dir, "check", limits, budget)
     if base_context:

--- a/packages/cli/src/templates/trellis/config.yaml
+++ b/packages/cli/src/templates/trellis/config.yaml
@@ -138,3 +138,29 @@ channel:
 #
 # prompt_injection:
 #   skip_keyword: "no-trellis"   # "" disables the escape hatch entirely
+
+#-------------------------------------------------------------------------------
+# Method Skills
+#-------------------------------------------------------------------------------
+# Compose reusable Agent Skills inside Trellis workflow roles. Trellis still
+# owns task state, artifacts, phase gates, Git restrictions, dispatch, and
+# reporting; these skills contribute only the method used inside that role.
+#
+# References are evaluated in list order. The first resolved method is primary;
+# later methods are supporting. Invalid references warn and fall back to the
+# built-in Trellis role.
+#
+# Reference forms:
+# - Project-local skill directory, relative to the project root
+# - global:<name>, resolved as ~/.agents/skills/<name>/SKILL.md
+#
+# method_skills:
+#   brainstorm:
+#     - global:grilling
+#   implement:
+#     - global:tdd
+#     - global:codebase-design
+#   check:
+#     - global:code-review
+#   debug:
+#     - global:diagnosing-bugs

--- a/packages/cli/src/templates/trellis/index.ts
+++ b/packages/cli/src/templates/trellis/index.ts
@@ -21,6 +21,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { injectMethodSkillsPreludeMarkdown } from "../../configurators/shared.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -54,6 +55,9 @@ export const commonSessionContext = readTemplate(
 );
 export const commonPackagesContext = readTemplate(
   "scripts/common/packages_context.py",
+);
+export const commonMethodSkills = readTemplate(
+  "scripts/common/method_skills.py",
 );
 export const commonWorkflowPhase = readTemplate(
   "scripts/common/workflow_phase.py",
@@ -110,6 +114,7 @@ export function getAllScripts(): Map<string, string> {
   scripts.set("common/task_store.py", commonTaskStore);
   scripts.set("common/session_context.py", commonSessionContext);
   scripts.set("common/packages_context.py", commonPackagesContext);
+  scripts.set("common/method_skills.py", commonMethodSkills);
   scripts.set("common/workflow_phase.py", commonWorkflowPhase);
   scripts.set("common/trellis_config.py", commonTrellisConfig);
   scripts.set("common/safe_commit.py", commonSafeCommit);
@@ -134,7 +139,13 @@ export function getAllScripts(): Map<string, string> {
  */
 export function getAllAgents(): Map<string, string> {
   const agents = new Map<string, string>();
-  agents.set("implement.md", implementAgentTemplate);
-  agents.set("check.md", checkAgentTemplate);
+  agents.set(
+    "implement.md",
+    injectMethodSkillsPreludeMarkdown(implementAgentTemplate, "implement"),
+  );
+  agents.set(
+    "check.md",
+    injectMethodSkillsPreludeMarkdown(checkAgentTemplate, "check"),
+  );
   return agents;
 }

--- a/packages/cli/src/templates/trellis/scripts/common/git_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/git_context.py
@@ -27,6 +27,11 @@ from .packages_context import (
     get_context_packages_text,
     get_context_packages_json,
 )
+from .method_skills import (
+    METHOD_SLOTS,
+    get_method_skills_text,
+    resolve_method_skills,
+)
 from .trellis_config import read_trellis_config
 from .workflow_phase import (
     filter_platform,
@@ -57,9 +62,19 @@ def main() -> None:
     parser.add_argument(
         "--mode",
         "-m",
-        choices=["default", "record", "packages", "phase"],
+        choices=[
+            "default",
+            "record",
+            "packages",
+            "phase",
+            "method-skills",
+        ],
         default="default",
-        help="Output mode: default (full context), record (for record-session), packages (package info only), phase (workflow step extraction)",
+        help=(
+            "Output mode: default (full context), record (for record-session), "
+            "packages (package info only), phase (workflow step extraction), "
+            "method-skills (resolved methods for a workflow role)"
+        ),
     )
     parser.add_argument(
         "--step",
@@ -68,6 +83,11 @@ def main() -> None:
     parser.add_argument(
         "--platform",
         help="Platform name for --mode phase, e.g. cursor, claude-code. Filters platform-tagged blocks.",
+    )
+    parser.add_argument(
+        "--slot",
+        choices=METHOD_SLOTS,
+        help="Workflow role for --mode method-skills.",
     )
 
     args = parser.parse_args()
@@ -95,6 +115,19 @@ def main() -> None:
             )
             content = filter_platform(content, effective)
         print(content, end="")
+    elif args.mode == "method-skills":
+        if not args.slot:
+            parser.error("--slot is required for --mode method-skills")
+        if args.json:
+            print(
+                json.dumps(
+                    resolve_method_skills(args.slot),
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            print(get_method_skills_text(args.slot))
     else:
         if args.json:
             output_json()

--- a/packages/cli/src/templates/trellis/scripts/common/method_skills.py
+++ b/packages/cli/src/templates/trellis/scripts/common/method_skills.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Resolve optional method skills for Trellis workflow roles."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PureWindowsPath
+from typing import TypedDict
+
+from .config import _load_config
+from .paths import get_repo_root
+
+
+METHOD_SLOTS = ("brainstorm", "implement", "check", "debug")
+GLOBAL_METHOD_PREFIX = "global:"
+GLOBAL_METHOD_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class ResolvedMethod(TypedDict):
+    reference: str
+    path: str
+
+
+class MethodDiagnostic(TypedDict):
+    reference: str
+    code: str
+    message: str
+
+
+class MethodSkillsResult(TypedDict):
+    slot: str
+    methods: list[ResolvedMethod]
+    diagnostics: list[MethodDiagnostic]
+
+
+def _diagnostic(reference: str, code: str, message: str) -> MethodDiagnostic:
+    return {"reference": reference, "code": code, "message": message}
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _method_skill_path(
+    reference: str,
+    repo_root: Path,
+) -> tuple[Path | None, MethodDiagnostic | None]:
+    """Validate a method reference and return its canonical SKILL.md path."""
+    if reference.startswith(GLOBAL_METHOD_PREFIX):
+        name = reference.removeprefix(GLOBAL_METHOD_PREFIX)
+        if not GLOBAL_METHOD_NAME.fullmatch(name):
+            return None, _diagnostic(
+                reference,
+                "invalid-global-name",
+                "global method names may contain only letters, numbers, dots, underscores, and hyphens",
+            )
+        try:
+            boundary_root = (Path.home() / ".agents" / "skills").resolve()
+            skill_dir = (boundary_root / name).resolve()
+        except (OSError, RuntimeError):
+            return None, _diagnostic(
+                reference,
+                "skill-not-found",
+                "method skill path could not be resolved",
+            )
+        if not _is_within(skill_dir, boundary_root):
+            return None, _diagnostic(
+                reference,
+                "outside-global-root",
+                "global method references must stay within ~/.agents/skills",
+            )
+    else:
+        reference_path = Path(reference)
+        if reference_path.is_absolute() or PureWindowsPath(reference).is_absolute():
+            return None, _diagnostic(
+                reference,
+                "outside-project",
+                "project-local method references must be relative to the project root",
+            )
+        try:
+            skill_dir = (repo_root / reference_path).resolve()
+        except (OSError, RuntimeError):
+            return None, _diagnostic(
+                reference,
+                "skill-not-found",
+                "method skill path could not be resolved",
+            )
+        if not _is_within(skill_dir, repo_root):
+            return None, _diagnostic(
+                reference,
+                "outside-project",
+                "project-local method references must stay within the project root",
+            )
+        boundary_root = repo_root
+
+    try:
+        skill_path = (skill_dir / "SKILL.md").resolve()
+    except (OSError, RuntimeError):
+        return None, _diagnostic(
+            reference,
+            "skill-not-found",
+            "method skill path could not be resolved",
+        )
+    if not _is_within(skill_path, boundary_root):
+        code = (
+            "outside-global-root"
+            if reference.startswith(GLOBAL_METHOD_PREFIX)
+            else "outside-project"
+        )
+        message = (
+            "global method references must stay within ~/.agents/skills"
+            if reference.startswith(GLOBAL_METHOD_PREFIX)
+            else "project-local method references must stay within the project root"
+        )
+        return None, _diagnostic(reference, code, message)
+    if not skill_dir.is_dir() or not skill_path.is_file():
+        return None, _diagnostic(
+            reference,
+            "skill-not-found",
+            "method reference must identify a directory containing SKILL.md",
+        )
+    if not os.access(skill_path, os.R_OK):
+        return None, _diagnostic(
+            reference,
+            "skill-unreadable",
+            "method SKILL.md is not readable",
+        )
+    return skill_path, None
+
+
+def resolve_method_skills(
+    slot: str,
+    repo_root: Path | None = None,
+) -> MethodSkillsResult:
+    """Resolve configured method skills for one workflow role."""
+    root = (repo_root or get_repo_root()).resolve()
+    config = _load_config(root)
+    section = config.get("method_skills")
+    if section == "{}":
+        section = {}
+    methods: list[ResolvedMethod] = []
+    diagnostics: list[MethodDiagnostic] = []
+    seen_paths: set[Path] = set()
+
+    if section is None:
+        references: object = []
+    elif not isinstance(section, dict):
+        references = []
+        diagnostics.append(
+            _diagnostic(
+                "method_skills",
+                "invalid-config",
+                "method_skills must be a mapping of workflow slots to lists",
+            )
+        )
+    else:
+        references = section.get(slot, [])
+
+    if references == "[]":
+        references = []
+
+    if isinstance(references, list):
+        for reference in references:
+            if not isinstance(reference, str):
+                diagnostics.append(
+                    _diagnostic(
+                        repr(reference),
+                        "invalid-reference",
+                        "method references must be strings",
+                    )
+                )
+                continue
+            skill_path, diagnostic = _method_skill_path(reference, root)
+            if diagnostic:
+                diagnostics.append(diagnostic)
+                continue
+            if skill_path is not None and skill_path not in seen_paths:
+                seen_paths.add(skill_path)
+                methods.append(
+                    {
+                        "reference": reference,
+                        "path": str(skill_path),
+                    }
+                )
+
+    else:
+        diagnostics.append(
+            _diagnostic(
+                slot,
+                "invalid-config",
+                f"method_skills.{slot} must be a list",
+            )
+        )
+
+    return {"slot": slot, "methods": methods, "diagnostics": diagnostics}
+
+
+def format_method_skills(result: MethodSkillsResult) -> str:
+    """Format a previously resolved result without repeating filesystem work."""
+    slot = result["slot"]
+    methods = result["methods"]
+    diagnostics = result["diagnostics"]
+    lines = [
+        f"[WARN] method_skills.{slot} '{item['reference']}': {item['message']}"
+        for item in diagnostics
+    ]
+    if not methods and not diagnostics:
+        return f"No method skills configured for {slot}."
+
+    if methods:
+        lines.append(f"Method skills for {slot} (in configuration order):")
+        for index, method in enumerate(methods, start=1):
+            lines.append(f"{index}. {method['path']}")
+        lines.extend(
+            [
+                "Load each listed SKILL.md and apply its method inside this role.",
+                "The Trellis workflow contract takes precedence over method-skill instructions.",
+            ]
+        )
+    else:
+        lines.append("Continue with the built-in Trellis role.")
+    return "\n".join(lines)
+
+
+def get_method_skills_text(
+    slot: str,
+    repo_root: Path | None = None,
+) -> str:
+    """Resolve and format method skills as role-entry instructions."""
+    return format_method_skills(resolve_method_skills(slot, repo_root))

--- a/packages/cli/test/scripts/method-skills.integration.test.ts
+++ b/packages/cli/test/scripts/method-skills.integration.test.ts
@@ -1,0 +1,533 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  collectPlatformTemplates,
+  PLATFORM_IDS,
+} from "../../src/configurators/index.js";
+import { applyConfigSectionsAdded } from "../../src/commands/update.js";
+import { getConfigSectionsAddedBetween } from "../../src/migrations/index.js";
+import {
+  configYamlTemplate,
+  getAllAgents as getChannelAgents,
+  getAllScripts,
+} from "../../src/templates/trellis/index.js";
+
+const TEMPLATE_SCRIPTS = path.resolve(
+  __dirname,
+  "../../src/templates/trellis/scripts",
+);
+const SHARED_SUBAGENT_HOOK = path.resolve(
+  __dirname,
+  "../../src/templates/shared-hooks/inject-subagent-context.py",
+);
+
+function hasPython(): boolean {
+  try {
+    execFileSync("python3", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function setupGeneratedProject(root: string): void {
+  fs.mkdirSync(path.join(root, ".trellis", "scripts"), { recursive: true });
+  fs.cpSync(TEMPLATE_SCRIPTS, path.join(root, ".trellis", "scripts"), {
+    recursive: true,
+  });
+}
+
+function writeProjectMethod(root: string, name: string): string {
+  const skillDir = path.join(root, ".agents", "skills", name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  const skillPath = path.join(skillDir, "SKILL.md");
+  fs.writeFileSync(skillPath, `# ${name}\n`, "utf-8");
+  return skillPath;
+}
+
+function runMethodSkills(
+  root: string,
+  slot: "brainstorm" | "implement" | "check" | "debug",
+  env: NodeJS.ProcessEnv = process.env,
+): { slot: string; methods: unknown[]; diagnostics: unknown[] } {
+  const output = execFileSync(
+    "python3",
+    [
+      path.join(root, ".trellis", "scripts", "get_context.py"),
+      "--mode",
+      "method-skills",
+      "--slot",
+      slot,
+      "--json",
+    ],
+    { cwd: root, encoding: "utf-8", env },
+  );
+  return JSON.parse(output) as {
+    slot: string;
+    methods: unknown[];
+    diagnostics: unknown[];
+  };
+}
+
+describe.skipIf(!hasPython())("method skills", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-method-skills-"));
+    setupGeneratedProject(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves a project-local brainstorm method through the generated runtime", () => {
+    const skillPath = writeProjectMethod(tmpDir, "team-brainstorm");
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      [
+        "method_skills:",
+        "  brainstorm:",
+        "    - .agents/skills/team-brainstorm",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    expect(runMethodSkills(tmpDir, "brainstorm")).toEqual({
+      slot: "brainstorm",
+      methods: [
+        {
+          reference: ".agents/skills/team-brainstorm",
+          path: fs.realpathSync(skillPath),
+        },
+      ],
+      diagnostics: [],
+    });
+  });
+
+  it("keeps brainstorm behavior unchanged when no methods are configured", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "session_auto_commit: true\n",
+      "utf-8",
+    );
+
+    expect(runMethodSkills(tmpDir, "brainstorm")).toEqual({
+      slot: "brainstorm",
+      methods: [],
+      diagnostics: [],
+    });
+  });
+
+  it("accepts YAML inline empty containers as no method configuration", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "method_skills:\n  brainstorm: []\n",
+      "utf-8",
+    );
+    expect(runMethodSkills(tmpDir, "brainstorm")).toEqual({
+      slot: "brainstorm",
+      methods: [],
+      diagnostics: [],
+    });
+
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      "method_skills: {}\n",
+      "utf-8",
+    );
+    expect(runMethodSkills(tmpDir, "brainstorm")).toEqual({
+      slot: "brainstorm",
+      methods: [],
+      diagnostics: [],
+    });
+  });
+
+  it("composes named global and project methods in order without duplicates", () => {
+    const projectSkill = writeProjectMethod(tmpDir, "team-brainstorm");
+    const fakeHome = path.join(tmpDir, "home");
+    const globalSkill = writeProjectMethod(fakeHome, "grilling");
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      [
+        "method_skills:",
+        "  brainstorm:",
+        "    - global:grilling",
+        "    - .agents/skills/team-brainstorm",
+        "    - global:grilling",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    expect(
+      runMethodSkills(tmpDir, "brainstorm", {
+        ...process.env,
+        HOME: fakeHome,
+      }),
+    ).toEqual({
+      slot: "brainstorm",
+      methods: [
+        {
+          reference: "global:grilling",
+          path: fs.realpathSync(globalSkill),
+        },
+        {
+          reference: ".agents/skills/team-brainstorm",
+          path: fs.realpathSync(projectSkill),
+        },
+      ],
+      diagnostics: [],
+    });
+  });
+
+  it("rejects unsafe or missing references with visible diagnostics and fallback", () => {
+    fs.writeFileSync(path.join(tmpDir, "ordinary.txt"), "not a skill\n");
+    fs.mkdirSync(path.join(tmpDir, ".agents", "skills", "empty"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      [
+        "method_skills:",
+        "  brainstorm:",
+        "    - ../outside-project",
+        "    - /absolute/method",
+        "    - global:../secret",
+        "    - .agents/skills/missing",
+        "    - ordinary.txt",
+        "    - .agents/skills/empty",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = runMethodSkills(tmpDir, "brainstorm");
+    expect(result.methods).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        reference: "../outside-project",
+        code: "outside-project",
+      }),
+      expect.objectContaining({
+        reference: "/absolute/method",
+        code: "outside-project",
+      }),
+      expect.objectContaining({
+        reference: "global:../secret",
+        code: "invalid-global-name",
+      }),
+      expect.objectContaining({
+        reference: ".agents/skills/missing",
+        code: "skill-not-found",
+      }),
+      expect.objectContaining({
+        reference: "ordinary.txt",
+        code: "skill-not-found",
+      }),
+      expect.objectContaining({
+        reference: ".agents/skills/empty",
+        code: "skill-not-found",
+      }),
+    ]);
+
+    const textOutput = execFileSync(
+      "python3",
+      [
+        path.join(tmpDir, ".trellis", "scripts", "get_context.py"),
+        "--mode",
+        "method-skills",
+        "--slot",
+        "brainstorm",
+      ],
+      { cwd: tmpDir, encoding: "utf-8" },
+    );
+    expect(textOutput).toContain(
+      "[WARN] method_skills.brainstorm '../outside-project'",
+    );
+    expect(textOutput).toContain("Continue with the built-in Trellis role");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a project SKILL.md symlink that escapes the project root",
+    () => {
+      const externalDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "trellis-external-method-"),
+      );
+      try {
+        const externalSkill = path.join(externalDir, "SKILL.md");
+        fs.writeFileSync(externalSkill, "# external\n", "utf-8");
+        const localDir = path.join(tmpDir, ".agents", "skills", "escaped");
+        fs.mkdirSync(localDir, { recursive: true });
+        fs.symlinkSync(externalSkill, path.join(localDir, "SKILL.md"));
+        fs.writeFileSync(
+          path.join(tmpDir, ".trellis", "config.yaml"),
+          "method_skills:\n  brainstorm:\n    - .agents/skills/escaped\n",
+          "utf-8",
+        );
+
+        expect(runMethodSkills(tmpDir, "brainstorm")).toEqual({
+          slot: "brainstorm",
+          methods: [],
+          diagnostics: [
+            expect.objectContaining({
+              reference: ".agents/skills/escaped",
+              code: "outside-project",
+            }),
+          ],
+        });
+      } finally {
+        fs.rmSync(externalDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reports a global skill symlink loop without stopping the role",
+    () => {
+      const fakeHome = path.join(tmpDir, "loop-home");
+      const globalRoot = path.join(fakeHome, ".agents", "skills");
+      fs.mkdirSync(globalRoot, { recursive: true });
+      fs.symlinkSync("loop", path.join(globalRoot, "loop"));
+      fs.writeFileSync(
+        path.join(tmpDir, ".trellis", "config.yaml"),
+        "method_skills:\n  brainstorm:\n    - global:loop\n",
+        "utf-8",
+      );
+
+      expect(
+        runMethodSkills(tmpDir, "brainstorm", {
+          ...process.env,
+          HOME: fakeHome,
+        }),
+      ).toEqual({
+        slot: "brainstorm",
+        methods: [],
+        diagnostics: [
+          expect.objectContaining({
+            reference: "global:loop",
+            code: "skill-not-found",
+          }),
+        ],
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reports an unreadable SKILL.md and keeps the built-in role available",
+    () => {
+      const skillPath = writeProjectMethod(tmpDir, "unreadable");
+      fs.writeFileSync(
+        path.join(tmpDir, ".trellis", "config.yaml"),
+        "method_skills:\n  debug:\n    - .agents/skills/unreadable\n",
+        "utf-8",
+      );
+      fs.chmodSync(skillPath, 0o000);
+      try {
+        expect(runMethodSkills(tmpDir, "debug")).toEqual({
+          slot: "debug",
+          methods: [],
+          diagnostics: [
+            expect.objectContaining({
+              reference: ".agents/skills/unreadable",
+              code: "skill-unreadable",
+            }),
+          ],
+        });
+      } finally {
+        fs.chmodSync(skillPath, 0o600);
+      }
+    },
+  );
+
+  it("generates a brainstorm role that composes methods under Trellis ownership", () => {
+    const templates = collectPlatformTemplates("claude-code");
+    const brainstorm = templates?.get(
+      ".claude/skills/trellis-brainstorm/SKILL.md",
+    );
+
+    expect(brainstorm).toContain(
+      "get_context.py --mode method-skills --slot brainstorm",
+    );
+    expect(brainstorm).toContain("Trellis workflow contract takes precedence");
+    expect(brainstorm).toContain("planning artifacts");
+  });
+
+  it("loads role-specific methods in every generated inline workflow role", () => {
+    const expectedSlots = new Map([
+      ["trellis-before-dev", "implement"],
+      ["trellis-check", "check"],
+      ["trellis-break-loop", "debug"],
+    ]);
+
+    for (const platform of PLATFORM_IDS) {
+      const templates = collectPlatformTemplates(platform);
+      expect(templates, `${platform} should collect its templates`).toBeDefined();
+      for (const [role, slot] of expectedSlots) {
+        const entries = [...(templates?.entries() ?? [])].filter(
+          ([filePath]) =>
+            filePath.includes(role) &&
+            !/\/(agents|droids)\//.test(filePath) &&
+            !/^\.reasonix\/skills\/trellis-(implement|check)\//.test(
+              filePath,
+            ),
+        );
+        if (role !== "trellis-check") {
+          expect(
+            entries.length,
+            `${platform} should generate ${role}`,
+          ).toBeGreaterThan(0);
+        }
+        for (const [filePath, content] of entries) {
+          expect(content, filePath).toContain(
+            `get_context.py --mode method-skills --slot ${slot}`,
+          );
+          expect(content, filePath).toContain(
+            "Trellis workflow contract takes precedence",
+          );
+        }
+      }
+    }
+  });
+
+  it("delivers methods at every generated implement and check subagent entry", () => {
+    for (const platform of PLATFORM_IDS) {
+      const templates = collectPlatformTemplates(platform);
+      if (!templates) continue;
+      const agentEntries = [...templates.entries()].filter(([filePath]) => {
+        const normalAgent = /\/(agents|droids)\/trellis-(implement|check)(\.|\/)/.test(
+          filePath,
+        );
+        const reasonixAgent =
+          /^\.reasonix\/skills\/trellis-(implement|check)\/SKILL\.md$/.test(
+            filePath,
+          );
+        return normalAgent || reasonixAgent;
+      });
+
+      for (const [filePath, content] of agentEntries) {
+        const slot = filePath.includes("trellis-check") ? "check" : "implement";
+        expect(
+          content,
+          `${platform}:${filePath} must load ${slot} methods at role entry`,
+        ).toContain(`get_context.py --mode method-skills --slot ${slot}`);
+      }
+    }
+  });
+
+  it("injects configured methods into native subagent context", () => {
+    const skillPath = writeProjectMethod(tmpDir, "test-first");
+    const taskDir = path.join(tmpDir, ".trellis", "tasks", "method-task");
+    fs.mkdirSync(taskDir, { recursive: true });
+    fs.writeFileSync(path.join(taskDir, "prd.md"), "# Method task\n");
+    fs.writeFileSync(
+      path.join(tmpDir, ".trellis", "config.yaml"),
+      [
+        "method_skills:",
+        "  implement:",
+        "    - .agents/skills/test-first",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const probe = [
+      "import importlib.util",
+      `spec = importlib.util.spec_from_file_location('hook', ${JSON.stringify(SHARED_SUBAGENT_HOOK)})`,
+      "hook = importlib.util.module_from_spec(spec)",
+      "spec.loader.exec_module(hook)",
+      `print(hook.get_implement_context(${JSON.stringify(tmpDir)}, '.trellis/tasks/method-task'))`,
+    ].join("\n");
+    const output = execFileSync("python3", ["-c", probe], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(output).toContain(fs.realpathSync(skillPath));
+    expect(output).toContain(
+      "The Trellis workflow contract takes precedence over method-skill instructions",
+    );
+  });
+
+  it("keeps native-hook method-loading failures visible and non-fatal", () => {
+    const emptyRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "trellis-method-hook-missing-"),
+    );
+    try {
+      const probe = [
+        "import importlib.util",
+        `spec = importlib.util.spec_from_file_location('hook', ${JSON.stringify(SHARED_SUBAGENT_HOOK)})`,
+        "hook = importlib.util.module_from_spec(spec)",
+        "spec.loader.exec_module(hook)",
+        `print(hook.get_method_skills_context(${JSON.stringify(emptyRoot)}, 'implement'))`,
+      ].join("\n");
+      const output = execFileSync("python3", ["-c", probe], {
+        cwd: emptyRoot,
+        encoding: "utf-8",
+      });
+
+      expect(output).toContain("[WARN] method_skills.implement");
+      expect(output).toContain("Continue with the built-in Trellis role");
+    } finally {
+      fs.rmSync(emptyRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("loads methods in Trellis channel runtime agents", () => {
+    for (const [name, content] of getChannelAgents()) {
+      const slot = name === "check.md" ? "check" : "implement";
+      expect(content).toContain(
+        `get_context.py --mode method-skills --slot ${slot}`,
+      );
+      expect(content).toContain("Trellis workflow contract takes precedence");
+    }
+  });
+
+  it("ships the resolver and documented method slots in new projects", () => {
+    expect(getAllScripts().has("common/method_skills.py")).toBe(true);
+    expect(configYamlTemplate).toContain("# Method Skills");
+    expect(configYamlTemplate).toContain("# method_skills:");
+    expect(configYamlTemplate).toContain("#   brainstorm:");
+    expect(configYamlTemplate).toContain("#   implement:");
+    expect(configYamlTemplate).toContain("#   check:");
+    expect(configYamlTemplate).toContain("#   debug:");
+    expect(configYamlTemplate).toContain("global:grilling");
+    expect(configYamlTemplate).toContain("global:tdd");
+  });
+
+  it("adds method-skills configuration to upgraded projects idempotently", () => {
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    fs.writeFileSync(
+      configPath,
+      "session_commit_message: local-customization\n",
+      "utf-8",
+    );
+    const entries = getConfigSectionsAddedBetween("0.6.8", "0.6.9");
+    expect(entries).toContainEqual({
+      file: ".trellis/config.yaml",
+      sentinel: "method_skills:",
+      sectionHeading: "Method Skills",
+    });
+    const templates = new Map([
+      [".trellis/config.yaml", configYamlTemplate],
+    ]);
+
+    expect(applyConfigSectionsAdded(entries, tmpDir, templates)).toEqual({
+      appended: 1,
+    });
+    const upgraded = fs.readFileSync(configPath, "utf-8");
+    expect(upgraded).toContain("session_commit_message: local-customization");
+    expect(upgraded).toContain("# Method Skills");
+    expect(upgraded.match(/method_skills:/g)).toHaveLength(1);
+
+    expect(applyConfigSectionsAdded(entries, tmpDir, templates)).toEqual({
+      appended: 0,
+    });
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(upgraded);
+  });
+});


### PR DESCRIPTION
## Summary

- add optional `method_skills` slots for brainstorm, implement, check, and debug
- resolve ordered project-local and `global:<name>` Agent Skills with canonical-path deduplication, boundary checks, visible diagnostics, and non-fatal fallback
- compose methods inside Trellis-owned roles across Markdown, TOML, JSON, native-hook, pull-based, inline, and channel-runtime entry paths
- add an additive 0.6.9 config migration, bilingual documentation, dogfood runtime parity, and integration coverage

## Why

Trellis should remain responsible for task state, planning artifacts, lifecycle gates, Git constraints, dispatch, verification, and reporting, while reusable Agent Skills contribute role-specific methods such as `grilling`, `tdd`, `codebase-design`, `code-review`, and `diagnosing-bugs`. This avoids copying third-party prompts or replacing Trellis roles and losing workflow guarantees.

## Behavior

```yaml
method_skills:
  brainstorm:
    - global:grilling
  implement:
    - global:tdd
    - global:codebase-design
  check:
    - global:code-review
  debug:
    - global:diagnosing-bugs
```

Project-local references are directories relative to the repository root. Named global references resolve beneath `~/.agents/skills/`. The first resolved method is primary, later methods are supporting, duplicate canonical paths are ignored, and invalid methods warn before Trellis continues with its built-in role.

This first version deliberately does not install, download, pin, discover, or recursively resolve skills, and it does not allow an external skill to replace a complete Trellis workflow role.

## Validation

- Standards review: PASS
- Spec review: PASS
- generated-platform runtime audit: 20 platforms, 1,011 init/update files compared byte-for-byte, 32 implement/check role entries verified
- generated Python runtime probes: all four slots, project/global ordering, canonical deduplication, inline empty YAML containers, project-boundary symlink escape, global symlink-loop fallback, native-hook success and visible failure fallback
- Python `py_compile`: PASS
- template/dogfood Python files: byte-identical
- TypeScript syntax stripping: PASS
- migration manifest JSON parse: PASS
- `git diff --check`: PASS

The repository's Vitest/typecheck commands could not run locally because dependencies were absent and the restricted environment could not reach the npm registry. The added Vitest integration suite is intended to run in CI.
