### PR TITLE
fix: resolve post-0.6.9 task and Codex regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup minimum supported Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.9"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.trellis/scripts/common/active_task.py
+++ b/.trellis/scripts/common/active_task.py
@@ -612,13 +612,16 @@ def clear_active_task(
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
 ) -> ActiveTask:
-    """Clear the active task by deleting the current session context file."""
+    """Clear the active task by deleting its resolved session context file."""
     context_key = resolve_context_key(platform_input, platform)
     if not context_key:
         return ActiveTask(None, "none")
 
     previous = resolve_active_task(repo_root, platform_input, platform)
-    context_path = _context_path(repo_root, context_key)
+    if not previous.context_key:
+        return previous
+
+    context_path = _context_path(repo_root, previous.context_key)
     if context_path.is_file():
         _remove_file(context_path)
     return previous

--- a/.trellis/scripts/common/active_task.py
+++ b/.trellis/scripts/common/active_task.py
@@ -618,7 +618,7 @@ def clear_active_task(
         return ActiveTask(None, "none")
 
     previous = resolve_active_task(repo_root, platform_input, platform)
-    if not previous.context_key:
+    if not previous.task_path or not previous.context_key:
         return previous
 
     context_path = _context_path(repo_root, previous.context_key)

--- a/.trellis/scripts/common/task_context.py
+++ b/.trellis/scripts/common/task_context.py
@@ -236,20 +236,22 @@ def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = N
         if extension in _CODE_FILE_EXTENSIONS and not _is_exempt_from_code_file_warning(
             file_path, task_rel
         ):
-            print(
-                f"  {colored(f'{file_name}:{line_num}: Warning: {file_path} looks like a code file — '
-                             'implement/check.jsonl should reference spec/research docs; '
-                             'agents read code themselves', Colors.YELLOW)}"
+            warning_message = (
+                f"{file_name}:{line_num}: Warning: {file_path} looks like a code file — "
+                "implement/check.jsonl should reference spec/research docs; "
+                "agents read code themselves"
             )
+            print(f"  {colored(warning_message, Colors.YELLOW)}")
 
         if max_file_bytes:
             size = full_path.stat().st_size
             if size > max_file_bytes:
-                print(
-                    f"  {colored(f'{file_name}:{line_num}: Warning: {file_path} is {size} bytes, '
-                                 f'exceeds context_injection.max_file_bytes ({max_file_bytes}); '
-                                 'injection will truncate it', Colors.YELLOW)}"
+                warning_message = (
+                    f"{file_name}:{line_num}: Warning: {file_path} is {size} bytes, "
+                    f"exceeds context_injection.max_file_bytes ({max_file_bytes}); "
+                    "injection will truncate it"
                 )
+                print(f"  {colored(warning_message, Colors.YELLOW)}")
 
     if errors == 0:
         print(f"  {colored(f'{file_name}: ✓ ({real_entries} entries)', Colors.GREEN)}")

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -501,9 +501,13 @@ The native hook path calls this resolver with `platform="codex"`,
 - Implement/check context order is role JSONL, `prd.md`, optional `design.md`,
   then optional `implement.md`. Research receives the resolved `Active task:`
   path and research-only context; it must not read implement/check manifests.
-- Custom Codex role profiles must retain a marker-gated child-side pull path:
-  native injection is preferred, while `Active task:` enables degraded loading
-  when the hook is untrusted or unavailable.
+- Codex may truncate model-visible `SubagentStart.additionalContext`, retain a
+  head/tail preview, and add `Full hook output saved to: <path>`. Custom role
+  profiles must treat this notice as stronger evidence than the marker: read
+  the saved full output first, use the role-specific `Active task:` pull
+  fallback if that read fails, and accept the marker as complete only when no
+  saved-output notice is present. Marker absence without a saved-output notice
+  also uses the pull fallback.
 - Native dispatch (`codex.dispatch_mode: auto`) does not set a model on the
   spawned sub-agent by default — Codex's own precedence (spawn value ->
   `[agents]` default -> parent) means the child **inherits the main
@@ -527,6 +531,10 @@ The native hook path calls this resolver with `platform="codex"`,
 | unknown/missing/malformed parent session | exit successfully with no output |
 | one unrelated runtime session exists | no output; never use sole-session fallback |
 | inherited `TRELLIS_CONTEXT_ID` conflicts with parent session | parent `session_id` wins on this native path |
+| complete output contains marker and no saved-output notice | child uses the injected role context directly |
+| output contains `Full hook output saved to: <path>` | child reads the referenced full output before role work |
+| referenced full-output file cannot be read | child uses its role-specific `Active task:` pull fallback |
+| no saved-output notice and marker is absent | child uses its role-specific `Active task:` pull fallback |
 | stale/missing task, malformed hook JSON, or unexpected error | fail open; Codex still starts the child |
 | non-Trellis `agent_type` | no Trellis output |
 
@@ -534,11 +542,12 @@ The native hook path calls this resolver with `platform="codex"`,
 
 - Good: a parent session dispatches `trellis-implement`; the child receives
   its curated implementation context and does not dispatch another role.
+- Good: Codex truncates a long payload but supplies a saved-output path; the
+  child reads that file before using any marker retained in the head preview.
 - Base: project Hook trust is pending; the child reads the dispatch prompt's
   `Active task:` value and follows the marker-absent pull protocol.
-- Bad: resolving an unknown native parent through `TRELLIS_CONTEXT_ID` or a
-  sole unrelated session. This leaks task context across windows and is
-  forbidden.
+- Bad: a retained marker causes the child to ignore a saved-output notice, or
+  research loads `implement.jsonl` / `check.jsonl`.
 
 #### 6. Tests Required
 
@@ -552,6 +561,9 @@ The native hook path calls this resolver with `platform="codex"`,
   Codex workflow-state banner.
 - Assert `configureCodex()` and `collectPlatformTemplates("codex")` remain
   byte-equivalent and distribute the shared injector.
