### PR TITLE
feat(codex): inject governing specs before patches

### DIFF
--- a/.claude/hooks/inject-spec-context.py
+++ b/.claude/hooks/inject-spec-context.py
@@ -11,9 +11,14 @@ lives in .trellis/scripts/common/spec_match.py and the decision engine in
 .trellis/scripts/common/spec_inject.py. This file is the IO shell: stdin,
 config, identity, state files, locking, GC, one print.
 
-Trigger: PostToolUse (matcher "Read|Edit|Write|MultiEdit") — registered on
-Claude Code only this iteration. The script keeps the shared-hooks
-platform-neutral shape so later platform registrations are wiring-only.
+Triggers:
+
+* Claude Code PostToolUse (matcher "Read|Edit|Write|MultiEdit") receives one
+  structured file path after the tool runs.
+* Codex PreToolUse (matcher "Edit|Write") receives an ``apply_patch`` command.
+  Every patch header is matched before the patch runs. When a FULL spec is
+  emitted, the patch is denied once so the model can read the injected rules
+  and retry; ticket-only reminders do not block.
 
 Behavior — per matched spec, per event (recency-decay aware):
 
@@ -53,18 +58,19 @@ A once-per-hour GC prunes conforming shards older than 48 h.
 
 Budget (config.yaml `spec_injection:`): per-spec cap `max_spec_chars`
 (default 9400) with code-point truncation + in-body notice; per-event cap
-`max_total_chars` (default 9500 — Claude Code's documented additionalContext
-ceiling is 10,000 characters, stay under with margin). Once the total budget
-is exhausted, remaining FULL bodies degrade to one <spec-index> block; tickets
-are counted last and dropped (with a stderr warning) only if even they do not
-fit.
+`max_total_chars` (default 9500 — below Claude Code's documented
+additionalContext ceiling, and enforced directly for Codex). Once the total
+budget is exhausted, remaining FULL bodies degrade to one <spec-index> block;
+tickets are counted last and dropped (with a stderr warning) only if even they
+do not fit.
 
 Refresh window (config.yaml `spec_injection:`): `refresh_window_seconds`
 (default 2700; `0` = never refresh unchanged content solely because time
 passed).
 
-Never blocks, never crashes: non-matching events, missing file_path, no
-matches, any internal error → exit 0 with no stdout (stderr warnings allowed).
+Fail-open on errors: non-matching events, malformed paths, no matches, or any
+internal error → exit 0 with no stdout (stderr warnings allowed). The only
+deliberate block is a Codex patch that just received a FULL governing spec.
 """
 from __future__ import annotations
 
@@ -141,9 +147,24 @@ GC_PROJECT_DIR_RE = re.compile(r"^[0-9a-f]{16}$")
 # `+` is part of the identity charset: subagent shards use the `+a-<agent_id>`
 # suffix (contract amendment 2 — without it those shards were never pruned).
 GC_SHARD_NAME_RE = re.compile(r"^[A-Za-z0-9_+-]+(\.[0-9]+)?\.jsonl$")
+CODEX_PATCH_PATH_RE = re.compile(
+    r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$"
+)
 
 def _warn(message: str) -> None:
     print(f"[inject-spec-context] WARN: {message}", file=sys.stderr)
+
+
+def _codex_patch_paths(command: str) -> list[str]:
+    """Return file paths from Codex's documented apply_patch grammar."""
+    paths: list[str] = []
+    for line in command.splitlines():
+        match = CODEX_PATCH_PATH_RE.fullmatch(line)
+        if match:
+            path = match.group(1).strip()
+            if path and path not in paths:
+                paths.append(path)
+    return paths
 
 
 def _agent_id(payload: dict) -> str:
@@ -567,16 +588,20 @@ def load_state(
     return result, latest_reset
 
 
-def append_records(fd: int, records: list[dict]) -> None:
-    """Append records as JSONL (O_APPEND). Best-effort — a failure warns and
-    proceeds (the emission already went out)."""
+def append_records(fd: int, records: list[dict]) -> bool:
+    """Append records as JSONL (O_APPEND) and report whether all bytes landed."""
     if not records:
-        return
+        return True
     try:
         blob = "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in records)
-        os.write(fd, blob.encode("utf-8"))
+        encoded = blob.encode("utf-8")
+        if os.write(fd, encoded) != len(encoded):
+            _warn("could not write complete state shard — state may be incomplete")
+            return False
+        return True
     except OSError:
         _warn("could not write state shard — state may be incomplete")
+        return False
 
 
 # =============================================================================
@@ -646,11 +671,14 @@ def main() -> int:
                 pass
         return 0
 
+    event_name = input_data.get("hook_event_name")
     tool_name = input_data.get("tool_name", "") or input_data.get("toolName", "")
     if not isinstance(tool_name, str) or not tool_name:
         return 0
+    is_codex_patch = event_name == "PreToolUse" and tool_name == "apply_patch"
+    logical_tool = "Edit" if is_codex_patch else tool_name
     # An empty `tools` list is the documented "disable every trigger" switch.
-    if not tools or tool_name not in tools:
+    if not tools or logical_tool not in tools:
         return 0
 
     # snake_case is Claude Code's shape; camelCase keeps parity with the
@@ -660,11 +688,6 @@ def main() -> int:
         tool_input = input_data.get("toolInput")
     if not isinstance(tool_input, dict):
         return 0
-    file_path = tool_input.get("file_path")
-    if not isinstance(file_path, str) or not file_path.strip():
-        return 0
-    file_path = file_path.strip()
-
     try:
         from common.spec_match import (  # type: ignore[import-not-found]
             match_specs_for_file,
@@ -676,7 +699,33 @@ def main() -> int:
     except Exception:
         return 0  # matching/decision engine unavailable — degrade to nothing
 
-    matches = match_specs_for_file(root, file_path)
+    if is_codex_patch:
+        command = tool_input.get("command")
+        if not isinstance(command, str):
+            return 0
+        raw_paths = _codex_patch_paths(command)
+    else:
+        file_path = tool_input.get("file_path")
+        if not isinstance(file_path, str) or not file_path.strip():
+            return 0
+        raw_paths = [file_path.strip()]
+
+    file_paths: list[str] = []
+    for raw_path in raw_paths:
+        normalized = normalize_repo_relative(root, raw_path)
+        if normalized is not None and normalized not in file_paths:
+            file_paths.append(normalized)
+    if not file_paths:
+        return 0
+
+    matches = []
+    match_files: dict[str, str] = {}
+    for file_path in file_paths:
+        for match in match_specs_for_file(root, file_path):
+            if match.rel_path in match_files:
+                continue
+            matches.append(match)
+            match_files[match.rel_path] = file_path
     if not matches:
         return 0
 
@@ -733,9 +782,8 @@ def main() -> int:
                         "ts": time.time(),
                     }
 
-    edited_rel = normalize_repo_relative(root, file_path) or str(file_path).replace(
-        "\\", "/"
-    )
+    edited_rel = match_files[matches[0].rel_path]
+    records_persisted = True
     try:
         payload, records = assemble_payload(
             edited_rel,
@@ -746,9 +794,10 @@ def main() -> int:
             max_spec_chars,
             max_total_chars,
             win_seconds,
+            match_files=match_files,
         )
         if fd is not None and records:
-            append_records(fd, records)
+            records_persisted = append_records(fd, records)
     finally:
         if fd is not None:
             unlock_shard(fd)
@@ -760,12 +809,25 @@ def main() -> int:
     if not payload:
         return 0
 
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "PostToolUse",
-            "additionalContext": payload,
-        }
+    hook_specific_output = {
+        "hookEventName": "PreToolUse" if is_codex_patch else "PostToolUse",
+        "additionalContext": payload,
     }
