### PR TITLE
chore: prepare v0.6.10 release

### DIFF
--- a/packages/cli/src/migrations/manifests/0.6.10.json
+++ b/packages/cli/src/migrations/manifests/0.6.10.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.10",
+  "description": "Python 3.9–3.11 task script compatibility, complete Codex hook context recovery, and correct fallback-session cleanup.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Bug Fixes:**\n- fix(scripts): restore Python 3.9–3.11 compatibility in `.trellis/scripts/common/task_context.py` by removing multiline nested f-strings (#476)\n- fix(codex): make `trellis-{implement,check,research}` recover saved `SubagentStart` output before trusting the injected marker (#465)\n- fix(scripts): make `task.py finish` clear the resolved fallback session while preserving ambiguous or unresolved sessions (#469)",
+  "migrations": [],
+  "notes": "Run `trellis update` to refresh task scripts and Codex sub-agent templates. No `--migrate` required."
+}


### PR DESCRIPTION
## Summary

- add the non-breaking v0.6.10 migration manifest
- document the three post-v0.6.9 fixes in matching English and Chinese changelogs
- update the docs-site submodule to mindfold-ai/docs#21

## Release behavior

- `breaking: false`
- `recommendMigrate: false`
- `migrations: []`
- `trellis update` refreshes the task scripts and Codex sub-agent templates; no `--migrate` is required

## Validation

- `node packages/cli/scripts/check-manifest-continuity.js`
- `node packages/cli/scripts/release-preflight.js check-versions`
- `node packages/cli/scripts/release-preflight.js verify-packed-cli`
- `node packages/cli/scripts/release-preflight.js publish-plan`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — core: 333 passed, 1 skipped; CLI: 1590 passed
- docs-site `pnpm lint`
- pushed submodule commits verified on their remotes

## Publish path

After this PR and mindfold-ai/docs#21 merge, run `pnpm release` from a clean, current `main`. The release script bumps both npm packages to v0.6.10, creates the tag, and lets the tag-triggered CI workflow publish to npm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site reference to the latest version.
  * Added release notes for version 0.6.10, including bug fixes and upgrade guidance.

* **Bug Fixes**
  * Documented multiple fixes included in the 0.6.10 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->