+- Assert all three generated role profiles place the saved-output notice check
+  before marker handling, fall back when the saved file is unreadable or the
+  marker is absent, and preserve implement/check/research role boundaries.
 
 #### 7. Wrong vs Correct
 
@@ -561,6 +573,12 @@ different parent task.
 
 **Correct:** make the strict native call explicit while preserving the defaults
 for legacy shell, hook, and pull-based consumers.
+
+**Wrong:** treat `<!-- trellis-hook-injected -->` as proof that the entire
+model-visible payload survived host truncation.
+
+**Correct:** let `Full hook output saved to: <path>` take precedence, read that
+file first, and use the role-specific pull fallback only when recovery fails.
 
 ### Step 7: Documentation
 

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -347,7 +347,7 @@ for session/window scoped task state:
 | `resolve_context_key(platform_input, platform)` | Accepts `session_id` / `sessionId` / `sessionID`, Cursor `conversation_id`, and transcript path fallbacks |
 | `resolve_active_task(repo_root, platform_input, platform)` | Returns an `ActiveTask` with `task_path`, `source_type`, `context_key`, and `stale` |
 | `set_active_task(...)` | Writes session runtime state when a context key exists; returns `None` without a context key |
-| `clear_active_task(...)` | Deletes the current session file; returns no active task without a context key |
+| `clear_active_task(...)` | Deletes the session file that supplied the resolved active task; returns no active task without a context key |
 
 `TRELLIS_CONTEXT_ID` is a context-key override for subprocesses. It is not a
 second task pointer and must never store a task path. A plain AI-run shell
@@ -448,9 +448,12 @@ a `.current-task` fallback or a Python hook directory.
   - transcript fallback -> `<platform>_transcript_<sha256-prefix>.json`
 - `TRELLIS_CONTEXT_ID` is already a complete context key. Do not prepend a
   platform name to it.
-- `task.py finish` deletes only the current session file. Without a
-  context key it returns "no current task" and must not delete
-  `.trellis/.current-task`.
+- `task.py finish` deletes only the session file that supplied the resolved
+  active task. For an exact match this is the current context key; for a
+  single-session fallback it is `ActiveTask.context_key` from that fallback.
+  Without a process context key, or when resolution returns no unique active
+  task, it deletes nothing. It must never delete `.trellis/.current-task` or
+  bulk-clear other sessions.
 - `task.py archive <task>` deletes every runtime session file whose
   `current_task` points at the archived task before moving the task directory.
 - Before moving anything, `cmd_archive` (`task_store.py`) calls
@@ -500,7 +503,9 @@ a `.current-task` fallback or a Python hook directory.
 | `list --json` / `list` with a parent whose stored status is `planning` and a child past `planning` | `display_status` (and human list label) shows `"active"`; `task.json.status` on disk stays `planning` |
 | `archive` / `validate` when `task.json.branch` no longer exists locally | Prints a yellow warning; does not block archive or fail validation |
 | stale session task + stale `.current-task` exists | Returns stale session state; no `.current-task` fallback |
-| `finish` with context key and active task | Deletes `.runtime/sessions/<key>.json` |
+| `finish` with an exact context-key match | Deletes only `.runtime/sessions/<exact-key>.json` |
+| `finish` with a missing exact match and one fallback session | Deletes only the fallback file named by the resolved `ActiveTask.context_key` |
+| `finish` with a missing exact match and multiple session files | Returns no current task and deletes nothing |
 | `finish` without context key | Returns no current task; does not delete `.current-task` |
 | `archive` for a task referenced by runtime sessions | Deletes those session files even when `finish` was skipped |
 | `archive` on a name that resolves outside `.trellis/tasks/` (e.g. `archive src` falling back to `repo_root/src`) | Refuses with "refusing to archive ..." and exit 1; source directory is left untouched |
@@ -510,11 +515,15 @@ a `.current-task` fallback or a Python hook directory.
 - Good: Cursor provides `conversation_id`; resolver writes
   `cursor_<conversation-id>.json` and hook/plugin output includes the
   session source (statuslines shorten it to `[session]`).
+- Good: a Codex shell has a new thread id while exactly one older session file
+  supplies the active task; `finish` reports `session-fallback:<old-key>` and
+  deletes that old file.
 - Base: A normal shell command has no session env; `task.py create` creates the
   task without `.runtime`, and `task.py start` degrades with a session identity
   hint instead of writing `.current-task`.
-- Bad: `task.py create --no-start` changes an existing session pointer, or any
-  resolver reads/writes `.trellis/.current-task` as an active-task fallback.
+- Bad: `finish` deletes the process-derived key instead of the resolved source
+  key, bulk-clears sessions, or any resolver reads/writes
+  `.trellis/.current-task` as an active-task fallback.
 
 ##### 6. Tests Required
 
@@ -532,6 +541,9 @@ a `.current-task` fallback or a Python hook directory.
 - Hook/statusline/plugin tests proving the resolver source is surfaced.
 - Stale session tests proving no `.current-task` fallback occurs when the session task
   path is stale.
+- Finish regression tests for exact-match deletion, sole-fallback deletion,
+  and ambiguous multi-session no-op behavior. Exact-match coverage must prove a
+  sibling session for the same task remains untouched.
 
 ##### 7. Wrong vs Correct
 
