### PR TITLE
fix(cli): skip binary context files

### DIFF
--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -1276,20 +1276,25 @@ The route depends on task intent, artifact presence, and execution mode. Missing
 
 ### 1. Scope / Trigger
 
-Sub-agent context injection (hook Python + Pi extension TS) caps how much task
-context is inlined into a sub-agent's first prompt. Added for #441 (task
-`07-22-subagent-context-limits`). Any change to injection formatting, caps, or
-config keys MUST be applied to **both** implementations:
+Sub-agent context injection (hook Python + Pi extension TS + OpenCode plugin)
+caps how much task context is inlined into a sub-agent's first prompt. Added for
+#441 (task `07-22-subagent-context-limits`). Any change to injection formatting,
+caps, binary detection, or config keys MUST be applied to **all three**
+implementations:
 
 - `packages/cli/src/templates/shared-hooks/inject-subagent-context.py`
 - `packages/cli/src/templates/pi/extensions/trellis/index.ts.txt`
+- `packages/cli/src/templates/opencode/lib/trellis-context.js`
 
 ### 2. Signatures
 
 - Python: `common.config.get_context_injection_limits() -> dict[str, int]`,
-  `truncate_utf8(data: bytes, cap: int) -> bytes`
+  `truncate_utf8(data: bytes, cap: int) -> bytes`,
+  `_is_binary_content(data: bytes) -> bool`
 - TS: `readContextInjectionLimits(repoRoot: string)`, `truncateUtf8(buf: Buffer, cap: number)`
   (exported for tests via `loadExtensionInternals()` in `pi.test.ts`)
+- OpenCode JS: `readContextInjectionLimits(repoRoot)`, `truncateUtf8(buf, cap)`,
+  `materializeFile(basePath, filePath, reason, limits, budget)`
 
 ### 3. Contracts
 
