### PR TITLE
chore(release): prepare v0.7.0-beta.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindfoldhq/trellis",
-  "version": "0.6.10",
+  "version": "0.7.0-0",
   "description": "AI capabilities grow like ivy — Trellis provides the structure to guide them along a disciplined path",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/migrations/manifests/0.7.0-beta.0.json
+++ b/packages/cli/src/migrations/manifests/0.7.0-beta.0.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.7.0-beta.0",
+  "description": "Path-scoped dynamic spec loading for Claude Code and Codex, plus layered workflow selection per task, developer, and team.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Enhancements:**\n- feat(hooks): deliver path-scoped specs dynamically through Claude Code PostToolUse and Codex PreToolUse hooks, with documented session reset handling\n- feat(workflow): save workflow variants and resolve task, developer, team, and global selections through one runtime chain",
+  "migrations": [],
+  "notes": "Run `trellis update` to install the new spec-injection hooks, workflow library support, and layered workflow resolver. No `--migrate` required."
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindfoldhq/trellis-core",
-  "version": "0.6.10",
+  "version": "0.7.0-0",
   "description": "Trellis core SDK — channel and task domain primitives consumed by the Trellis CLI and downstream Node services",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- seed CLI and core at `0.7.0-0` so the beta release script produces `0.7.0-beta.0`
- add the `0.7.0-beta.0` migration manifest
- update the docs submodule to the merged 0.7 beta documentation

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `env -u TRELLIS_DISABLE_HOOKS pnpm test` (2035 passed, 1 skipped)
- `node packages/cli/scripts/check-manifest-continuity.js`
- `node packages/cli/scripts/check-docs-changelog.js --type beta`
- `node packages/cli/scripts/release-preflight.js verify-packed-cli`
- fresh Claude Code + Codex init and update dry-run
- packed asset checks for spec injection and workflow selection