@@ -555,6 +567,26 @@ elif resolve_context_key():
         print(f"Activated task for this session: {active.task_path}", file=sys.stderr)
         print(f"Source: {active.source}", file=sys.stderr)
 ```
+
+###### Wrong
+
+```python
+previous = resolve_active_task(repo_root, platform_input, platform)
+context_path = _context_path(repo_root, resolve_context_key(platform_input, platform))
+```
+
+This leaves a sole fallback file active when the process key and resolved
+source key differ.
+
+###### Correct
+
+```python
+previous = resolve_active_task(repo_root, platform_input, platform)
+if previous.context_key:
+    context_path = _context_path(repo_root, previous.context_key)
+```
+
+Deletion ownership follows the resolver result and never guesses another file.
 
 ### `common/types.py` — Typed Data Model
 

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -518,6 +518,9 @@ a `.current-task` fallback or a Python hook directory.
 - Good: a Codex shell has a new thread id while exactly one older session file
   supplies the active task; `finish` reports `session-fallback:<old-key>` and
   deletes that old file.
+- Good: the exact session file is empty or malformed while another session
+  exists; `finish` reports no current task and preserves both files because no
+  unique active task was resolved.
 - Base: A normal shell command has no session env; `task.py create` creates the
   task without `.runtime`, and `task.py start` degrades with a session identity
   hint instead of writing `.current-task`.
@@ -542,8 +545,9 @@ a `.current-task` fallback or a Python hook directory.
 - Stale session tests proving no `.current-task` fallback occurs when the session task
   path is stale.
 - Finish regression tests for exact-match deletion, sole-fallback deletion,
-  and ambiguous multi-session no-op behavior. Exact-match coverage must prove a
-  sibling session for the same task remains untouched.
+  ambiguous multi-session no-op behavior, and malformed/empty exact-session
+  no-op behavior. Exact-match coverage must prove a sibling session for the
+  same task remains untouched.
 
 ##### 7. Wrong vs Correct
 

--- a/.trellis/spec/cli/unit-test/index.md
+++ b/.trellis/spec/cli/unit-test/index.md
@@ -55,7 +55,7 @@ Do **not** maintain a manual coverage table — always run `pnpm test:coverage` 
 | Stage | What Runs | Rationale |
 |-------|-----------|-----------|
 | **pre-commit** (husky) | `lint-staged` (eslint + prettier) | Keep fast; don't add tests here or developers will skip with `--no-verify` |
-| **CI** (GitHub Actions, PR gate) | `pnpm lint` → `pnpm build` → `pnpm test` | Full suite; ~312 tests run in ~1s, no reason to split |
+| **CI** (GitHub Actions, PR gate) | Pin Python 3.9 → `pnpm typecheck` → `pnpm lint` → `pnpm build` → `pnpm test` | Run the full suite with the minimum supported Python so shipped-script syntax regressions cannot hide behind a newer runner |
 
 **When to reconsider**: If total test time exceeds 5 minutes, split into fast (unit) and slow (integration) stages. Currently unnecessary.
 

--- a/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/check.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/check.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/implement.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/implement.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/prd.md
+++ b/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/prd.md
@@ -1,0 +1,53 @@
+# Fix #465 Codex truncated hook context recovery
+
+## Goal
+
+Ensure Codex Trellis sub-agents recover the complete hook payload or load task
+context themselves when `SubagentStart.additionalContext` is truncated.
+
+## Background
+
+Codex keeps a head/tail preview when hook output exceeds its model-visible
+budget and reports `Full hook output saved to: <path>`. Trellis puts
+`<!-- trellis-hook-injected -->` at the start of the payload. The shipped
+Codex implement, check, and research profiles currently treat that marker as
+proof that the entire payload was loaded, so files removed from the middle are
+silently skipped.
+
+## Requirements
+
+- Update the three shipped Codex agent profiles with this precedence:
+  1. A `Full hook output saved to:` notice means the visible payload is
+     incomplete; read the referenced file before doing role work.
+  2. If that file cannot be read, use the existing role-specific pull fallback.
+  3. Only a marker without a truncation notice means injected context is
+     complete.
+- Implement and check fallbacks must read the role JSONL, each listed file,
+  `prd.md`, and optional `design.md` / `implement.md`.
+- Research must remain role-isolated: recover its full hook output or use the
+  supplied active-task path, but never load `implement.jsonl` or `check.jsonl`.
+- Limit the change to shipped Codex templates and their tests. The tracked
+  project `.codex/agents` files currently use an older pull-only profile and
+  must not be rewritten as an unrelated dogfood migration.
+- Preserve model-key hints, recursion guards, TOML validity, and update-time
+  model-key preservation.
+
+## Acceptance Criteria
+
+- [x] Generated implement, check, and research profiles all distinguish
+      truncated output from complete marker-bearing output.
+- [x] Each profile attempts the saved full-output file before its role-specific
+      fallback.
+- [x] Implement/check fallbacks name the correct JSONL and task artifacts;
+      research does not name either execution JSONL.
+- [x] `trellis init --codex` still produces valid agent TOML with unchanged
+      model-key and recursion-guard behavior.
+- [x] Focused template tests would fail if any one of the three roles regressed
+      to marker-only detection.
+
+## Out of Scope
+
+- Changing Codex's hook-output limit.
+- Reducing Trellis context-injection limits.
+- Adding runtime parsing or file reads to the hook itself.
+- Changing non-Codex agent profiles.

--- a/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/task.json
+++ b/.trellis/tasks/archive/2026-07/07-27-codex-hook-truncation-recovery/task.json
@@ -1,0 +1,28 @@
+{
+  "id": "codex-hook-truncation-recovery",
+  "name": "codex-hook-truncation-recovery",
+  "title": "Fix #465 Codex truncated hook context recovery",
+  "description": "Prevent Codex agents from treating truncated SubagentStart context as complete.",
+  "status": "completed",
+  "dev_type": null,
+  "scope": null,
+  "package": "cli",
+  "priority": "P1",
+  "creator": "taosu",
+  "assignee": "taosu",
+  "createdAt": "2026-07-27",
+  "completedAt": "2026-07-27",
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": "07-27-post-069-regression-fixes",
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "github_issue": "465"
+  }
+}

--- a/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/check.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/check.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/implement.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/implement.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/prd.md
+++ b/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/prd.md
@@ -1,0 +1,45 @@
+# Fix #469 fallback session cleanup
+
+## Goal
+
+Make `task.py finish` delete the session file that actually supplied the
+resolved active task, including a single-session fallback.
+
+## Background
+
+`clear_active_task()` resolves the previous task correctly, including
+`source_type="session-fallback"` and its source `context_key`, but deletes the
+path derived from the current process identity. When those keys differ, finish
+reports success while the fallback file remains and immediately reactivates
+the completed task.
+
+## Requirements
+
+- Resolve the previous active task before choosing the file to delete.
+- Delete the file identified by the resolved active task's `context_key`,
+  whether the source is an exact session or a single-session fallback.
+- Preserve the safe no-task/no-context behavior: do not guess a file and do not
+  delete unrelated runtime sessions.
+- Keep `clear_task_from_sessions()` and archive behavior unchanged; finish
+  clears one resolved session, not every session pointing at the task.
+- Keep the canonical `active_task.py` template and tracked live copy
+  byte-identical.
+- Add a regression test matching the reported flow: a different
+  `CODEX_THREAD_ID`, exactly one older session file, `finish`, then `current`.
+
+## Acceptance Criteria
+
+- [x] Exact-session finish still removes the exact session file and returns the
+      previous task/source.
+- [x] Fallback-session finish removes the fallback file named by
+      `previous.context_key`.
+- [x] After fallback finish, `task.py current --source` returns no active task.
+- [x] Zero-session and ambiguous multi-session cases delete nothing.
+- [x] Other sessions for the same task remain untouched by `finish`.
+- [x] The canonical template and tracked live copy are byte-identical.
+
+## Out of Scope
+
+- Redesigning or removing single-session fallback.
+- Fixing the separate OpenCode fallback-selection behavior in #446.
+- Changing archive-wide session cleanup.

--- a/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/task.json
+++ b/.trellis/tasks/archive/2026-07/07-27-fallback-session-cleanup/task.json
@@ -1,0 +1,28 @@
+{
+  "id": "fallback-session-cleanup",
+  "name": "fallback-session-cleanup",
+  "title": "Fix #469 fallback session cleanup",
+  "description": "Delete the session file that actually supplied the fallback active task and cover finish-to-current behavior.",
+  "status": "completed",
+  "dev_type": null,
+  "scope": null,
+  "package": "cli",
+  "priority": "P1",
+  "creator": "taosu",
+  "assignee": "taosu",
+  "createdAt": "2026-07-27",
+  "completedAt": "2026-07-27",
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": "07-27-post-069-regression-fixes",
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "github_issue": "469"
+  }
+}

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/check.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/check.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/design.md
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/design.md
@@ -1,0 +1,66 @@
+# Design: Post-0.6.9 Regression Fixes
+
+## Boundaries
+
+The parent task coordinates three isolated fixes and owns no shared runtime
+implementation.
+
+| Child | Change boundary | Existing mechanism reused |
+|---|---|---|
+| #476 | Two warning expressions in `task_context.py` | Plain string construction and existing validation flow |
+| #465 | Three shipped Codex agent-profile instructions | Existing marker and role-specific pull fallback |
+| #469 | `clear_active_task()` deletion target | Resolved `ActiveTask.context_key` and `_context_path()` |
+
+No new helper, configuration key, file format, or compatibility layer is
+required.
+
+## Data and Control Flow
+
+### #476
+
+JSONL validation builds each warning message as a normal string, passes it to
+`colored()`, and prints the same result. Moving string construction outside a
+nested f-string changes only parser compatibility.
+
+### #465
+
+Codex supplies either the complete hook payload or a truncated preview plus a
+saved-output path. The child profile interprets the host notice before the
+Trellis marker:
+
+```text
+saved-output notice -> read full payload -> role work
+                  \-> read failure -> existing role pull fallback
+marker without notice -> role work
+no marker/no notice -> existing role pull fallback
+```
+
+This remains an instruction-level recovery protocol; the hook does not inspect
+or compensate for host truncation.
+
+### #469
+
+`resolve_active_task()` is the source of truth for both the previous task and
+the context key that supplied it. `clear_active_task()` deletes
+`_context_path(repo_root, previous.context_key)` only when that resolved key is
+present. It must not fall back to bulk cleanup.
+
+## Compatibility
+
+- Python scripts continue targeting Python 3.9+.
+- Codex profile TOML structure, model-key preservation, and recursion guards
+  remain unchanged.
+- Active-task persistence format remains unchanged.
+- Canonical templates and tracked live script copies retain their existing
+  parity requirements.
+
+## Risk and Rollback
+
+- #476 risk is warning-output drift; exact message assertions and twin parity
+  contain it.
+- #465 risk is weakening research-role isolation; role-specific assertions
+  prevent execution JSONL loading by research.
+- #469 risk is deleting another session; tests must prove finish removes only
+  the resolved source context.
+
+Each child can be reverted independently.

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/implement.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/implement.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/implement.md
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/implement.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Post-0.6.9 Regression Fixes
+
+## Execution Order
+
+### 1. Fix #476
+
+- Activate `07-27-python-task-script-compat`.
+- Load `trellis-before-dev` and run required impact analysis before editing.
+- Replace both PEP 701-only warning expressions without changing output.
+- Keep template/live `task_context.py` copies byte-identical.
+- Add a focused regression guard.
+- Verify with:
+  - `uv run --no-project --python 3.9 python -m py_compile <both files>`
+  - `uv run --no-project --python 3.11 python -m py_compile <both files>`
+  - `uv run --no-project --python 3.9 python ./.trellis/scripts/task.py --help`
+  - `uv run --no-project --python 3.11 python ./.trellis/scripts/task.py --help`
+  - `pnpm --filter @mindfoldhq/trellis exec vitest run test/regression.test.ts`
+
+### 2. Fix #465
+
+- Activate `07-27-codex-hook-truncation-recovery`.
+- Load `trellis-before-dev`; inspect template ownership before editing.
+- Update all three shipped Codex profiles with truncation-first recovery.
+- Preserve role boundaries, recursion guards, model hints, and TOML shape.
+- Add focused assertions in `test/templates/codex.test.ts`.
+- Verify with:
+  - `pnpm --filter @mindfoldhq/trellis exec vitest run test/templates/codex.test.ts`
+  - a temporary-project `trellis init --codex` smoke check using the built CLI
+
+### 3. Fix #469
+
+- Activate `07-27-fallback-session-cleanup`.
+- Load `trellis-before-dev` and run impact analysis for
+  `clear_active_task()` before editing.
+- Delete the session path from the resolved previous context key.
+- Keep template/live `active_task.py` copies byte-identical.
+- Add the reported finish-to-current regression to the existing active-task
+  regression suite.
+- Verify with:
+  - `pnpm --filter @mindfoldhq/trellis exec vitest run test/regression.test.ts`
+  - a direct Python reproduction with mismatched current/fallback context keys
+
+## Integration Review
+
+- Review the combined diff against all four planning artifacts.
+- Confirm no child introduced unrelated refactoring or shared abstractions.
+- Run:
+  - `pnpm build`
+  - `pnpm test`
+  - `pnpm lint`
+  - `pnpm typecheck`
+  - `pnpm --filter @mindfoldhq/trellis lint:py`
+- Run `detect_changes()` against `main` before committing.
+- Update relevant executable specs only when implementation changes a frozen
+  contract; do not restate unchanged behavior.
+
+## Rollback Points
+
+- Complete and verify each child before starting the next.
+- Keep commits child-scoped so any fix can be reverted independently.

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/prd.md
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/prd.md
@@ -1,0 +1,55 @@
+# Fix post-0.6.9 task and Codex regressions
+
+## Goal
+
+Restore supported Python task-script execution, complete Codex sub-agent
+context recovery, and correct fallback-session cleanup through three
+independently verifiable fixes.
+
+## Background
+
+- [#476](https://github.com/mindfold-ai/Trellis/issues/476) makes every
+  `task.py` command fail at import time on supported Python 3.9-3.11.
+- [#465](https://github.com/mindfold-ai/Trellis/issues/465) allows Codex to
+  truncate `SubagentStart.additionalContext` while the retained marker tells
+  the child agent that all task context is present.
+- [#469](https://github.com/mindfold-ai/Trellis/issues/469) lets
+  `task.py finish` report success without deleting the session file that
+  supplied a single-session fallback.
+
+## Child Tasks
+
+| Child | Deliverable |
+|---|---|
+| `07-27-python-task-script-compat` | Fix #476 and preserve Python 3.9+ compatibility |
+| `07-27-codex-hook-truncation-recovery` | Fix #465 in shipped Codex agent profiles |
+| `07-27-fallback-session-cleanup` | Fix #469 without clearing unrelated sessions |
+
+## Requirements
+
+- Each defect must be implemented, tested, reviewed, and archived through its
+  owning child task.
+- The child tasks must remain independently revertible; no shared abstraction
+  may be introduced solely to group unrelated fixes.
+- Implementation order is #476, then #465, then #469. The order reflects user
+  impact, not a code dependency.
+- Generated templates and tracked live copies must follow their existing
+  ownership/parity rules.
+- The final integration review must inspect the combined diff and run the full
+  repository verification suite.
+
+## Acceptance Criteria
+
+- [x] All three child tasks satisfy their acceptance criteria and are archived.
+- [x] The combined diff contains only files owned by the three fixes plus
+      required specs, tests, and task records.
+- [x] `pnpm build`, `pnpm test`, `pnpm lint`, and `pnpm typecheck` pass after
+      all children are integrated.
+- [x] GitNexus/available change detection confirms only the expected symbols
+      and execution flows are affected before commit.
+
+## Out of Scope
+
+- Publishing a release.
+- Commenting on or closing the GitHub issues.
+- Refactoring the broader context-injection or active-task architecture.

--- a/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/task.json
+++ b/.trellis/tasks/archive/2026-07/07-27-post-069-regression-fixes/task.json
@@ -1,0 +1,32 @@
+{
+  "id": "post-069-regression-fixes",
+  "name": "post-069-regression-fixes",
+  "title": "Fix post-0.6.9 task and Codex regressions",
+  "description": "Fix #476, #465, and #469 as independently verifiable regressions.",
+  "status": "completed",
+  "dev_type": null,
+  "scope": null,
+  "package": "cli",
+  "priority": "P0",
+  "creator": "taosu",
+  "assignee": "taosu",
+  "createdAt": "2026-07-27",
+  "completedAt": "2026-07-27",
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [
+    "07-27-codex-hook-truncation-recovery",
+    "07-27-fallback-session-cleanup",
+    "07-27-python-task-script-compat"
+  ],
+  "parent": null,
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "github_issues": "476,465,469"
+  }
+}

--- a/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/check.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/check.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/implement.jsonl
+++ b/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/implement.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}

--- a/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/prd.md
+++ b/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/prd.md
@@ -1,0 +1,44 @@
+# Fix #476 Python 3.9-3.11 task script compatibility
+
+## Goal
+
+Make every generated `task.py` command parse and run on the documented Python
+3.9+ floor.
+
+## Background
+
+`common/task_context.py` contains two multiline nested f-strings introduced
+with the context-injection warnings. PEP 701 permits this grammar on Python
+3.12+, but Python 3.9-3.11 fail while importing the module, before command
+dispatch. The two affected warning blocks are currently near lines 240 and
+249 in both the canonical template and tracked live copy.
+
+## Requirements
+
+- Remove both PEP 701-only expressions without changing warning text, color,
+  validation severity, or exit behavior.
+- Keep
+  `packages/cli/src/templates/trellis/scripts/common/task_context.py` and
+  `.trellis/scripts/common/task_context.py` byte-identical.
+- Preserve the documented Python 3.9 minimum; do not raise the version floor or
+  suppress syntax failures.
+- Add a regression gate that fails on the current construct even when the CI
+  host runs Python 3.12+.
+- Verify the distributed scripts with real Python 3.9 and 3.11 interpreters.
+
+## Acceptance Criteria
+
+- [x] Python 3.9 and 3.11 can compile both `task_context.py` copies.
+- [x] Python 3.9 and 3.11 can run `.trellis/scripts/task.py --help` without a
+      syntax error.
+- [x] Both code-file and oversized-file warnings retain their existing text,
+      color, and non-blocking behavior.
+- [x] The canonical template and tracked live copy are byte-identical.
+- [x] The focused regression test fails against the pre-fix source and passes
+      after the fix.
+
+## Out of Scope
+
+- A Python CI matrix for the whole repository.
+- Any change to context-injection limits or JSONL validation policy.
+- Publishing a patch release.

--- a/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/task.json
+++ b/.trellis/tasks/archive/2026-07/07-27-python-task-script-compat/task.json
@@ -1,0 +1,28 @@
+{
+  "id": "python-task-script-compat",
+  "name": "python-task-script-compat",
+  "title": "Fix #476 Python 3.9-3.11 task script compatibility",
+  "description": "Remove PEP 701-only syntax from generated task scripts and add real interpreter regression coverage.",
+  "status": "completed",
+  "dev_type": null,
+  "scope": null,
+  "package": "cli",
+  "priority": "P0",
+  "creator": "taosu",
+  "assignee": "taosu",
+  "createdAt": "2026-07-27",
+  "completedAt": "2026-07-27",
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": "07-27-post-069-regression-fixes",
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "github_issue": "476"
+  }
+}

--- a/packages/cli/src/templates/codex/agents/trellis-check.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-check.toml
@@ -17,9 +17,11 @@ CRITICAL — Recursion guard (read first):
 You are the Trellis reviewer agent.
 
 Trellis Context Loading Protocol:
-- Look for the `<!-- trellis-hook-injected -->` marker in your input above.
-- If the marker is present, the native `SubagentStart` hook has already loaded the role-specific task artifacts and spec context. Proceed directly with the check work.
-- If the marker is absent, find `Active task: <path>` in your dispatch prompt. Read `<path>/check.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before checking. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
+- First look for `Full hook output saved to: <path>` in your input above. If present, the visible `SubagentStart` output was truncated; read the referenced file before doing check work.
+- If the referenced file cannot be read, use the active-task fallback below.
+- If there is no saved-output notice and the `<!-- trellis-hook-injected -->` marker is present, the hook loaded the complete role-specific task artifacts and spec context.
+- If there is no saved-output notice and the marker is absent, use the active-task fallback below.
+- For the fallback, find `Active task: <path>` in your dispatch prompt. Read `<path>/check.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before checking. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
 
 Your job is to review code changes against specs AND fix issues directly — not just report them. You have write access; use it.
 

--- a/packages/cli/src/templates/codex/agents/trellis-implement.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-implement.toml
@@ -17,9 +17,11 @@ CRITICAL — Recursion guard (read first):
 You are the Trellis implementer agent.
 
 Trellis Context Loading Protocol:
-- Look for the `<!-- trellis-hook-injected -->` marker in your input above.
-- If the marker is present, the native `SubagentStart` hook has already loaded the role-specific task artifacts and spec context. Proceed directly with the implementation work.
-- If the marker is absent, find `Active task: <path>` in your dispatch prompt. Read `<path>/implement.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before doing the work. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
+- First look for `Full hook output saved to: <path>` in your input above. If present, the visible `SubagentStart` output was truncated; read the referenced file before doing implementation work.
+- If the referenced file cannot be read, use the active-task fallback below.
+- If there is no saved-output notice and the `<!-- trellis-hook-injected -->` marker is present, the hook loaded the complete role-specific task artifacts and spec context.
+- If there is no saved-output notice and the marker is absent, use the active-task fallback below.
+- For the fallback, find `Active task: <path>` in your dispatch prompt. Read `<path>/implement.jsonl`, each file listed there, `<path>/prd.md`, `<path>/design.md` if present, and `<path>/implement.md` if present before doing the work. If the dispatch prompt has no active-task path, ask the main session; do not guess or use another session's task.
 
 Rules:
 - Read before write. Follow `.trellis/spec/` guidance relevant to the task.