@@ -1303,13 +1308,18 @@ context_injection:
 ```
 
 - `0` disables that limit; negative / non-int → default + stderr warning.
-- Notice strings (byte-frozen, identical in both implementations):
+- Notice strings (byte-frozen, identical in all three implementations):
   - truncation: `\n[Trellis: truncated at {cap} bytes — read {path} for the full content]`
   - degradation: `[Trellis: not inlined (total context limit reached) — {path} ({size} bytes): {reason}]`
+  - binary reference: `[Trellis: not inlined (binary file) — {path} ({size} bytes): {reason}]`
 - Artifact reasons: `Requirements document` / `Technical design document` / `Execution plan document`.
 - Accounting: `=== path ===` headers and notices count toward `max_total_bytes`.
   Processing order unchanged: jsonl entries first, then prd → design → implement.md.
 - Truncation is UTF-8-safe: back off over continuation bytes; drop an incomplete lead byte.
+- JSONL-referenced files are classified from bytes, not extensions. A NUL byte
+  or invalid UTF-8 marks the file as binary. Binary bytes are never decoded or
+  inlined, including when `max_file_bytes` and `max_total_bytes` are `0`; only
+  the binary-reference notice counts toward the total budget.
 - `task.py validate` emits non-blocking hygiene warnings (yellow, exit code unchanged):
   code-file extension outside `.trellis/spec/`, `docs/`, `docs-site/`, or the task's
   own dir; and entries larger than `max_file_bytes`.
@@ -1320,12 +1330,15 @@ context_injection:
 - file > `max_file_bytes` → truncated + truncation notice
 - artifact > `max_artifact_bytes` → truncated + truncation notice
 - next block would exceed `max_total_bytes` → index line instead of content
+- referenced file contains NUL or invalid UTF-8 → binary-reference notice only
 - invalid config value → default for that key + stderr warning, never a crash
 
 ### 5. Good/Base/Bad Cases
 
 - Good: curated spec files of a few KB — output byte-identical to pre-cap behavior.
 - Base: one 2 MiB file → ≤32 KiB inlined + notice; total payload ≤128 KiB.
+- Binary: PNG or invalid UTF-8 with unlimited caps → path/size/reason notice,
+  with no `=== path ===` block and no decoded bytes.
 - Bad (guarded): setting values via env vars or CLI flags — not supported; config.yaml only.
 
 ### 6. Tests Required
@@ -1335,20 +1348,24 @@ context_injection:
   3-file total overflow / `0` disable / config override / golden under-cap / validate warnings).
 - TS: `packages/cli/test/templates/pi.test.ts` `describe("pi extension: context injection limits (issue #441)")`
   — same matrix, asserts the exact frozen notice strings.
+- OpenCode: `packages/cli/test/templates/opencode.test.ts`
+  `describe("opencode context injection limits (issue #441)")` — same binary
+  and limit behavior through the real prompt-injection plugin seam.
 - Template: `trellis.test.ts` asserts config.yaml's `context_injection` section exists and is fully commented.
 
 ### 7. Wrong vs Correct
 
 #### Wrong
 
-Change a notice string or cap semantics in one implementation only, or account
-only file bodies (not headers/notices) toward the total budget.
+Change a notice string, binary predicate, or cap semantics in one implementation
+only; infer binary content from the extension; or account only file bodies (not
+headers/notices) toward the total budget.
 
 #### Correct
 
-Treat the notice strings, key names, ordering, and accounting rules above as a
-frozen cross-implementation contract; change both sides plus both test suites in
-the same commit.
+Treat the notice strings, byte-based binary predicate, key names, ordering, and
+accounting rules above as a frozen cross-implementation contract; change all
+three loaders plus their regression suites in the same commit.
 
 > **Warning**: Pi's jsonl block format converged to the Python format
 > (`=== path ===` headers) in this change — an approved deviation from Pi's old

--- a/packages/cli/src/templates/opencode/lib/trellis-context.js
+++ b/packages/cli/src/templates/opencode/lib/trellis-context.js
@@ -10,7 +10,7 @@ import { isAbsolute, join } from "path"
 import { platform } from "os"
 import { execSync } from "child_process"
 import { createHash } from "crypto"
-import { Buffer } from "buffer"
+import { Buffer, isUtf8 } from "buffer"
 import process from "process"
 
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
@@ -208,6 +208,14 @@ function truncateNotice(path, cap) {
   return `\n[Trellis: truncated at ${cap} bytes — read ${path} for the full content]`
 }
 
+function isBinaryContent(data) {
+  return data.includes(0) || !isUtf8(data)
+}
+
+function binaryNotice(path, size, reason) {
+  return `[Trellis: not inlined (binary file) — ${path} (${size} bytes): ${reason}]`
+}
+
 function indexNotice(path, size, reason) {
   return `[Trellis: not inlined (total context limit reached) — ${path} (${size} bytes): ${reason}]`
 }
@@ -249,6 +257,11 @@ function materializeFile(basePath, filePath, reason, limits, budget) {
   if (data === null) return null
 
   const size = data.length
+  if (isBinaryContent(data)) {
+    const notice = binaryNotice(filePath, size, reason)
+    budget.add(Buffer.byteLength(notice, "utf-8"))
+    return notice
+  }
   const cap = limits.max_file_bytes
   const truncated = truncateUtf8(data, cap)
   let content = truncated.toString("utf-8")

--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -9,6 +9,7 @@ import {
   resolve,
 } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
+import { isUtf8 } from "node:buffer";
 
 // ── Types ──────────────────────────────────────────────────────────────
 type JsonObject = Record<string, unknown>;
@@ -838,6 +839,12 @@ class ContextBudget {
 function truncateNotice(path: string, cap: number): string {
   return `\n[Trellis: truncated at ${cap} bytes — read ${path} for the full content]`;
 }
+function isBinaryContent(data: Buffer): boolean {
+  return data.includes(0) || !isUtf8(data);
+}
+function binaryNotice(path: string, size: number, reason: string): string {
+  return `[Trellis: not inlined (binary file) — ${path} (${size} bytes): ${reason}]`;
+}
 function indexNotice(path: string, size: number, reason: string): string {
   return `[Trellis: not inlined (total context limit reached) — ${path} (${size} bytes): ${reason}]`;
 }
@@ -882,6 +889,11 @@ function materializeFile(
   const data = readFileBytes(basePath, filePath);
   if (data === null) return null;
   const size = data.length;
+  if (isBinaryContent(data)) {
+    const notice = binaryNotice(filePath, size, reason);
+    budget.add(Buffer.byteLength(notice, "utf-8"));
+    return notice;
+  }
   const cap = limits.max_file_bytes;
   const truncated = truncateUtf8(data, cap);
   let content = truncated.toString("utf-8");

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -246,6 +246,24 @@ def _truncate_notice(path: str, cap: int) -> str:
     return f"\n[Trellis: truncated at {cap} bytes — read {path} for the full content]"
 
 
+def _is_binary_content(data: bytes) -> bool:
+    """Return True when raw bytes should not be decoded into model context."""
+    if b"\x00" in data:
+        return True
+    try:
+        data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def _binary_notice(path: str, size: int, reason: str) -> str:
+    return (
+        f"[Trellis: not inlined (binary file) — "
+        f"{path} ({size} bytes): {reason}]"
+    )
+
+
 def _index_notice(path: str, size: int, reason: str) -> str:
     return (
         f"[Trellis: not inlined (total context limit reached) — "
@@ -286,6 +304,11 @@ def _materialize_file(
         return None
 
     size = len(data)
+    if _is_binary_content(data):
+        notice = _binary_notice(file_path, size, reason)
+        budget.add(len(notice.encode("utf-8")))
+        return notice
+
     cap = limits["max_file_bytes"]
     truncated_bytes = truncate_utf8(data, cap)
     content = truncated_bytes.decode("utf-8", errors="replace")

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -326,6 +326,51 @@ print("all-valid")
         expect(out).not.toContain("[Trellis: not inlined");
       });
 
+      it("keeps binary jsonl references as notices even when limits are unlimited", () => {
+        const taskDir = makeTask(tmp, "task-binary-reference");
+        const binary = Buffer.from([
+          0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x41, 0x42,
+        ]);
+        fs.writeFileSync(path.join(tmp, "design.png"), binary);
+        fs.writeFileSync(
+          path.join(tmp, "invalid.bin"),
+          Buffer.from([0xff, 0xfe, 0xfd]),
+        );
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          [
+            JSON.stringify({ file: "design.png", reason: "visual baseline" }),
+            JSON.stringify({ file: "invalid.bin", reason: "legacy export" }),
+          ].join("\n") + "\n",
+          "utf-8",
+        );
+        writeConfig(
+          tmp,
+          [
+            "context_injection:",
+            "  max_file_bytes: 0",
+            "  max_total_bytes: 0",
+          ].join("\n"),
+        );
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+
+        expect(out).toContain(
+          "[Trellis: not inlined (binary file) — design.png (10 bytes): visual baseline]",
+        );
+        expect(out).toContain(
+          "[Trellis: not inlined (binary file) — invalid.bin (3 bytes): legacy export]",
+        );
+        expect(out).not.toContain("=== design.png ===");
+        expect(out).not.toContain("=== invalid.bin ===");
+        expect(out).not.toContain("\u0000");
+        expect(out).not.toContain("�");
+      });
+
       it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", () => {
         const taskDir = makeTask(tmp, "task-oversize");
         fs.writeFileSync(

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -371,6 +371,60 @@ print("all-valid")
         expect(out).not.toContain("�");
       });
 
+      it("does not misclassify legitimate multi-byte UTF-8 content as binary", () => {
+        const taskDir = makeTask(tmp, "task-utf8-not-binary");
+        const multiByteContent =
+          "emoji: 🎉🚀 cjk: 中文测试 bmp: café naïve\n";
+        fs.writeFileSync(
+          path.join(tmp, "multibyte.md"),
+          multiByteContent,
+          "utf-8",
+        );
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: "multibyte.md", reason: "unicode spec" }) +
+            "\n",
+          "utf-8",
+        );
+        writeConfig(tmp, "");
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+
+        expect(out).toContain(`=== multibyte.md ===\n${multiByteContent}`);
+        expect(out).not.toContain("[Trellis: not inlined (binary file)");
+      });
+
+      it("classifies a file as binary when binary bytes appear only at the end", () => {
+        const taskDir = makeTask(tmp, "task-text-head-binary-tail");
+        const mixed = Buffer.concat([
+          Buffer.from("looks like a normal text file up front\n", "utf-8"),
+          Buffer.from([0x00, 0xff, 0xfe]),
+        ]);
+        fs.writeFileSync(path.join(tmp, "mixed.dat"), mixed);
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: "mixed.dat", reason: "mixed content" }) +
+            "\n",
+          "utf-8",
+        );
+        writeConfig(tmp, "");
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+
+        expect(out).toContain(
+          `[Trellis: not inlined (binary file) — mixed.dat (${mixed.length} bytes): mixed content]`,
+        );
+        expect(out).not.toContain("=== mixed.dat ===");
+      });
+
       it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", () => {
         const taskDir = makeTask(tmp, "task-oversize");
         fs.writeFileSync(

--- a/packages/cli/test/templates/opencode.test.ts
+++ b/packages/cli/test/templates/opencode.test.ts
@@ -1047,6 +1047,38 @@ describe("opencode context injection limits (issue #441)", () => {
       expect(prompt).not.toContain("[Trellis: not inlined");
     });
 
+    it("keeps binary jsonl references as notices even when limits are unlimited", async () => {
+      const binary = Buffer.from([
+        0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x41, 0x42,
+      ]);
+      writeFileSync(join(dir, "design.png"), binary);
+      writeFileSync(join(dir, "invalid.bin"), Buffer.from([0xff, 0xfe, 0xfd]));
+      writeJsonlEntries([
+        { file: "design.png", reason: "visual baseline" },
+        { file: "invalid.bin", reason: "legacy export" },
+      ]);
+      writeConfig(
+        [
+          "context_injection:",
+          "  max_file_bytes: 0",
+          "  max_total_bytes: 0",
+        ].join("\n"),
+      );
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(
+        "[Trellis: not inlined (binary file) — design.png (10 bytes): visual baseline]",
+      );
+      expect(prompt).toContain(
+        "[Trellis: not inlined (binary file) — invalid.bin (3 bytes): legacy export]",
+      );
+      expect(prompt).not.toContain("=== design.png ===");
+      expect(prompt).not.toContain("=== invalid.bin ===");
+      expect(prompt).not.toContain("\u0000");
+      expect(prompt).not.toContain("�");
+    });
+
     it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", async () => {
       writeFileSync(join(dir, "big.txt"), "A".repeat(2 * 1024 * 1024), "utf-8");
       writeJsonlEntries([{ file: "big.txt", reason: "big" }]);

--- a/packages/cli/test/templates/opencode.test.ts
+++ b/packages/cli/test/templates/opencode.test.ts
@@ -1079,6 +1079,34 @@ describe("opencode context injection limits (issue #441)", () => {
       expect(prompt).not.toContain("�");
     });
 
+    it("does not misclassify legitimate multi-byte UTF-8 content as binary", async () => {
+      const multiByteContent =
+        "emoji: 🎉🚀 cjk: 中文测试 bmp: café naïve\n";
+      writeFileSync(join(dir, "multibyte.md"), multiByteContent, "utf-8");
+      writeJsonlEntries([{ file: "multibyte.md", reason: "unicode spec" }]);
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(`=== multibyte.md ===\n${multiByteContent}`);
+      expect(prompt).not.toContain("[Trellis: not inlined (binary file)");
+    });
+
+    it("classifies a file as binary when binary bytes appear only at the end", async () => {
+      const mixed = Buffer.concat([
+        Buffer.from("looks like a normal text file up front\n", "utf-8"),
+        Buffer.from([0x00, 0xff, 0xfe]),
+      ]);
+      writeFileSync(join(dir, "mixed.dat"), mixed);
+      writeJsonlEntries([{ file: "mixed.dat", reason: "mixed content" }]);
+
+      const prompt = await runImplementHook();
+
+      expect(prompt).toContain(
+        `[Trellis: not inlined (binary file) — mixed.dat (${mixed.length} bytes): mixed content]`,
+      );
+      expect(prompt).not.toContain("=== mixed.dat ===");
+    });
+
     it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", async () => {
       writeFileSync(join(dir, "big.txt"), "A".repeat(2 * 1024 * 1024), "utf-8");
       writeJsonlEntries([{ file: "big.txt", reason: "big" }]);

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -777,6 +777,46 @@ describe("pi extension: context injection limits (issue #441)", () => {
       expect(out).not.toContain("[Trellis: not inlined");
     });
 
+    it("keeps binary jsonl references as notices even when limits are unlimited", () => {
+      const root = createRoot();
+      const taskDir = activateTask(root, "task-binary-reference");
+      const binary = Buffer.from([
+        0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x41, 0x42,
+      ]);
+      writeFileSync(join(root, "design.png"), binary);
+      writeFileSync(join(root, "invalid.bin"), Buffer.from([0xff, 0xfe, 0xfd]));
+      writeFileSync(
+        join(taskDir, "implement.jsonl"),
+        [
+          JSON.stringify({ file: "design.png", reason: "visual baseline" }),
+          JSON.stringify({ file: "invalid.bin", reason: "legacy export" }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+      writeConfig(
+        root,
+        [
+          "context_injection:",
+          "  max_file_bytes: 0",
+          "  max_total_bytes: 0",
+        ].join("\n"),
+      );
+
+      const { buildContextForTest } = loadExtensionInternals();
+      const out = buildContextForTest(root, "trellis-implement", SESSION_KEY);
+
+      expect(out).toContain(
+        "[Trellis: not inlined (binary file) — design.png (10 bytes): visual baseline]",
+      );
+      expect(out).toContain(
+        "[Trellis: not inlined (binary file) — invalid.bin (3 bytes): legacy export]",
+      );
+      expect(out).not.toContain("=== design.png ===");
+      expect(out).not.toContain("=== invalid.bin ===");
+      expect(out).not.toContain("\u0000");
+      expect(out).not.toContain("�");
+    });
+
     it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", () => {
       const root = createRoot();
       const taskDir = activateTask(root, "task-oversize");

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -817,6 +817,51 @@ describe("pi extension: context injection limits (issue #441)", () => {
       expect(out).not.toContain("�");
     });
 
+    it("does not misclassify legitimate multi-byte UTF-8 content as binary", () => {
+      const root = createRoot();
+      const taskDir = activateTask(root, "task-utf8-not-binary");
+      const multiByteContent =
+        "emoji: 🎉🚀 cjk: 中文测试 bmp: café naïve\n";
+      writeFileSync(join(root, "multibyte.md"), multiByteContent, "utf-8");
+      writeFileSync(
+        join(taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "multibyte.md", reason: "unicode spec" }) +
+          "\n",
+        "utf-8",
+      );
+      writeConfig(root, "");
+
+      const { buildContextForTest } = loadExtensionInternals();
+      const out = buildContextForTest(root, "trellis-implement", SESSION_KEY);
+
+      expect(out).toContain(`=== multibyte.md ===\n${multiByteContent}`);
+      expect(out).not.toContain("[Trellis: not inlined (binary file)");
+    });
+
+    it("classifies a file as binary when binary bytes appear only at the end", () => {
+      const root = createRoot();
+      const taskDir = activateTask(root, "task-text-head-binary-tail");
+      const mixed = Buffer.concat([
+        Buffer.from("looks like a normal text file up front\n", "utf-8"),
+        Buffer.from([0x00, 0xff, 0xfe]),
+      ]);
+      writeFileSync(join(root, "mixed.dat"), mixed);
+      writeFileSync(
+        join(taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "mixed.dat", reason: "mixed content" }) + "\n",
+        "utf-8",
+      );
+      writeConfig(root, "");
+
+      const { buildContextForTest } = loadExtensionInternals();
+      const out = buildContextForTest(root, "trellis-implement", SESSION_KEY);
+
+      expect(out).toContain(
+        `[Trellis: not inlined (binary file) — mixed.dat (${mixed.length} bytes): mixed content]`,
+      );
+      expect(out).not.toContain("=== mixed.dat ===");
+    });
+
     it("truncates an oversized jsonl-referenced file at max_file_bytes with a notice", () => {
       const root = createRoot();
       const taskDir = activateTask(root, "task-oversize");


### PR DESCRIPTION
## Summary

- detect binary JSONL context references from raw bytes using NUL and strict UTF-8 checks
- emit a reference-only notice that preserves path, byte size, and reason, even when context limits are unlimited
- keep Pi, OpenCode, and the shared Python hook behavior and regression coverage aligned
- document the three-loader context injection contract

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/templates/pi.test.ts`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/templates/opencode.test.ts`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/scripts/context-injection-limits.integration.test.ts -t "inject-subagent-context.py"`
- `gitnexus detect-changes --scope compare --base-ref main` reports low risk and no affected processes

The full `pnpm test` run still has pre-existing failures on this checkout because `packages/cli/src/templates/trellis/scripts/common/task_context.py:240` does not parse under the local Python runtime. The new binary-context tests pass in the full run.

## Motivation

Trellis 0.6.8 could inline an entire referenced PNG into a Pi sub-agent context and exhaust the model context window. Current `main` caps the payload after #456, but still decodes and injects binary garbage. This change retains the artifact reference while ensuring binary bytes never enter the prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented embedding binary and invalid-UTF-8 file contents directly into injected prompt context.
  * Added standardized “not inlined (binary file)” notices (including filename, byte size, and reason) instead of corrupted output.
  * Ensured consistent behavior across supported context-injection integrations, including unlimited context limits.

* **Documentation**
  * Expanded and formalized the context-injection limits contract, including binary classification semantics and cross-implementation update requirements.

* **Tests**
  * Added integration and template tests covering binary detection and UTF-8 non-regression, including “unlimited” cap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->