+    if (
+        is_codex_patch
+        and records_persisted
+        and any(record.get("mode") == "full" for record in records)
+    ):
+        hook_specific_output.update(
+            {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    "Trellis injected governing specs. Review them, then retry "
+                    "this patch."
+                ),
+            }
+        )
+    output = {"hookSpecificOutput": hook_specific_output}
     print(json.dumps(output, ensure_ascii=False))
     return 0
 
@@ -774,5 +836,5 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception:
-        # A context hook must never break the tool result or the session.
+        # Hook failures must never break the tool result or the session.
         sys.exit(0)

--- a/.trellis/scripts/common/spec_inject.py
+++ b/.trellis/scripts/common/spec_inject.py
@@ -6,8 +6,7 @@ Decision logic for path-scoped spec injection (ticket-refresh model).
 Pure logic only: the per-spec decision engine, block rendering and budgeted
 payload assembly. Importing this module has no side effects; every piece of IO
 orchestration (stdin, config, identity, state files, locking, GC) lives in the
-hook that calls it — ``.claude/hooks/inject-spec-context.py``. Unit tests
-import this module directly.
+platform hook that calls it. Unit tests import this module directly.
 
 Clock
     The periodic refresh window uses epoch seconds. Context resets are
@@ -258,6 +257,7 @@ def assemble_payload(
     max_spec_chars: int,
     max_total_chars: int,
     win_seconds: int,
+    match_files: dict[str, str] | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Assemble the additionalContext payload from the matched specs.
 
@@ -268,8 +268,15 @@ def assemble_payload(
     Every candidate block is measured against the *assembled* payload string
     (``"\\n\\n".join(...)``), so the per-event character ceiling holds for the
     exact string that is emitted.
+
+    ``match_files`` maps a governing spec to the first matching file in a
+    multi-file tool call. Single-file callers omit it and retain the original
+    ``edited_rel`` behavior.
     """
     blocks: list[str] = []
+
+    def file_for(match: SpecMatch) -> str:
+        return (match_files or {}).get(match.rel_path, edited_rel)
 
     def fits(candidate: str, reserve: int = 0) -> bool:
         """Does ``candidate`` fit the per-event ceiling, keeping ``reserve``
@@ -302,7 +309,7 @@ def assemble_payload(
         return named
 
     index_lines: list[str] = []
-    ticket_pending: list[tuple[str, str]] = []  # (spec_rel, sha256_hex)
+    ticket_pending: list[tuple[str, str, str]] = []  # (file, spec, sha256)
     records: list[dict[str, Any]] = []
 
     for match_idx, match in enumerate(matches):
@@ -335,7 +342,7 @@ def assemble_payload(
 
         if decision == "ticket":
             # Deferred: tickets are counted against the budget last.
-            ticket_pending.append((match.rel_path, sha256_hex))
+            ticket_pending.append((file_for(match), match.rel_path, sha256_hex))
             continue
 
         pending = [*index_lines, *_all_index_lines[match_idx + 1 :]]
@@ -347,7 +354,8 @@ def assemble_payload(
         complete = len(body) >= len(text)
         if not complete:
             body += truncation_notice(match.rel_path, max_spec_chars)
-        block = render_full(edited_rel, match.rel_path, sha12, body)
+        matching_file = file_for(match)
+        block = render_full(matching_file, match.rel_path, sha12, body)
         if not _fits(block):
             # Contract amendment 1: before degrading, truncate FURTHER to the
             # largest body prefix that fits the remaining total budget
@@ -356,7 +364,12 @@ def assemble_payload(
             # wrapper > total cap) and long specs fell straight to an index
             # line — the rejected index-only mode by another route.
             derived = _derive_fitting_full(
-                edited_rel, match.rel_path, sha12, text, max_spec_chars, _fits
+                matching_file,
+                match.rel_path,
+                sha12,
+                text,
+                max_spec_chars,
+                _fits,
             )
             if derived is not None:
                 derived_block, derived_complete = derived
@@ -413,8 +426,10 @@ def assemble_payload(
         if chosen:
             blocks.append(_index_block(chosen))
 
-    for spec_rel, sha256_hex in ticket_pending:
-        ticket = render_ticket(edited_rel, spec_rel, sha256_hex[:12], stateless)
+    for matching_file, spec_rel, sha256_hex in ticket_pending:
+        ticket = render_ticket(
+            matching_file, spec_rel, sha256_hex[:12], stateless
+        )
         if not fits(ticket):
             _warn(f"ticket for {spec_rel} dropped — per-event budget exhausted")
             continue

--- a/.trellis/spec/cli/backend/spec-injection.md
+++ b/.trellis/spec/cli/backend/spec-injection.md
@@ -3,10 +3,14 @@ name: spec-injection
 description: Path-scoped on-demand spec injection — frontmatter contract, glob matching, hook flow, budgets, ticket-refresh state machine, identity ladder, platform matrix
 paths:
   - packages/cli/src/templates/shared-hooks/inject-spec-context.py
+  - packages/cli/src/templates/shared-hooks/index.ts
+  - packages/cli/src/templates/codex/hooks.json
   - packages/cli/src/templates/trellis/scripts/common/git_context.py
   - packages/cli/src/templates/trellis/scripts/common/spec_match.py
   - packages/cli/src/templates/trellis/scripts/common/spec_inject.py
   - packages/cli/test/scripts/spec-injection.integration.test.ts
+  - packages/cli/test/templates/codex.test.ts
+  - packages/cli/test/templates/shared-hooks.test.ts
   - .claude/hooks/inject-spec-context.py
   - .trellis/scripts/common/git_context.py
   - .trellis/scripts/common/spec_match.py
@@ -35,8 +39,8 @@ paths:
 | Matching engine              | `packages/cli/src/templates/trellis/scripts/common/spec_match.py` (live twin `.trellis/scripts/common/spec_match.py`)                                                           |
 | Decision engine (pure logic) | `packages/cli/src/templates/trellis/scripts/common/spec_inject.py` (live twin `.trellis/scripts/common/spec_inject.py`)                                                         |
 | Injection hook (IO shell)    | `packages/cli/src/templates/shared-hooks/inject-spec-context.py` (live twin `.claude/hooks/inject-spec-context.py`)                                                             |
-| Registration                 | `packages/cli/src/templates/claude/settings.json` `PostToolUse` (live twin `.claude/settings.json`)                                                                             |
-| Distribution                 | `packages/cli/src/templates/shared-hooks/index.ts` `SHARED_HOOKS_BY_PLATFORM` (claude only this iteration)                                                                      |
+| Registration                 | Claude: `packages/cli/src/templates/claude/settings.json` `PostToolUse`; Codex: `packages/cli/src/templates/codex/hooks.json` `PreToolUse`                                       |
+| Distribution                 | `packages/cli/src/templates/shared-hooks/index.ts` `SHARED_HOOKS_BY_PLATFORM` (Claude Code and Codex)                                                                           |
 | Config                       | `spec_injection:` section of `.trellis/config.yaml` — shipped commented-out (defaults apply) in both the template (`templates/trellis/config.yaml`) and this repo's live config |
 | Pull mode                    | `get_context.py --mode spec --file <path>` (dispatch in `common/git_context.py`)                                                                                                |
 | Refresh state                | `${TRELLIS_SPEC_STATE_DIR:-~/.trellis/spec-inject}/<project16>/<identity>.jsonl` (user-global, outside the repo)                                                                |
@@ -193,19 +197,26 @@ Contract:
 
 ## 4. Injection hook (`shared-hooks/inject-spec-context.py`)
 
-Registered on **Claude Code only** this iteration: **one** `PostToolUse` entry
-with matcher `"Read|Edit|Write|MultiEdit"` (official pipe-separated
-list-of-exact-strings semantics — the docs' own PostToolUse example uses
-`"Edit|Write"`; re-verified 2026-07-25) running
-`{{PYTHON_CMD}} .claude/hooks/inject-spec-context.py`, timeout 15. Touching a
-governed file — even a `Read` — counts; the miss path stays a fast exit. Which
-tool events trigger is filtered **in-hook** by `spec_injection.tools` (default
-those four), so users can e.g. drop `Read` without editing settings. The
-same hook also runs after `SessionStart(source=clear|compact)` with the
-SessionStart-standard timeout 30 to record a context reset; it is deliberately
-absent from `source=startup`.
-script keeps the shared-hooks platform-neutral shape so later registrations
-are wiring-only.
+Registered on two platforms:
+
+- **Claude Code** uses `PostToolUse` matcher
+  `"Read|Edit|Write|MultiEdit"` and receives one structured
+  `tool_input.file_path` after the tool runs. Touching a governed file — even
+  a `Read` — counts.
+- **Codex** uses `PreToolUse` matcher `"Edit|Write"`; these documented matcher
+  aliases select the native `apply_patch` tool, whose stdin still reports
+  `tool_name: "apply_patch"` and carries the raw patch in
+  `tool_input.command`. The hook parses only patch metadata headers
+  (`Add File`, `Update File`, `Delete File`, `Move to`), never shell text.
+  A FULL emission returns `permissionDecision: "deny"` so Codex reads the
+  injected spec before retrying. Ticket-only reminders are injected without a
+  permission decision, so the patch proceeds. The Codex handler sets
+  `additionalContextLimit: 0`; the hook's own 9,500-character ceiling remains
+  the single budget.
+
+Both platforms register `SessionStart(source=clear|compact)` to record a
+context reset and omit `source=startup`. Which tool events trigger remains
+filtered in-hook by `spec_injection.tools`.
 
 ### Structure: pure logic vs IO shell
 
@@ -231,13 +242,17 @@ read+hashed — it degrades straight to an index line with a stderr warn.
 6. A `SessionStart` with `source=clear|compact` resolves the base session
    identity, appends one reset marker, and exits silently. Other SessionStart
    sources exit silently.
-7. `tool_name` (fallback `toolName`) must be a non-empty string;
-   `tool_input.file_path` must be a non-empty string; `tool_name` not
-   in `spec_injection.tools` → silent exit (`tools: []` disables every
-   trigger — early exit).
+7. `tool_name` (fallback `toolName`) must be a non-empty string and enabled by
+   `spec_injection.tools` (`tools: []` disables every trigger). Claude reads
+   one non-empty `tool_input.file_path`. Codex maps `apply_patch` to the
+   logical `Edit` filter and extracts every path from
+   `tool_input.command`; malformed commands or paths outside the repo exit
+   silently.
 8. Import `common.spec_match` + `common.spec_inject` from `.trellis/scripts`
    (sys.path extension); import failure → degrade to nothing.
-9. Match; no matches → silent exit.
+9. Match every extracted file. A governing spec that matches multiple files
+   in one patch appears once, attributed to its first matching file. No
+   matches → silent exit.
 10. Resolve the base session identity and agent-specific emission identity;
     unless stateless: run GC (hourly gate), read the latest reset marker from
     the base shard, then open the emission identity's state shard for
@@ -248,7 +263,8 @@ read+hashed — it degrades straight to an index line with a stderr warn.
     assemble the budgeted payload; state lines are appended **under the same
     lock**, only for specs that actually emitted (FULL or TICKET) — silent and
     budget-dropped specs record nothing and stay eligible.
-11. Empty payload → silent exit; otherwise print exactly one JSON object:
+11. Empty payload → silent exit; otherwise print exactly one JSON object.
+    Claude emits:
 
 ```json
 {
@@ -259,13 +275,34 @@ read+hashed — it degrades straight to an index line with a stderr warn.
 }
 ```
 
-Top-level `try/except → sys.exit(0)`: the hook **never** blocks the tool
-result, never crashes the session, never exits non-zero. stdout carries hook
-JSON or nothing; all warnings go to stderr.
+    Codex emits the same `additionalContext` under `PreToolUse`. When at least
+    one FULL block was emitted, it also emits:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Trellis injected governing specs. Review them, then retry this patch.",
+    "additionalContext": "<payload>"
+  }
+}
+```
+
+State is written before this intentional denial, so the retry is silent for
+unchanged specs. A ticket-only response omits both permission fields and lets
+the patch run.
+
+Top-level `try/except → sys.exit(0)`: failures never crash or block the
+session. Claude never blocks a tool result; Codex blocks only a patch that has
+just received a FULL spec. stdout carries hook JSON or nothing; all warnings
+go to stderr.
 
 ### Payload shape
 
-One block per emitting spec, joined by a blank line. A **FULL** block inlines
+One block per emitting spec, joined by a blank line. In a multi-file Codex
+patch, specs are deduplicated by spec path and the `file` attribute names the
+first patch file governed by that spec. A **FULL** block inlines
 the (budgeted) spec body and carries the `sha256` attribute — the first 12 hex
 of `sha256(spec bytes)` — that the decision engine keys refresh on:
 
@@ -566,8 +603,9 @@ spec_injection:
 - `refresh_window_seconds` sizes the fixed wall-clock refresh window (§4).
   `0` disables time-based reminders; clear/compact reset events still force
   FULL.
-- `tools` filters which tool events trigger the hook (names as the platform
-  reports them). Both grammars are accepted: a block list (`- Edit` items)
+- `tools` filters which logical tool events trigger the hook. Codex
+  `apply_patch` maps to `Edit`; this avoids exposing a Codex-only config name.
+  Both grammars are accepted: a block list (`- Edit` items)
   and a flow sequence (`tools: [Edit, Write]`). An **empty list (`[]`, either
   grammar) is a deliberate "never trigger"** and is respected — early exit;
   unknown tool names warn once to stderr (they can never match); any other
@@ -603,14 +641,15 @@ python3 .trellis/scripts/get_context.py --mode spec --file packages/cli/src/comm
 
 ## 8. Platform matrix
 
-| Platform                                                                                            | Push injection | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| --------------------------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code                                                                                         | ✅ wired       | PostToolUse fires for **sub-agent tool calls too** — injection lands in the editing agent's own context (desired; complements, never duplicates, JSONL curation — different channel, refresh state is per session identity, and a subagent keeps state separate from its parent). Windows: cosmetic "hook error" display bug on record (claude-code#45065); if PostToolUse ever fails to fire, the feature degrades to nothing — no breakage. |
-| cursor, codex, gemini, qoder, copilot, codebuddy, droid, kiro, trae, zcode, opencode, pi, omp, snow | follow-up      | The hook script is platform-neutral; registering one of these is wiring-only (settings template + `SHARED_HOOKS_BY_PLATFORM` row) **after** verifying the platform has a tool-event hook that consumes `additionalContext`.                                                                                                                                                                                                                   |
-| kilo, antigravity, devin                                                                            | ❌ impossible  | No hook surface at all.                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| grok                                                                                                | ❌ impossible  | Hook stdout `additionalContext` is not consumed (verified 0.2.x).                                                                                                                                                                                                                                                                                                                                                                             |
-| kimi                                                                                                | ❌ impossible  | Hooks are user-level only (`~/.kimi-code/config.toml`); Trellis writes no project-level hook files.                                                                                                                                                                                                                                                                                                                                           |
-| reasonix                                                                                            | ❌ impossible  | No prompt/tool hook surface.                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Platform                                                                                     | Push injection | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code                                                                                  | ✅ wired       | PostToolUse fires for **sub-agent tool calls too** — injection lands in the editing agent's own context. Windows: cosmetic "hook error" display bug on record (claude-code#45065); if PostToolUse ever fails to fire, the feature degrades to nothing.                                                                                                                                                                                            |
+| Codex                                                                                        | ✅ wired       | Codex 0.145.0 hook schema and runtime re-verified 2026-07-28: `Edit|Write` aliases select `apply_patch`; PreToolUse accepts `additionalContext` together with `permissionDecision: deny`; `SessionStart(source=compact)` runs before immediate continuation. FULL blocks deny once and the model retries; ticket-only reminders proceed. Project hooks still require Codex trust/review. |
+| cursor, gemini, qoder, copilot, codebuddy, droid, kiro, trae, zcode, opencode, pi, omp, snow | follow-up      | Register only after verifying the platform has a tool-event hook that consumes injected context and, for pre-tool hooks, can return it to the model before retry.                                                                                                                                                                                                                                                                               |
+| kilo, antigravity, devin                                                                     | ❌ impossible  | No hook surface at all.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| grok                                                                                         | ❌ impossible  | Hook stdout `additionalContext` is not consumed (verified 0.2.x).                                                                                                                                                                                                                                                                                                                                                                             |
+| kimi                                                                                         | ❌ impossible  | Hooks are user-level only (`~/.kimi-code/config.toml`); Trellis writes no project-level hook files.                                                                                                                                                                                                                                                                                                                                           |
+| reasonix                                                                                     | ❌ impossible  | No prompt/tool hook surface.                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 Pull mode (`--mode spec`) works on **every** platform; "impossible" above
 refers to push injection only.
@@ -655,6 +694,8 @@ checklists, no change to sub-agent JSONL curation or its budgets.
 | SessionStart reset state is unwritable                                    | no state write, exit 0; later tool events retain their normal circuit breaker                                                                                                                                         |
 | Matching/decision engine unimportable                                     | hook degrades to nothing, exit 0                                                                                                                                                                                      |
 | Hook internal bug                                                         | top-level try/except → exit 0, no output                                                                                                                                                                              |
+| Codex patch payload malformed or path outside repo                         | no match, empty stdout, patch proceeds                                                                                                                                                                                |
+| Codex state unavailable                                                    | stateless ticket-only response without `permissionDecision`; patch proceeds instead of entering a deny loop                                                                                                           |
 | Payload near ceiling                                                      | budget enforced on the assembled payload string — ≤ 9,500 characters with separators, index block, summary and tickets all counted; overflow index lines collapse into a `(+N more …)` summary, itself budget-checked |
 | Invalid config values                                                     | stderr warn, per-key defaults                                                                                                                                                                                         |
 | Windows PostToolUse quirk                                                 | cosmetic error display only (#45065); worst case: no injection                                                                                                                                                        |
@@ -701,9 +742,9 @@ decision-engine cases import `common/spec_inject.py` directly):
   block at the head bound warns + skips; an hr-opening prose file is silently
   not-frontmatter; case-insensitive glob match on darwin/win32 (IGNORECASE).
 
-Hook E2E matrix (fabricated PostToolUse stdin; every case asserts exit 0 and
-valid-JSON-or-empty stdout; set `TRELLIS_SPEC_STATE_DIR` per run for
-hermeticity):
+Hook E2E matrix (fabricated Claude PostToolUse and Codex PreToolUse stdin;
+every case asserts exit 0 and valid-JSON-or-empty stdout; set
+`TRELLIS_SPEC_STATE_DIR` per run for hermeticity):
 
 - first touch → FULL `<spec-context>` with a `sha256` attr; second touch within
   the wall-clock window → empty; touch past the fixture-controlled window →
@@ -724,6 +765,9 @@ hermeticity):
   window (the stateful ticket wording is never a lie).
 - malformed `paths:` skipped with stderr warn; `spec_injection.enabled:
 false` → empty; non-trigger tool / missing `file_path` / no `.trellis` → empty.
+- Codex first `apply_patch` FULL → `permissionDecision: deny`; identical retry
+  → empty; refresh ticket → context with no permission decision; multi-file
+  Add/Update/Delete/Move paths all match and a shared spec emits once.
 
 Pull mode:
 
@@ -738,6 +782,9 @@ Template shape:
 - Claude settings template asserts the single `PostToolUse` entry with matcher
   `"Read|Edit|Write|MultiEdit"`, plus the reset hook after clear and compact
   but not startup.
+- Codex hooks template asserts `PreToolUse` matcher `"Edit|Write"`,
+  `additionalContextLimit: 0`, and the clear/compact SessionStart reset hook;
+  the shared-hook capability table distributes the script to both platforms.
 
 ---
 
@@ -753,6 +800,8 @@ Template shape:
 - Re-verify Claude's documented additionalContext ceiling before changing
   budget defaults, and record the verification date here (last verified
   2026-07-25: 10,000 characters, all hook output strings).
+- Re-verify Codex's PreToolUse output schema and matcher aliases when changing
+  the deny/retry contract (last verified 2026-07-28 against Codex 0.145.0).
 - Register any new shared-hook file in `SHARED_HOOKS_BY_PLATFORM` and
   `ALL_HOOK_FILES` in the same commit that creates it.
 
@@ -761,8 +810,9 @@ Template shape:
 - Don't add a YAML dependency — the parser is hand-rolled by design.
 - Don't add a central path mapping to `config.yaml` or cache frontmatter
   scans.
-- Don't make the hook exit non-zero, print errors to stdout, or block the
-  tool result — degrade to nothing instead.
+- Don't make the hook exit non-zero or print errors to stdout. Do not block
+  Claude tools. On Codex, block only when this event emitted a FULL spec;
+  errors, index-only output, tickets, and silent hits must proceed.
 - Don't rely on the refresh state for correctness: it is best-effort by
   design, so duplicate injection must always be safe — and its unwritable
   failure mode is the bounded ticket-only circuit breaker, never silence.

--- a/packages/cli/src/templates/codex/hooks.json
+++ b/packages/cli/src/templates/codex/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "^(?:clear|compact)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-spec-context.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
@@ -19,6 +31,19 @@
             "type": "command",
             "command": "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-subagent-context.py",
             "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{PYTHON_CMD}} -X utf8 .codex/hooks/inject-spec-context.py",
+            "timeout": 15,
+            "additionalContextLimit": 0
           }
         ]
       }

--- a/packages/cli/src/templates/shared-hooks/index.ts
+++ b/packages/cli/src/templates/shared-hooks/index.ts
@@ -69,10 +69,10 @@ export type SharedHookPlatform =
  *   (per-turn breadcrumb), and `inject-subagent-context.py` (sub-agent
  *   spawn). The scripts emit a plain-text Kiro branch — Kiro adds a hook's
  *   stdout directly to the conversation context (no JSON envelope).
- * - `inject-spec-context.py` — path-scoped spec injection on
- *   Read/Edit/Write/MultiEdit (PostToolUse). Claude Code only this iteration;
- *   other platforms are a follow-up (class-2 platforms use
- *   `get_context.py --mode spec` pull mode instead).
+ * - `inject-spec-context.py` — path-scoped spec injection. Claude Code uses
+ *   PostToolUse Read/Edit/Write/MultiEdit; Codex uses PreToolUse Edit|Write
+ *   and parses the native apply_patch payload. Class-2 platforms use
+ *   `get_context.py --mode spec` pull mode instead.
  * - Claude Code `statusLine` is intentionally not installed by default.
  *   Users can add their own statusLine command in `.claude/settings.json`,
  *   or opt in to the Trellis one via `trellis init --with-statusline`
@@ -92,7 +92,6 @@ export const SHARED_HOOKS_BY_PLATFORM: Record<
     "session-start.py",
     "inject-workflow-state.py",
     "inject-subagent-context.py",
-    // Claude only this iteration — other platforms are a follow-up.
     "inject-spec-context.py",
   ],
   cursor: [
@@ -100,7 +99,11 @@ export const SHARED_HOOKS_BY_PLATFORM: Record<
     "inject-shell-session-context.py",
     "inject-subagent-context.py",
   ],
-  codex: ["inject-workflow-state.py", "inject-subagent-context.py"],
+  codex: [
+    "inject-workflow-state.py",
+    "inject-subagent-context.py",
+    "inject-spec-context.py",
+  ],
   gemini: ["session-start.py", "inject-workflow-state.py"],
   qoder: ["session-start.py", "inject-workflow-state.py"],
   copilot: ["inject-workflow-state.py"],

--- a/packages/cli/src/templates/shared-hooks/inject-spec-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-spec-context.py
@@ -11,9 +11,14 @@ lives in .trellis/scripts/common/spec_match.py and the decision engine in
 .trellis/scripts/common/spec_inject.py. This file is the IO shell: stdin,
 config, identity, state files, locking, GC, one print.
 
-Trigger: PostToolUse (matcher "Read|Edit|Write|MultiEdit") — registered on
-Claude Code only this iteration. The script keeps the shared-hooks
-platform-neutral shape so later platform registrations are wiring-only.
+Triggers:
+
+* Claude Code PostToolUse (matcher "Read|Edit|Write|MultiEdit") receives one
+  structured file path after the tool runs.
+* Codex PreToolUse (matcher "Edit|Write") receives an ``apply_patch`` command.
+  Every patch header is matched before the patch runs. When a FULL spec is
+  emitted, the patch is denied once so the model can read the injected rules
+  and retry; ticket-only reminders do not block.
 
 Behavior — per matched spec, per event (recency-decay aware):
 
@@ -53,18 +58,19 @@ A once-per-hour GC prunes conforming shards older than 48 h.
 
 Budget (config.yaml `spec_injection:`): per-spec cap `max_spec_chars`
 (default 9400) with code-point truncation + in-body notice; per-event cap
-`max_total_chars` (default 9500 — Claude Code's documented additionalContext
-ceiling is 10,000 characters, stay under with margin). Once the total budget
-is exhausted, remaining FULL bodies degrade to one <spec-index> block; tickets
-are counted last and dropped (with a stderr warning) only if even they do not
-fit.
+`max_total_chars` (default 9500 — below Claude Code's documented
+additionalContext ceiling, and enforced directly for Codex). Once the total
+budget is exhausted, remaining FULL bodies degrade to one <spec-index> block;
+tickets are counted last and dropped (with a stderr warning) only if even they
+do not fit.
 
 Refresh window (config.yaml `spec_injection:`): `refresh_window_seconds`
 (default 2700; `0` = never refresh unchanged content solely because time
 passed).
 
-Never blocks, never crashes: non-matching events, missing file_path, no
-matches, any internal error → exit 0 with no stdout (stderr warnings allowed).
+Fail-open on errors: non-matching events, malformed paths, no matches, or any
+internal error → exit 0 with no stdout (stderr warnings allowed). The only
+deliberate block is a Codex patch that just received a FULL governing spec.
 """
 from __future__ import annotations
 
@@ -141,9 +147,24 @@ GC_PROJECT_DIR_RE = re.compile(r"^[0-9a-f]{16}$")
 # `+` is part of the identity charset: subagent shards use the `+a-<agent_id>`
 # suffix (contract amendment 2 — without it those shards were never pruned).
 GC_SHARD_NAME_RE = re.compile(r"^[A-Za-z0-9_+-]+(\.[0-9]+)?\.jsonl$")
+CODEX_PATCH_PATH_RE = re.compile(
+    r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$"
+)
 
 def _warn(message: str) -> None:
     print(f"[inject-spec-context] WARN: {message}", file=sys.stderr)
+
+
+def _codex_patch_paths(command: str) -> list[str]:
+    """Return file paths from Codex's documented apply_patch grammar."""
+    paths: list[str] = []
+    for line in command.splitlines():
+        match = CODEX_PATCH_PATH_RE.fullmatch(line)
+        if match:
+            path = match.group(1).strip()
+            if path and path not in paths:
+                paths.append(path)
+    return paths
 
 
 def _agent_id(payload: dict) -> str:
@@ -567,16 +588,20 @@ def load_state(
     return result, latest_reset
 
 
-def append_records(fd: int, records: list[dict]) -> None:
-    """Append records as JSONL (O_APPEND). Best-effort — a failure warns and
-    proceeds (the emission already went out)."""
+def append_records(fd: int, records: list[dict]) -> bool:
+    """Append records as JSONL (O_APPEND) and report whether all bytes landed."""
     if not records:
-        return
+        return True
     try:
         blob = "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in records)
-        os.write(fd, blob.encode("utf-8"))
+        encoded = blob.encode("utf-8")
+        if os.write(fd, encoded) != len(encoded):
+            _warn("could not write complete state shard — state may be incomplete")
+            return False
+        return True
     except OSError:
         _warn("could not write state shard — state may be incomplete")
+        return False
 
 
 # =============================================================================
@@ -646,11 +671,14 @@ def main() -> int:
                 pass
         return 0
 
+    event_name = input_data.get("hook_event_name")
     tool_name = input_data.get("tool_name", "") or input_data.get("toolName", "")
     if not isinstance(tool_name, str) or not tool_name:
         return 0
+    is_codex_patch = event_name == "PreToolUse" and tool_name == "apply_patch"
+    logical_tool = "Edit" if is_codex_patch else tool_name
     # An empty `tools` list is the documented "disable every trigger" switch.
-    if not tools or tool_name not in tools:
+    if not tools or logical_tool not in tools:
         return 0
 
     # snake_case is Claude Code's shape; camelCase keeps parity with the
@@ -660,11 +688,6 @@ def main() -> int:
         tool_input = input_data.get("toolInput")
     if not isinstance(tool_input, dict):
         return 0
-    file_path = tool_input.get("file_path")
-    if not isinstance(file_path, str) or not file_path.strip():
-        return 0
-    file_path = file_path.strip()
-
     try:
         from common.spec_match import (  # type: ignore[import-not-found]
             match_specs_for_file,
@@ -676,7 +699,33 @@ def main() -> int:
     except Exception:
         return 0  # matching/decision engine unavailable — degrade to nothing
 
-    matches = match_specs_for_file(root, file_path)
+    if is_codex_patch:
+        command = tool_input.get("command")
+        if not isinstance(command, str):
+            return 0
+        raw_paths = _codex_patch_paths(command)
+    else:
+        file_path = tool_input.get("file_path")
+        if not isinstance(file_path, str) or not file_path.strip():
+            return 0
+        raw_paths = [file_path.strip()]
+
+    file_paths: list[str] = []
+    for raw_path in raw_paths:
+        normalized = normalize_repo_relative(root, raw_path)
+        if normalized is not None and normalized not in file_paths:
+            file_paths.append(normalized)
+    if not file_paths:
+        return 0
+
+    matches = []
+    match_files: dict[str, str] = {}
+    for file_path in file_paths:
+        for match in match_specs_for_file(root, file_path):
+            if match.rel_path in match_files:
+                continue
+            matches.append(match)
+            match_files[match.rel_path] = file_path
     if not matches:
         return 0
 
@@ -733,9 +782,8 @@ def main() -> int:
                         "ts": time.time(),
                     }
 
-    edited_rel = normalize_repo_relative(root, file_path) or str(file_path).replace(
-        "\\", "/"
-    )
+    edited_rel = match_files[matches[0].rel_path]
+    records_persisted = True
     try:
         payload, records = assemble_payload(
             edited_rel,
@@ -746,9 +794,10 @@ def main() -> int:
             max_spec_chars,
             max_total_chars,
             win_seconds,
+            match_files=match_files,
         )
         if fd is not None and records:
-            append_records(fd, records)
+            records_persisted = append_records(fd, records)
     finally:
         if fd is not None:
             unlock_shard(fd)
@@ -760,12 +809,25 @@ def main() -> int:
     if not payload:
         return 0
 
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "PostToolUse",
-            "additionalContext": payload,
-        }
+    hook_specific_output = {
+        "hookEventName": "PreToolUse" if is_codex_patch else "PostToolUse",
+        "additionalContext": payload,
     }
+    if (
+        is_codex_patch
+        and records_persisted
+        and any(record.get("mode") == "full" for record in records)
+    ):
+        hook_specific_output.update(
+            {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    "Trellis injected governing specs. Review them, then retry "
+                    "this patch."
+                ),
+            }
+        )
+    output = {"hookSpecificOutput": hook_specific_output}
     print(json.dumps(output, ensure_ascii=False))
     return 0
 
@@ -774,5 +836,5 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception:
-        # A context hook must never break the tool result or the session.
+        # Hook failures must never break the tool result or the session.
         sys.exit(0)

--- a/packages/cli/src/templates/trellis/scripts/common/spec_inject.py
+++ b/packages/cli/src/templates/trellis/scripts/common/spec_inject.py
@@ -6,8 +6,7 @@ Decision logic for path-scoped spec injection (ticket-refresh model).
 Pure logic only: the per-spec decision engine, block rendering and budgeted
 payload assembly. Importing this module has no side effects; every piece of IO
 orchestration (stdin, config, identity, state files, locking, GC) lives in the
-hook that calls it — ``.claude/hooks/inject-spec-context.py``. Unit tests
-import this module directly.
+platform hook that calls it. Unit tests import this module directly.
 
 Clock
     The periodic refresh window uses epoch seconds. Context resets are
@@ -258,6 +257,7 @@ def assemble_payload(
     max_spec_chars: int,
     max_total_chars: int,
     win_seconds: int,
+    match_files: dict[str, str] | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Assemble the additionalContext payload from the matched specs.
 
@@ -268,8 +268,15 @@ def assemble_payload(
     Every candidate block is measured against the *assembled* payload string
     (``"\\n\\n".join(...)``), so the per-event character ceiling holds for the
     exact string that is emitted.
+
+    ``match_files`` maps a governing spec to the first matching file in a
+    multi-file tool call. Single-file callers omit it and retain the original
+    ``edited_rel`` behavior.
     """
     blocks: list[str] = []
+
+    def file_for(match: SpecMatch) -> str:
+        return (match_files or {}).get(match.rel_path, edited_rel)
 
     def fits(candidate: str, reserve: int = 0) -> bool:
         """Does ``candidate`` fit the per-event ceiling, keeping ``reserve``
@@ -302,7 +309,7 @@ def assemble_payload(
         return named
 
     index_lines: list[str] = []
-    ticket_pending: list[tuple[str, str]] = []  # (spec_rel, sha256_hex)
+    ticket_pending: list[tuple[str, str, str]] = []  # (file, spec, sha256)
     records: list[dict[str, Any]] = []
 
     for match_idx, match in enumerate(matches):
@@ -335,7 +342,7 @@ def assemble_payload(
 
         if decision == "ticket":
             # Deferred: tickets are counted against the budget last.
-            ticket_pending.append((match.rel_path, sha256_hex))
+            ticket_pending.append((file_for(match), match.rel_path, sha256_hex))
             continue
 
         pending = [*index_lines, *_all_index_lines[match_idx + 1 :]]
@@ -347,7 +354,8 @@ def assemble_payload(
         complete = len(body) >= len(text)
         if not complete:
             body += truncation_notice(match.rel_path, max_spec_chars)
-        block = render_full(edited_rel, match.rel_path, sha12, body)
+        matching_file = file_for(match)
+        block = render_full(matching_file, match.rel_path, sha12, body)
         if not _fits(block):
             # Contract amendment 1: before degrading, truncate FURTHER to the
             # largest body prefix that fits the remaining total budget
@@ -356,7 +364,12 @@ def assemble_payload(
             # wrapper > total cap) and long specs fell straight to an index
             # line — the rejected index-only mode by another route.
             derived = _derive_fitting_full(
-                edited_rel, match.rel_path, sha12, text, max_spec_chars, _fits
+                matching_file,
+                match.rel_path,
+                sha12,
+                text,
+                max_spec_chars,
+                _fits,
             )
             if derived is not None:
                 derived_block, derived_complete = derived
@@ -413,8 +426,10 @@ def assemble_payload(
         if chosen:
             blocks.append(_index_block(chosen))
 
-    for spec_rel, sha256_hex in ticket_pending:
-        ticket = render_ticket(edited_rel, spec_rel, sha256_hex[:12], stateless)
+    for matching_file, spec_rel, sha256_hex in ticket_pending:
+        ticket = render_ticket(
+            matching_file, spec_rel, sha256_hex[:12], stateless
+        )
         if not fits(ticket):
             _warn(f"ticket for {spec_rel} dropped — per-event budget exhausted")
             continue

--- a/packages/cli/test/scripts/spec-injection.integration.test.ts
+++ b/packages/cli/test/scripts/spec-injection.integration.test.ts
@@ -12,8 +12,9 @@
  *   - `src/templates/trellis/scripts/common/spec_inject.py` — the pure decision
  *     engine (R7): `decide` truth table, `within_window`, `truncate_chars`,
  *     `assemble_payload`'s hard character ceiling
- *   - `src/templates/shared-hooks/inject-spec-context.py` — PostToolUse and
- *     SessionStart hook E2E: character budgets, lifecycle reset markers,
+ *   - `src/templates/shared-hooks/inject-spec-context.py` — Claude
+ *     PostToolUse, Codex PreToolUse, and SessionStart hook E2E: character
+ *     budgets, lifecycle reset markers,
  *     parent/subagent state, the pid-less locked state file, the unwritable
  *     circuit breaker and scoped GC, stateless ticket wording and tools config
  *   - `get_context.py --mode spec --file <path>` — pull mode
@@ -119,7 +120,10 @@ function readShardRecords(shard: string): StateRecord[] {
  * exactly one (R4 pins one file per identity). */
 function soleShard(tmp: string): string {
   const shards = listJsonl(stateBase(tmp));
-  expect(shards.length, `expected exactly one shard, got ${shards.join(", ")}`).toBe(1);
+  expect(
+    shards.length,
+    `expected exactly one shard, got ${shards.join(", ")}`,
+  ).toBe(1);
   return shards[0];
 }
 
@@ -278,12 +282,41 @@ function buildPayload(tmp: string, opts: PayloadOpts): string {
   return JSON.stringify(payload);
 }
 
-function additionalContext(stdout: string): string {
+function buildCodexPatchPayload(
+  tmp: string,
+  patch: string,
+  session = "sess-1",
+): string {
+  return JSON.stringify({
+    hook_event_name: "PreToolUse",
+    cwd: tmp,
+    session_id: session,
+    tool_name: "apply_patch",
+    tool_input: { command: patch },
+  });
+}
+
+function hookOutput(stdout: string): {
+  hookEventName: string;
+  additionalContext: string;
+  permissionDecision?: string;
+  permissionDecisionReason?: string;
+} {
   const parsed = JSON.parse(stdout) as {
-    hookSpecificOutput: { hookEventName: string; additionalContext: string };
+    hookSpecificOutput: {
+      hookEventName: string;
+      additionalContext: string;
+      permissionDecision?: string;
+      permissionDecisionReason?: string;
+    };
   };
-  expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
-  return parsed.hookSpecificOutput.additionalContext;
+  return parsed.hookSpecificOutput;
+}
+
+function additionalContext(stdout: string): string {
+  const output = hookOutput(stdout);
+  expect(output.hookEventName).toBe("PostToolUse");
+  return output.additionalContext;
 }
 
 /** Extract the 12-hex sha256 attr the FULL/TICKET tags carry; fail loudly if
@@ -301,7 +334,9 @@ function requireSha(ctx: string): string {
 function fullBlockBody(ctx: string): string {
   const m = /^<spec-context [^\n>]*>\n([\s\S]*)\n<\/spec-context>$/.exec(ctx);
   if (!m) {
-    throw new Error(`expected exactly one <spec-context> block: ${ctx.slice(0, 200)}`);
+    throw new Error(
+      `expected exactly one <spec-context> block: ${ctx.slice(0, 200)}`,
+    );
   }
   return m[1];
 }
@@ -1000,6 +1035,109 @@ print(f"v={rec['v']} version={STATE_VERSION} reset={rec['reset']}")
       expect(requireSha(ctx)).toMatch(/^[0-9a-f]{12}$/);
       expect(ctx).toContain("Command spec body.");
       expect(ctx).toContain("</spec-context>");
+    });
+
+    it("denies the first Codex apply_patch with the full spec, then allows the retry", () => {
+      writeGoverningSpec();
+      const payload = buildCodexPatchPayload(
+        tmp,
+        "*** Begin Patch\n*** Update File: src/commands/update.ts\n@@\n-old\n+new\n*** End Patch\n",
+      );
+
+      const first = runHook(tmp, payload);
+      expect(first.status).toBe(0);
+      const output = hookOutput(first.stdout);
+      expect(output.hookEventName).toBe("PreToolUse");
+      expect(output.permissionDecision).toBe("deny");
+      expect(output.permissionDecisionReason).toContain("retry");
+      expect(output.additionalContext).toContain(
+        `<spec-context file="${EDITED}" spec="${SPEC_REL}" sha256="`,
+      );
+
+      const retry = runHook(tmp, payload);
+      expect(retry.status).toBe(0);
+      expect(retry.stdout.trim()).toBe("");
+    });
+
+    it("allows a Codex apply_patch when only a refresh ticket is due", () => {
+      writeGoverningSpec();
+      const payload = buildCodexPatchPayload(
+        tmp,
+        "*** Begin Patch\n*** Update File: src/commands/update.ts\n@@\n-old\n+new\n*** End Patch\n",
+      );
+      expect(runHook(tmp, payload).status).toBe(0);
+
+      const shard = soleShard(tmp);
+      const record = readShardRecords(shard)[0];
+      fs.writeFileSync(
+        shard,
+        JSON.stringify({ ...record, ts: 0 }) + "\n",
+        "utf-8",
+      );
+
+      const refresh = runHook(tmp, payload);
+      expect(refresh.status).toBe(0);
+      const output = hookOutput(refresh.stdout);
+      expect(output.hookEventName).toBe("PreToolUse");
+      expect(output.permissionDecision).toBeUndefined();
+      expect(output.additionalContext).toContain("<spec-ticket");
+      expect(output.additionalContext).toContain(STATEFUL_TICKET_BODY);
+    });
+
+    it("matches every file in a Codex patch and injects a shared spec once", () => {
+      writeSpec(
+        tmp,
+        "models.md",
+        "---\ndescription: model rules\npaths:\n  - src/models/**\n---\nModel spec body.\n",
+      );
+      writeSpec(
+        tmp,
+        "legacy.md",
+        "---\npaths:\n  - src/legacy/**\n---\nLegacy deletion rules.\n",
+      );
+      writeSpec(
+        tmp,
+        "entities.md",
+        "---\npaths:\n  - src/entities/**\n---\nEntity move rules.\n",
+      );
+      const payload = buildCodexPatchPayload(
+        tmp,
+        [
+          "*** Begin Patch",
+          "*** Update File: README.md",
+          "@@",
+          "-old",
+          "+new",
+          "*** Add File: src/models/account.ts",
+          "+export const account = {};",
+          "*** Delete File: src/legacy/obsolete.ts",
+          "*** Update File: src/models/user.ts",
+          "*** Move to: src/entities/user.ts",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+          "",
+        ].join("\n"),
+      );
+
+      const r = runHook(tmp, payload);
+      expect(r.status).toBe(0);
+      const output = hookOutput(r.stdout);
+      expect(output.permissionDecision).toBe("deny");
+      expect(output.additionalContext).toContain(
+        '<spec-context file="src/models/account.ts" spec=".trellis/spec/models.md"',
+      );
+      expect(output.additionalContext).toContain(
+        '<spec-context file="src/legacy/obsolete.ts" spec=".trellis/spec/legacy.md"',
+      );
+      expect(output.additionalContext).toContain(
+        '<spec-context file="src/entities/user.ts" spec=".trellis/spec/entities.md"',
+      );
+      expect(
+        output.additionalContext.match(/spec=".trellis\/spec\/models.md"/g),
+      ).toHaveLength(1);
+      expect(output.additionalContext.match(/<spec-context /g)).toHaveLength(3);
     });
 
     it("goes silent on a second touch of the same session within the refresh window", () => {

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -62,11 +62,18 @@ describe("codex getAllAgents", () => {
 });
 
 describe("codex native sub-agent hooks", () => {
-  it("preserves main-session workflow injection and scopes SubagentStart to Trellis roles", () => {
+  it("registers dynamic spec injection and preserves existing context hooks", () => {
     const config = JSON.parse(getHooksConfig()) as {
       hooks: Record<
         string,
-        { matcher?: string; hooks: { command: string }[] }[]
+        {
+          matcher?: string;
+          hooks: {
+            command: string;
+            timeout?: number;
+            additionalContextLimit?: number;
+          }[];
+        }[]
       >;
     };
 
@@ -87,6 +94,22 @@ describe("codex native sub-agent hooks", () => {
     expect(matcher.test("trellis-implement-extra")).toBe(false);
     expect(subagentStart?.hooks[0]?.command).toContain(
       ".codex/hooks/inject-subagent-context.py",
+    );
+
+    expect(config.hooks.SessionStart).toHaveLength(1);
+    expect(config.hooks.SessionStart[0]?.matcher).toBe("^(?:clear|compact)$");
+    expect(config.hooks.SessionStart[0]?.hooks[0]?.command).toContain(
+      ".codex/hooks/inject-spec-context.py",
+    );
+
+    expect(config.hooks.PreToolUse).toHaveLength(1);
+    expect(config.hooks.PreToolUse[0]?.matcher).toBe("Edit|Write");
+    expect(config.hooks.PreToolUse[0]?.hooks[0]).toMatchObject({
+      timeout: 15,
+      additionalContextLimit: 0,
+    });
+    expect(config.hooks.PreToolUse[0]?.hooks[0]?.command).toContain(
+      ".codex/hooks/inject-spec-context.py",
     );
   });
 });
@@ -151,7 +174,9 @@ describe("codex sub-agent recursion guard (issue #234)", () => {
       expect(content).toContain("trellis-implement");
       expect(content).toContain("trellis-check");
       // Mentions the leakage source so the reader knows why
-      expect(content).toMatch(/SessionStart|dispatch.*main session|breadcrumb/i);
+      expect(content).toMatch(
+        /SessionStart|dispatch.*main session|breadcrumb/i,
+      );
     });
   }
 });
@@ -173,9 +198,7 @@ describe("codex two-channel sub-agent context (native SubagentStart)", () => {
       const savedOutputNotice = content.indexOf(
         "Full hook output saved to: <path>",
       );
-      const injectionMarker = content.indexOf(
-        "<!-- trellis-hook-injected -->",
-      );
+      const injectionMarker = content.indexOf("<!-- trellis-hook-injected -->");
 
       expect(savedOutputNotice).toBeGreaterThan(-1);
       expect(injectionMarker).toBeGreaterThan(savedOutputNotice);
@@ -236,7 +259,9 @@ describe("codex session-start.py compact SessionStart context", () => {
     expect(content).toContain("design.md if present");
     expect(content).not.toContain("<sub-agent-notice>");
     expect(content).not.toContain("guides (inlined");
-    expect(content).not.toContain("Project spec indexes are listed by path below");
+    expect(content).not.toContain(
+      "Project spec indexes are listed by path below",
+    );
   });
 
   it("documents fail-open exception suppression", () => {

--- a/packages/cli/test/templates/shared-hooks.test.ts
+++ b/packages/cli/test/templates/shared-hooks.test.ts
@@ -19,9 +19,7 @@ const EMPTY_EXCEPT_PASS_RE = /except[^\n]*:\n\s*pass\s*$/m;
 describe("shared-hooks capability table", () => {
   it("every capability-table entry names a real shared-hook file", () => {
     const realFiles = new Set(getSharedHookScripts().map((h) => h.name));
-    for (const [platform, hooks] of Object.entries(
-      SHARED_HOOKS_BY_PLATFORM,
-    )) {
+    for (const [platform, hooks] of Object.entries(SHARED_HOOKS_BY_PLATFORM)) {
       for (const hook of hooks) {
         expect(
           realFiles.has(hook),
@@ -47,9 +45,7 @@ describe("shared-hooks capability table", () => {
   it("statusline.py is not distributed by default", () => {
     const realFiles = new Set(getSharedHookScripts().map((h) => h.name));
     expect(realFiles.has("statusline.py")).toBe(false);
-    for (const [platform, hooks] of Object.entries(
-      SHARED_HOOKS_BY_PLATFORM,
-    )) {
+    for (const [platform, hooks] of Object.entries(SHARED_HOOKS_BY_PLATFORM)) {
       expect(
         (hooks as readonly string[]).includes("statusline.py"),
         `${platform} must not install the generated statusline.py hook by default`,
@@ -61,9 +57,7 @@ describe("shared-hooks capability table", () => {
     // Codex uses SubagentStart.additionalContext; these remaining platforms
     // are class-2 and load their context from an agent-definition prelude.
     const class2 = new Set(["copilot", "gemini", "qoder", "trae"]);
-    for (const [platform, hooks] of Object.entries(
-      SHARED_HOOKS_BY_PLATFORM,
-    )) {
+    for (const [platform, hooks] of Object.entries(SHARED_HOOKS_BY_PLATFORM)) {
       const has = hooks.includes("inject-subagent-context.py");
       if (class2.has(platform))
         expect(
@@ -77,21 +71,13 @@ describe("shared-hooks capability table", () => {
     );
   });
 
-  it("inject-spec-context.py is distributed to Claude Code only (this iteration)", () => {
-    // PostToolUse spec injection is registered on Claude Code only; other
-    // platforms are a follow-up (class-2 platforms use the
-    // `get_context.py --mode spec` pull mode instead).
-    for (const [platform, hooks] of Object.entries(
-      SHARED_HOOKS_BY_PLATFORM,
-    )) {
-      const has = hooks.includes("inject-spec-context.py");
-      if (platform === "claude") expect(has).toBe(true);
-      else
-        expect(
-          has,
-          `${platform} must not ship inject-spec-context.py — Claude-only this iteration`,
-        ).toBe(false);
-    }
+  it("inject-spec-context.py is distributed to Claude Code and Codex", () => {
+    const providers = Object.entries(SHARED_HOOKS_BY_PLATFORM)
+      .filter(([, hooks]) => hooks.includes("inject-spec-context.py"))
+      .map(([platform]) => platform)
+      .sort();
+
+    expect(providers).toEqual(["claude", "codex"]);
   });
 
   it("codex + copilot do not take the shared session-start.py (they bundle their own)", () => {
@@ -100,9 +86,7 @@ describe("shared-hooks capability table", () => {
   });
 
   it("inject-shell-session-context.py goes to Cursor only", () => {
-    for (const [platform, hooks] of Object.entries(
-      SHARED_HOOKS_BY_PLATFORM,
-    )) {
+    for (const [platform, hooks] of Object.entries(SHARED_HOOKS_BY_PLATFORM)) {
       const has = hooks.includes("inject-shell-session-context.py");
       if (platform === "cursor") expect(has).toBe(true);
       else
@@ -172,12 +156,17 @@ describe("shared-hooks capability table", () => {
     const sessionStart = getSharedHookScripts().find(
       (h) => h.name === "session-start.py",
     );
-    expect(sessionStart, "session-start.py is missing from shared-hooks/").toBeDefined();
+    expect(
+      sessionStart,
+      "session-start.py is missing from shared-hooks/",
+    ).toBeDefined();
     const content = sessionStart ? sessionStart.content : "";
     expect(content).toContain("<trellis-workflow>");
     expect(content).toContain("Task context order");
     expect(content).toContain("jsonl entries -> `prd.md`");
-    expect(content).toContain("Lightweight task can request start review with PRD-only");
+    expect(content).toContain(
+      "Lightweight task can request start review with PRD-only",
+    );
     expect(content).toContain("complex task must add");
     expect(content).not.toContain("Status: READY");
     expect(content).not.toContain("<workflow>");


### PR DESCRIPTION
## Summary

- distribute the shared spec-injection hook to Codex
- register Codex `PreToolUse` and compaction-reset hooks
- parse every file path in a native `apply_patch` call
- inject governing specs before the edit, deny the first full-spec patch, and allow the informed retry
- keep Claude Code on its existing `PostToolUse` flow while sharing the decision and state logic

## Why

Claude Code requires a file read before editing, so its existing post-read injection can teach the model before a later write. Codex can patch a file without reading it first, which makes post-use injection too late.

Codex therefore needs the same shared provider through `PreToolUse`. When a full spec is due, the hook returns the spec as model-visible context and denies the current patch once. Codex then retries with the governing rules in context. Ticket-only refreshes do not block the edit.

## Impact

Projects initialized or updated with Codex now receive path-scoped specs at the point of editing. Claude Code behavior remains unchanged. Platform support continues to come from the shared provider capability table rather than duplicated conditionals.

## Validation

- Core tests: 333 passed, 1 skipped
- CLI tests: 1702 passed
- targeted shared-hook, Codex-template, and spec-injection integration tests passed
- ESLint and pre-commit verification passed
- real Codex CLI 0.144.3 end-to-end test with trusted project hooks and no trust bypass:
  - the first `apply_patch` was blocked by `PreToolUse`
  - the governing spec was delivered to the model
  - Codex retried automatically and wrote the spec-required value
  - the state shard recorded a `full` emission