--- a/packages/cli/src/templates/codex/agents/trellis-research.toml
+++ b/packages/cli/src/templates/codex/agents/trellis-research.toml
@@ -15,12 +15,17 @@ through the chat reply is a failure.
 
 ## Trellis Context Loading Protocol
 
-Look for the `<!-- trellis-hook-injected -->` marker in your input above.
-
-- If the marker is present, the native `SubagentStart` hook has supplied the
-  `Active task: <path>` header and research-only context. Use that task path.
-- If the marker is absent, find `Active task: <path>` in your dispatch prompt.
-  If it is absent too, ask the main session for the path; do not run
+- First look for `Full hook output saved to: <path>` in your input above. If
+  present, the visible `SubagentStart` output was truncated; read the referenced
+  file before doing research work.
+- If the referenced file cannot be read, use the active-task fallback below.
+- If there is no saved-output notice and the
+  `<!-- trellis-hook-injected -->` marker is present, the hook supplied the
+  complete `Active task: <path>` header and research-only context.
+- If there is no saved-output notice and the marker is absent, use the
+  active-task fallback below.
+- For the fallback, find `Active task: <path>` in your dispatch prompt. If it
+  is absent too, ask the main session for the path; do not run
   `task.py current`, guess, or use another session's task.
 - Do not load `implement.jsonl` or `check.jsonl`; research is role-isolated.
 

