### PR TITLE
feat(workflow): add local workflow scaffolding

### DIFF
--- a/.trellis/spec/cli/backend/commands-workflow.md
+++ b/.trellis/spec/cli/backend/commands-workflow.md
@@ -46,6 +46,8 @@ trellis workflow --template <id> --create-new
 trellis workflow --save <id>
 trellis workflow --marketplace <source> --save <id>
 trellis workflow --save <id> --force
+trellis workflow create <id>
+trellis workflow create <id> --skip-defaults
 
 trellis init --workflow <id>
 trellis init --workflow-source <source> --workflow <id>
@@ -150,6 +152,21 @@ Library ownership contract (`.trellis/workflows/`):
   listing the `.md` ids found on disk (sorted); the section is omitted when
   the directory is absent or empty.
 
+Local scaffold contract (`workflow create`):
+
+- `trellis workflow create <id>` writes
+  `.trellis/workflows/<id>.md` from the bundled native workflow. Reusing the
+  native source keeps all parser-sensitive headings, platform markers, and
+  `[workflow-state:*]` blocks intact without maintaining a second template.
+- The command never changes or removes `.trellis/workflow.md` or its template
+  hash. The global file remains the zero-config fallback.
+- In a TTY, the command asks two confirm questions in order: project default
+  (`config.yaml` `default_workflow`) and personal default (`.developer`
+  `workflow=`). Both default to no. `--skip-defaults` and non-TTY execution
+  create only the scaffold.
+- Existing variant files are never overwritten. Config and developer writes
+  are atomic and preserve unrelated content.
+
 Marker validation contract (`--save` only; warn, never block):
 
 - After writing the library file, `--save` checks the saved content for the
@@ -199,6 +216,11 @@ Native source-of-truth contract:
 | `--save missing-id` | `WorkflowResolveError` surfaced as command error; nothing written |
 | `--save` of a template missing parser markers | Write the file, exit 0, one stderr warning listing the missing markers |
 | `trellis update` with saved library files present | Leave `.trellis/workflows/` untouched |
+| `workflow create <id>` | Write a native-based scaffold to `.trellis/workflows/<id>.md`; leave the global workflow and hash untouched |
+| `workflow create <id>` where the file exists | Exit 1 without changing the existing variant |
+| `workflow create <id>` where id fails `[A-Za-z0-9_-]+` | Exit 1 before creating a path |
+| Interactive scaffold creation | Ask project default first, then personal default; write only selected defaults |
+| `workflow create <id> --skip-defaults` or non-TTY | Create the scaffold without prompting or changing defaults |
 
 ### 5. Good/Base/Bad Cases
 
@@ -253,6 +275,10 @@ Integration tests:
 - `--save` combined with `--template` or `--create-new` fails.
 - `--list` shows saved library ids in a `Library` section.
 - `trellis update` leaves saved library files intact.
+- `workflow create` produces the complete native workflow, preserves the
+  global workflow and hash contract, and refuses unsafe ids or existing files.
+- Interactive scaffold creation asks project then personal default and writes
+  the selected ids without disturbing unrelated config/developer content.
 
 Runtime parsing validation:
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -8,6 +8,7 @@ import { upgrade } from "../commands/upgrade.js";
 import { uninstall } from "../commands/uninstall.js";
 import { runMem } from "../commands/mem.js";
 import {
+  runCreateWorkflowCommand,
   runWorkflowCommand,
   WorkflowCommandError,
 } from "../commands/workflow.js";
@@ -259,7 +260,7 @@ program
     }
   });
 
-program
+const workflowCommand = program
   .command("workflow")
   .description(
     "List or switch the project's .trellis/workflow.md template (native, tdd, channel-driven-subagent-dispatch, or marketplace)",
@@ -307,6 +308,35 @@ program
       process.exit(1);
     }
   });