--- a/packages/cli/src/templates/trellis/scripts/common/active_task.py
+++ b/packages/cli/src/templates/trellis/scripts/common/active_task.py
@@ -612,13 +612,16 @@ def clear_active_task(
     platform_input: dict[str, Any] | None = None,
     platform: str | None = None,
 ) -> ActiveTask:
-    """Clear the active task by deleting the current session context file."""
+    """Clear the active task by deleting its resolved session context file."""
     context_key = resolve_context_key(platform_input, platform)
     if not context_key:
         return ActiveTask(None, "none")
 
     previous = resolve_active_task(repo_root, platform_input, platform)
-    context_path = _context_path(repo_root, context_key)
+    if not previous.context_key:
+        return previous
+
+    context_path = _context_path(repo_root, previous.context_key)
     if context_path.is_file():
         _remove_file(context_path)
     return previous

--- a/packages/cli/src/templates/trellis/scripts/common/active_task.py
+++ b/packages/cli/src/templates/trellis/scripts/common/active_task.py
@@ -618,7 +618,7 @@ def clear_active_task(
         return ActiveTask(None, "none")
 
     previous = resolve_active_task(repo_root, platform_input, platform)
-    if not previous.context_key:
+    if not previous.task_path or not previous.context_key:
         return previous
 
     context_path = _context_path(repo_root, previous.context_key)

--- a/packages/cli/src/templates/trellis/scripts/common/task_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_context.py
@@ -236,20 +236,22 @@ def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = N
         if extension in _CODE_FILE_EXTENSIONS and not _is_exempt_from_code_file_warning(
             file_path, task_rel
         ):
-            print(
-                f"  {colored(f'{file_name}:{line_num}: Warning: {file_path} looks like a code file — '
-                             'implement/check.jsonl should reference spec/research docs; '
-                             'agents read code themselves', Colors.YELLOW)}"
+            warning_message = (
+                f"{file_name}:{line_num}: Warning: {file_path} looks like a code file — "
+                "implement/check.jsonl should reference spec/research docs; "
+                "agents read code themselves"
             )
+            print(f"  {colored(warning_message, Colors.YELLOW)}")
 
         if max_file_bytes:
             size = full_path.stat().st_size
             if size > max_file_bytes:
-                print(
-                    f"  {colored(f'{file_name}:{line_num}: Warning: {file_path} is {size} bytes, '
-                                 f'exceeds context_injection.max_file_bytes ({max_file_bytes}); '
-                                 'injection will truncate it', Colors.YELLOW)}"
+                warning_message = (
+                    f"{file_name}:{line_num}: Warning: {file_path} is {size} bytes, "
+                    f"exceeds context_injection.max_file_bytes ({max_file_bytes}); "
+                    "injection will truncate it"
                 )
+                print(f"  {colored(warning_message, Colors.YELLOW)}")
 
     if errors == 0:
         print(f"  {colored(f'{file_name}: ✓ ({real_entries} entries)', Colors.GREEN)}")

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -4025,6 +4025,44 @@ print(json.dumps({
     );
   });
 
+  it("[issue #469] finish preserves a malformed exact session when another session exists", () => {
+    setupTaskRepo();
+    writeProjectFile(
+      path.join(
+        ".trellis",
+        ".runtime",
+        "sessions",
+        "codex_malformed.json",
+      ),
+      "{",
+    );
+    writeSessionContext("codex_other", ".trellis/tasks/issue-106");
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const sessionsDir = path.join(
+      tmpDir,
+      ".trellis",
+      ".runtime",
+      "sessions",
+    );
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ CODEX_THREAD_ID: "malformed" }),
+      },
+    );
+
+    expect(output).toContain("No current task set");
+    expect(fs.existsSync(path.join(sessionsDir, "codex_malformed.json"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(sessionsDir, "codex_other.json"))).toBe(
+      true,
+    );
+  });
+
   // ------------------------------------------------------------
   // inject-workflow-state.py hook (workflow-enforcement-v2)
   // ------------------------------------------------------------

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -3930,6 +3930,101 @@ print(json.dumps({
     expect(output).not.toContain("session-fallback");
   });
 
+  it("[issue #469] finish removes only the exact matched session file", () => {
+    setupTaskRepo();
+    writeSessionContext("codex_exact", ".trellis/tasks/issue-106");
+    writeSessionContext("codex_thread_sibling", ".trellis/tasks/issue-106");
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const sessionsDir = path.join(
+      tmpDir,
+      ".trellis",
+      ".runtime",
+      "sessions",
+    );
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ CODEX_THREAD_ID: "exact" }),
+      },
+    );
+
+    expect(output).toContain("Source: session:codex_exact");
+    expect(fs.existsSync(path.join(sessionsDir, "codex_exact.json"))).toBe(
+      false,
+    );
+    expect(
+      fs.existsSync(path.join(sessionsDir, "codex_thread_sibling.json")),
+    ).toBe(true);
+  });
+
+  it("[issue #469] finish removes the sole fallback session file", () => {
+    setupTaskRepo();
+    writeSessionContext(
+      "codex_previous-thread",
+      ".trellis/tasks/issue-106",
+    );
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const fallbackPath = path.join(
+      tmpDir,
+      ".trellis",
+      ".runtime",
+      "sessions",
+      "codex_previous-thread.json",
+    );
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ CODEX_THREAD_ID: "current-thread" }),
+      },
+    );
+
+    expect(output).toContain(
+      "Source: session-fallback:codex_previous-thread",
+    );
+    expect(fs.existsSync(fallbackPath)).toBe(false);
+
+    const current = runTaskCurrent({ CODEX_THREAD_ID: "current-thread" });
+    expect(current.status).toBe(1);
+    expect(current.output).toContain("Current task: (none)");
+    expect(current.output).toContain("Source: none");
+  });
+
+  it("[issue #469] finish deletes nothing when fallback resolution is ambiguous", () => {
+    setupTaskRepo();
+    writeSessionContext("codex_thread_a", ".trellis/tasks/issue-106");
+    writeSessionContext("codex_thread_b", ".trellis/tasks/issue-106");
+    const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
+    const sessionsDir = path.join(
+      tmpDir,
+      ".trellis",
+      ".runtime",
+      "sessions",
+    );
+
+    const output = execSync(
+      `${pythonCmd} ${JSON.stringify(taskScriptPath)} finish`,
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+        env: sessionEnv({ CODEX_THREAD_ID: "current-thread" }),
+      },
+    );
+
+    expect(output).toContain("No current task set");
+    expect(fs.existsSync(path.join(sessionsDir, "codex_thread_a.json"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(sessionsDir, "codex_thread_b.json"))).toBe(
+      true,
+    );
+  });
+
   // ------------------------------------------------------------
   // inject-workflow-state.py hook (workflow-enforcement-v2)
   // ------------------------------------------------------------

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -23,10 +23,24 @@ const TEMPLATE_SCRIPTS = path.resolve(
   __dirname,
   "../../src/templates/trellis/scripts",
 );