+
+workflowCommand
+  .command("create <workflow-id>")
+  .description(
+    "Create .trellis/workflows/<workflow-id>.md from the native workflow",
+  )
+  .option(
+    "--skip-defaults",
+    "Create the workflow without project or personal default prompts",
+  )
+  .action(
+    async (
+      workflowId: string,
+      options: { skipDefaults?: boolean },
+    ): Promise<void> => {
+      try {
+        await runCreateWorkflowCommand(workflowId, options);
+      } catch (error) {
+        console.error(
+          chalk.red("Error:"),
+          error instanceof Error ? error.message : error,
+        );
+        if (process.env.DEBUG || process.env.TRELLIS_DEBUG) {
+          console.error(error instanceof Error ? error.stack : error);
+        }
+        process.exit(1);
+      }
+    },
+  );
 
 program
   .command("platforms")

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -45,6 +45,7 @@ import {
   type ResolvedWorkflowTemplate,
   type WorkflowTemplateListing,
 } from "../utils/workflow-resolver.js";
+import { writeFileAtomic } from "../utils/atomic-write.js";
 
 export interface WorkflowCommandOptions {
   template?: string;
@@ -53,6 +54,10 @@ export interface WorkflowCommandOptions {
   force?: boolean;
   createNew?: boolean;
   save?: string;
+}
+
+export interface CreateWorkflowOptions {
+  skipDefaults?: boolean;
 }
 
 /**
@@ -75,6 +80,10 @@ function workflowFilePath(cwd: string): string {
 
 function workflowsLibraryDir(cwd: string): string {
   return path.join(cwd, WORKFLOWS_LIB_REL);
+}
+
+function workflowLibraryPath(cwd: string, id: string): string {
+  return path.join(workflowsLibraryDir(cwd), `${id}.md`);
 }
 
 function isInteractive(): boolean {
@@ -362,6 +371,138 @@ async function saveWorkflowToLibrary(
   console.log(chalk.green(`  ✓ Saved "${template.id}" to ${destRel}`));
 
   warnAboutMissingMarkers(finalContent, destRel);
+}
+
+function setProjectDefaultWorkflow(cwd: string, id: string): void {
+  const configPath = path.join(cwd, DIR_NAMES.WORKFLOW, "config.yaml");
+  if (!fs.existsSync(configPath)) {
+    throw new WorkflowCommandError(
+      `Cannot set the project default because ${DIR_NAMES.WORKFLOW}/config.yaml is missing.`,
+    );
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8");
+  const line = `default_workflow: ${id}`;
+  let next: string;
+  if (/^default_workflow\s*:/m.test(content)) {
+    next = content.replace(/^default_workflow\s*:.*$/m, line);
+  } else if (/^#\s*default_workflow\s*:/m.test(content)) {
+    next = content.replace(/^#\s*default_workflow\s*:.*$/m, line);
+  } else {
+    next = `${content.trimEnd()}\n\n${line}\n`;
+  }
+  writeFileAtomic(configPath, next);
+}
+
+function setPersonalDefaultWorkflow(cwd: string, id: string): void {
+  const developerPath = path.join(cwd, PATHS.DEVELOPER_FILE);
+  if (!fs.existsSync(developerPath)) {
+    throw new WorkflowCommandError(
+      `Cannot set the personal default because ${PATHS.DEVELOPER_FILE} is missing. Run \`trellis init -u <name>\` first.`,
+    );
+  }
+
+  const content = fs.readFileSync(developerPath, "utf-8");
+  const line = `workflow=${id}`;
+  const next = /^workflow=.*$/m.test(content)
+    ? content.replace(/^workflow=.*$/m, line)
+    : `${content.trimEnd()}\n${line}\n`;
+  writeFileAtomic(developerPath, next);
+}
+
+async function chooseWorkflowDefaults(id: string): Promise<{
+  projectDefault: boolean;
+  personalDefault: boolean;
+}> {
+  const { projectDefault } = await inquirer.prompt<{
+    projectDefault: boolean;
+  }>([
+    {
+      type: "confirm",
+      name: "projectDefault",
+      message: `Set "${id}" as the project default in .trellis/config.yaml?`,
+      default: false,
+    },
+  ]);
+  const { personalDefault } = await inquirer.prompt<{
+    personalDefault: boolean;
+  }>([
+    {
+      type: "confirm",
+      name: "personalDefault",
+      message: `Set "${id}" as your personal default in .trellis/.developer?`,
+      default: false,
+    },
+  ]);
+  return { projectDefault, personalDefault };
+}
+
+/**
+ * Create a user-managed workflow variant from the bundled native workflow.
+ *
+ * Reusing native keeps every parser-sensitive heading, platform marker, and
+ * workflow-state block intact without maintaining a second scaffold template.
+ * The global `.trellis/workflow.md` and its hash entry are never changed.
+ */
+export async function runCreateWorkflowCommand(
+  id: string,
+  options: CreateWorkflowOptions = {},
+): Promise<void> {
+  const cwd = process.cwd();
+  if (!fs.existsSync(path.join(cwd, DIR_NAMES.WORKFLOW))) {
+    throw new WorkflowCommandError(
+      "No .trellis/ directory found. Run `trellis init` first.",
+    );
+  }
+  if (!WORKFLOW_ID_RE.test(id)) {
+    throw new WorkflowCommandError(
+      `Invalid workflow id "${id}". Workflow ids must match [A-Za-z0-9_-]+.`,
+    );
+  }
+
+  const destPath = workflowLibraryPath(cwd, id);
+  const destRel = `${WORKFLOWS_LIB_REL}/${id}.md`;
+  if (fs.existsSync(destPath)) {
+    throw new WorkflowCommandError(
+      `${destRel} already exists. Choose another workflow id or edit the existing file.`,
+    );
+  }
+
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  const native = await resolveWorkflowTemplate(NATIVE_WORKFLOW_ID);
+  writeFileAtomic(destPath, replacePythonCommandLiterals(native.content));
+  console.log(chalk.green(`  ✓ Created ${destRel} from the native workflow`));
+
+  if (options.skipDefaults || !isInteractive()) return;
+
+  const defaults = await chooseWorkflowDefaults(id);
+  if (
+    defaults.projectDefault &&
+    !fs.existsSync(path.join(cwd, DIR_NAMES.WORKFLOW, "config.yaml"))
+  ) {
+    throw new WorkflowCommandError(
+      `Created ${destRel}, but cannot set the project default because ${DIR_NAMES.WORKFLOW}/config.yaml is missing.`,
+    );
+  }
+  if (
+    defaults.personalDefault &&
+    !fs.existsSync(path.join(cwd, PATHS.DEVELOPER_FILE))
+  ) {
+    throw new WorkflowCommandError(
+      `Created ${destRel}, but cannot set the personal default because ${PATHS.DEVELOPER_FILE} is missing. Run \`trellis init -u <name>\` first.`,
+    );
+  }
+
+  if (defaults.projectDefault) {
+    setProjectDefaultWorkflow(cwd, id);
+    console.log(
+      chalk.green(`  ✓ Set default_workflow: ${id} in .trellis/config.yaml`),
+    );
+  }
+  if (defaults.personalDefault) {
+    setPersonalDefaultWorkflow(cwd, id);
+    console.log(chalk.green(`  ✓ Set workflow=${id} in .trellis/.developer`));
+  }
 }
 
 /**

--- a/packages/cli/test/commands/workflow.integration.test.ts
+++ b/packages/cli/test/commands/workflow.integration.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import inquirer from "inquirer";
 
 vi.mock("figlet", () => ({
   default: { textSync: vi.fn(() => "TRELLIS") },
@@ -37,7 +38,11 @@ vi.mock("node:child_process", () => ({
 
 import { init } from "../../src/commands/init.js";
 import { update } from "../../src/commands/update.js";
-import { runWorkflowCommand, WorkflowCommandError } from "../../src/commands/workflow.js";
+import {
+  runCreateWorkflowCommand,
+  runWorkflowCommand,
+  WorkflowCommandError,
+} from "../../src/commands/workflow.js";
 import { PATHS } from "../../src/constants/paths.js";
 import { loadHashes } from "../../src/utils/template-hash.js";
 import { workflowMdTemplate } from "../../src/templates/trellis/index.js";
@@ -140,7 +145,8 @@ describe("trellis workflow integration", () => {
         },
       ],
     };
-    const customContent = "# Custom Workflow\n\n## Phase Index\nCustom phase.\n";
+    const customContent =
+      "# Custom Workflow\n\n## Phase Index\nCustom phase.\n";
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL) => {
@@ -179,9 +185,7 @@ describe("trellis workflow integration", () => {
   it("trellis workflow --template native refreshes hash after switching from tdd", async () => {
     stubMarketplaceFetch();
     await init({ yes: true, workflow: "tdd" } as Record<string, unknown>);
-    expect(
-      loadHashes(tmpDir)[PATHS.WORKFLOW_GUIDE_FILE],
-    ).toBeUndefined();
+    expect(loadHashes(tmpDir)[PATHS.WORKFLOW_GUIDE_FILE]).toBeUndefined();
 
     // Switching FROM a non-native workflow requires --force because the file
     // has no stored hash → the resolver conservatively flags it as "modified",
@@ -208,6 +212,124 @@ describe("trellis workflow integration", () => {
       replacePythonCommandLiterals(TDD_CONTENT),
     );
     expect(loadHashes(tmpDir)[PATHS.WORKFLOW_GUIDE_FILE]).toBeUndefined();
+  });
+
+  it("workflow create generates a complete native scaffold without changing defaults", async () => {
+    stubMarketplaceFetch();
+    await init({ yes: true, user: "alice" });
+
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    const developerPath = path.join(tmpDir, ".trellis", ".developer");
+    fs.writeFileSync(developerPath, "name=alice\n", "utf-8");
+    const configBefore = fs.readFileSync(configPath, "utf-8");
+    const developerBefore = fs.readFileSync(developerPath, "utf-8");
+    const workflowBefore = fs.readFileSync(
+      path.join(tmpDir, PATHS.WORKFLOW_GUIDE_FILE),
+      "utf-8",
+    );
+
+    await runCreateWorkflowCommand("review-first", { skipDefaults: true });
+
+    expect(
+      fs.readFileSync(
+        path.join(tmpDir, ".trellis", "workflows", "review-first.md"),
+        "utf-8",
+      ),
+    ).toBe(replacePythonCommandLiterals(workflowMdTemplate));
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(configBefore);
+    expect(fs.readFileSync(developerPath, "utf-8")).toBe(developerBefore);
+    expect(
+      fs.readFileSync(path.join(tmpDir, PATHS.WORKFLOW_GUIDE_FILE), "utf-8"),
+    ).toBe(workflowBefore);
+  });
+
+  it("workflow create prompts for project then personal defaults and writes both", async () => {
+    stubMarketplaceFetch();
+    await init({ yes: true, user: "alice" });
+    const configPath = path.join(tmpDir, ".trellis", "config.yaml");
+    fs.writeFileSync(
+      configPath,
+      fs
+        .readFileSync(configPath, "utf-8")
+        .replace(
+          "# default_workflow: native",
+          "default_workflow: old-workflow",
+        ),
+      "utf-8",
+    );
+    const developerPath = path.join(tmpDir, ".trellis", ".developer");
+    fs.writeFileSync(
+      developerPath,
+      "name=alice\nworkflow=old-workflow\n",
+      "utf-8",
+    );
+    vi.mocked(inquirer.prompt).mockClear();
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({ projectDefault: true })
+      .mockResolvedValueOnce({ personalDefault: true });
+
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+
+    try {
+      await runCreateWorkflowCommand("review-first");
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+
+    expect(vi.mocked(inquirer.prompt)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(inquirer.prompt).mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({
+        name: "projectDefault",
+        type: "confirm",
+      }),
+    ]);
+    expect(vi.mocked(inquirer.prompt).mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({
+        name: "personalDefault",
+        type: "confirm",
+      }),
+    ]);
+    const config = fs.readFileSync(configPath, "utf-8");
+    expect(config).toContain("default_workflow: review-first");
+    expect(config).not.toContain("old-workflow");
+    expect(config.match(/^default_workflow\s*:/gm)).toHaveLength(1);
+
+    const developer = fs.readFileSync(developerPath, "utf-8");
+    expect(developer).toContain("name=alice");
+    expect(developer).toContain("workflow=review-first");
+    expect(developer).not.toContain("old-workflow");
+    expect(developer.match(/^workflow=/gm)).toHaveLength(1);
+  });
+
+  it("workflow create rejects unsafe ids and preserves an existing variant", async () => {
+    stubMarketplaceFetch();
+    await init({ yes: true });
+
+    await expect(
+      runCreateWorkflowCommand("../outside", { skipDefaults: true }),
+    ).rejects.toThrow(/Invalid workflow id/);
+    expect(fs.existsSync(path.join(tmpDir, "outside.md"))).toBe(false);
+
+    const variantPath = path.join(
+      tmpDir,
+      ".trellis",
+      "workflows",
+      "review-first.md",
+    );
+    fs.mkdirSync(path.dirname(variantPath), { recursive: true });
+    fs.writeFileSync(variantPath, "# local workflow", "utf-8");
+
+    await expect(
+      runCreateWorkflowCommand("review-first", { skipDefaults: true }),
+    ).rejects.toThrow(/already exists/);
+    expect(fs.readFileSync(variantPath, "utf-8")).toBe("# local workflow");
   });
 
   it("non-interactive run with a locally-modified workflow.md fails without --force", async () => {
@@ -400,9 +522,9 @@ describe("trellis workflow integration", () => {
 
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockClear();
-    await expect(
-      runWorkflowCommand({ save: "../evil" }),
-    ).rejects.toThrow(/Invalid workflow id/);
+    await expect(runWorkflowCommand({ save: "../evil" })).rejects.toThrow(
+      /Invalid workflow id/,
+    );
     // Rejected before the template pipeline: no marketplace fetch, no write.
     expect(fetchMock).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(tmpDir, ".trellis", "evil.md"))).toBe(false);


### PR DESCRIPTION
## Summary

- add `trellis workflow create <workflow-id>` to scaffold a user-managed variant from the bundled native workflow
- prompt serially for project and personal defaults, with `--skip-defaults` and non-TTY support
- preserve `.trellis/workflow.md` as the permanent zero-config fallback and never overwrite existing variants
- update the beta workflow documentation and record the remaining platform-specific limits

## Behavior

The generated file is written to `.trellis/workflows/<workflow-id>.md`. When interactive, the command asks in this order:

1. set `.trellis/config.yaml` `default_workflow`
2. set `.trellis/.developer` `workflow=`

Both prompts default to no. Config writes are atomic and preserve unrelated content.

## Runtime audit

The existing resolver continues to apply task pin -> personal default -> project default -> global workflow. Shared Python hooks, Codex/Copilot SessionStart, OpenCode per-turn injection, and phase lookup already use it. The docs now explicitly list Pi/OMP, Snow context injection, and OpenCode SessionStart as current global-only paths.

## Documentation

- mindfold-ai/docs#25
- mindfold-ai/docs#26

## Validation

- `env -u TRELLIS_DISABLE_HOOKS pnpm test` (Core: 333 passed, 1 skipped; CLI: 1705 passed)
- Core + CLI typecheck, lint, and build
- `pnpm exec vitest run test/commands/workflow.integration.test.ts` (21 passed)
- real CLI smoke test for `init` + `workflow create --skip-defaults`
- `git diff --check`