+const TASK_CONTEXT_PATH = path.join(
+  TEMPLATE_SCRIPTS,
+  "common",
+  "task_context.py",
+);
 const HOOK_PATH = path.resolve(
   __dirname,
   "../../src/templates/shared-hooks/inject-subagent-context.py",
 );
+
+describe("task_context.py Python compatibility", () => {
+  it("avoids the nested multiline f-strings rejected by Python 3.9-3.11 (#476)", () => {
+    const source = fs.readFileSync(TASK_CONTEXT_PATH, "utf-8");
+    expect(
+      source.match(/f"[ ]{2}\{colored\(f'[^'\n]*'\s*\n\s*f?'/g) ?? [],
+    ).toHaveLength(0);
+  });
+});
 
 function hasPython(): boolean {
   try {
@@ -612,7 +626,11 @@ print("all-valid")
         );
         const { status, stdout } = runValidate(taskDir);
         expect(status).toBe(0);
-        expect(stdout).toContain("looks like a code file");
+        expect(stdout).toContain(
+          "implement.jsonl:1: Warning: src/index.ts looks like a code file — " +
+            "implement/check.jsonl should reference spec/research docs; " +
+            "agents read code themselves",
+        );
         expect(stdout).toContain("All validations passed");
       });
 
@@ -655,8 +673,11 @@ print("all-valid")
         );
         const { status, stdout } = runValidate(taskDir);
         expect(status).toBe(0);
-        expect(stdout).toContain("oversized.md is 200 bytes");
-        expect(stdout).toContain("context_injection.max_file_bytes (100)");
+        expect(stdout).toContain(
+          "implement.jsonl:1: Warning: oversized.md is 200 bytes, " +
+            "exceeds context_injection.max_file_bytes (100); " +
+            "injection will truncate it",
+        );
       });
 
       it("stays warning-free for a clean, under-cap, spec-only manifest", () => {

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -170,6 +170,18 @@ describe("codex two-channel sub-agent context (native SubagentStart)", () => {
       );
       const content = fs.readFileSync(tomlPath, "utf-8");
 
+      const savedOutputNotice = content.indexOf(
+        "Full hook output saved to: <path>",
+      );
+      const injectionMarker = content.indexOf(
+        "<!-- trellis-hook-injected -->",
+      );
+
+      expect(savedOutputNotice).toBeGreaterThan(-1);
+      expect(injectionMarker).toBeGreaterThan(savedOutputNotice);
+      expect(content).toMatch(/read the referenced\s+file/i);
+      expect(content).toMatch(/referenced file cannot be read/i);
+      expect(content).toMatch(/marker is absent/i);
       expect(content).toContain("<!-- trellis-hook-injected -->");
       expect(content).toContain("Active task: <path>");
       expect(content).not.toContain("[features]");
@@ -177,6 +189,25 @@ describe("codex two-channel sub-agent context (native SubagentStart)", () => {
       expect(content).not.toContain("[features.multi_agent_v2]");
     });
   }
+
+  it("keeps implement and check pull fallbacks role-specific", () => {
+    for (const [name, manifest] of [
+      ["trellis-implement", "implement.jsonl"],
+      ["trellis-check", "check.jsonl"],
+    ] as const) {
+      const tomlPath = path.join(
+        repoRoot,
+        "packages/cli/src/templates/codex/agents",
+        `${name}.toml`,
+      );
+      const content = fs.readFileSync(tomlPath, "utf-8");
+
+      expect(content).toContain(`<path>/${manifest}`);
+      expect(content).toContain("<path>/prd.md");
+      expect(content).toContain("<path>/design.md");
+      expect(content).toContain("<path>/implement.md");
+    }
+  });
 
   it("keeps research task resolution role-isolated from implement/check manifests", () => {
     const researchPath = path.join(


### PR DESCRIPTION
## Summary

- restore Python 3.9–3.11 compatibility for generated task scripts
- recover complete Codex sub-agent context when hook output is truncated
- clear the session file that actually supplied a fallback active task
- preserve unresolved or ambiguous session state instead of exposing another window as the sole fallback
- run CI with the minimum supported Python version

## Root causes

- `task_context.py` used multiline nested f-strings that require PEP 701 and fail to parse before Python 3.12
- Codex retains a head/tail preview for oversized hook output, so the leading Trellis marker could survive while middle context was missing
- `clear_active_task()` resolved the fallback task correctly but deleted the process-derived session key instead of the resolved source key
- an unresolved exact session still carried a context key, allowing cleanup to delete it and make another session the sole fallback

## Impact

Generated task commands work again on the documented Python 3.9+ floor. Codex implement, check, and research agents recover the complete hook payload before using role-specific fallbacks. `task.py finish` removes only a uniquely resolved active-task session and leaves unrelated or ambiguous session files untouched.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — core: 333 passed, 1 skipped; CLI: 1590 passed
- `pnpm --filter @mindfoldhq/trellis lint:py` — 0 errors
- Python 3.9 context-injection integration suite — 25 passed
- independent standards and spec reviews

Closes #465
Closes #469
Closes #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex sub-agent context recovery when hook output is truncated by prioritizing saved hook output and using role-specific fallbacks.
  * Fixed `finish`/session cleanup to delete only the resolved session context (safe no-op on ambiguity).
  * Restored Python 3.9–3.11 compatibility for generated task scripts.
  * Preserved/clarified non-blocking JSONL validation warning output.
* **CI & Tests**
  * CI now targets Python 3.9 and runs type checking before lint/build/test.
  * Added regression and integration coverage for Codex recovery, safe cleanup, and warning messaging.
* **Documentation**
  * Updated platform integration and task lifecycle/context-loading guidance to match the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->