### PR TITLE
feat(pi): support dynamic workflow selection

### DIFF
--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -1098,7 +1098,7 @@ The body of the `<workflow-state>` breadcrumb MUST be byte-identical across clas
 Concrete rules:
 
 - **Regex parity**: `templates/pi/extensions/trellis/index.ts.txt:WORKFLOW_STATE_TAG_RE` MUST mirror `templates/shared-hooks/inject-workflow-state.py:_TAG_RE` byte-for-byte. Both use the closing-tag backreference `\1` (or its TS equivalent in `[\/workflow-state:\1\]`) so a tag block parses identically in Python and TypeScript.
-- **Breadcrumb body source**: `loadWorkflowBreadcrumbs()` in the Pi extension reads `.trellis/workflow.md` directly — same source as the Python hook. There is no separate TS-side template for breadcrumb bodies. If the regex drifts, the TS port silently falls back to hardcoded defaults and Pi loses parity.
+- **Breadcrumb body source**: `workflowBreadcrumb()` in the Pi extension reads the path selected by `resolveWorkflowMd()`, which mirrors the Python task → personal → team → global precedence. There is no separate TS-side template for breadcrumb bodies. If the resolver or regex drifts, Pi loses parity.
 - **Status writer parity**: `task.json.status` is the sole input to "which `[workflow-state:STATUS]` block fires". Both the Python hook (`get_active_task` + status read) and the TS port (`readActiveTaskStatus()` in `index.ts.txt`) MUST agree on the status string. Custom statuses pass through both unchanged.
 - **`<session-overview>` parity**: Pi shells out to `python3 .trellis/scripts/get_context.py` rather than re-implementing context generation in TS, so output stays canonical. Don't replace this with an inline TS implementation — that's a parity drift waiting to happen.
 

--- a/.trellis/spec/cli/backend/workflow-state-contract.md
+++ b/.trellis/spec/cli/backend/workflow-state-contract.md
@@ -163,12 +163,12 @@ Consumers that resolve per-task:
 | `shared-hooks/inject-workflow-state.py` (`load_breadcrumbs`) | per-turn `[workflow-state:*]` breadcrumb bodies |
 | `scripts/common/workflow_phase.py` (`get_context.py --mode phase`) | phase/step detail bodies |
 | `opencode/plugins/inject-workflow-state.js` (`resolveWorkflowMd`) | per-turn breadcrumbs (JS port; mirrors the Python rule for the same inputs) |
+| `pi/extensions/trellis/index.ts.txt` (`resolveWorkflowMd`) | per-turn breadcrumbs (TS port; mirrors the Python rule for the same inputs) |
 | `codex/hooks/session-start.py` + `copilot/hooks/session-start.py` (`_resolve_workflow_md`) | platform-specific SessionStart Phase Index TOC |
 
-Known degradation: the Pi and OMP extensions keep injecting the global
-`.trellis/workflow.md` regardless of per-task, personal, or team selection
-(their workflow reads live inside monolithic TS extensions). Parity there is a
-tracked follow-up.
+Known degradation: the OMP extension keeps injecting the global
+`.trellis/workflow.md` regardless of per-task, personal, or team selection.
+Parity there is a tracked follow-up.
 
 Absent a per-task pin **and** the personal/team default keys, every consumer
 resolves to the global `.trellis/workflow.md` — output is byte-identical to a

--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -1081,10 +1081,66 @@ function adoptKey(root: string, key: string): string {
 }
 
 // ── Workflow State Breadcrumb ─────────────────────────────────────────
+const WORKFLOW_ID_RE = /^[A-Za-z0-9_-]+$/;
+const DEFAULT_WORKFLOW_RE =
+  /^default_workflow:\s*(['"]?)([A-Za-z0-9_-]+)\1\s*(?:#.*)?$/m;
+
+function workflowVariant(root: string, workflowId: string): string {
+  if (!WORKFLOW_ID_RE.test(workflowId)) return "";
+  const path = join(root, ".trellis", "workflows", `${workflowId}.md`);
+  return exists(path) ? path : "";
+}
+
+function developerWorkflowId(root: string): string {
+  for (const line of readText(join(root, ".trellis", ".developer")).split(
+    /\r?\n/,
+  )) {
+    if (line.startsWith("workflow="))
+      return line.slice("workflow=".length).trim();
+  }
+  return "";
+}
+
+function configDefaultWorkflowId(root: string): string {
+  return (
+    readText(join(root, ".trellis", "config.yaml")).match(
+      DEFAULT_WORKFLOW_RE,
+    )?.[2] ?? ""
+  );
+}
+
+/** Mirrors common/workflow_selection.py without spawning another Python
+ * process on every Pi turn. Invalid or missing selections fall through. */
+function resolveWorkflowMd(root: string, key: string | null): string {
+  const taskDir = readTaskDir(root, key);
+  let workflowId = "";
+  if (taskDir) {
+    try {
+      const task = JSON.parse(
+        readText(join(taskDir, "task.json")),
+      ) as JsonObject;
+      workflowId = typeof task.workflow === "string" ? task.workflow : "";
+    } catch {}
+  }
+  if (workflowId) {
+    const pinned = workflowVariant(root, workflowId);
+    if (pinned) return pinned;
+    console.error(
+      `Warning: active task selects workflow ${JSON.stringify(workflowId)} but .trellis/workflows/ has no matching file; using default workflow resolution`,
+    );
+  }
+
+  const personal = workflowVariant(root, developerWorkflowId(root));
+  if (personal) return personal;
+  const team = workflowVariant(root, configDefaultWorkflowId(root));
+  if (team) return team;
+  return join(root, ".trellis", "workflow.md");
+}
+
 const WF_RE =
   /\[workflow-state:([A-Za-z0-9_-]+)\]\s*\n([\s\S]*?)\n\s*\[\/workflow-state:\1\]/g;
 function workflowBreadcrumb(root: string, key: string | null): string {
-  const wf = readText(join(root, ".trellis", "workflow.md"));
+  const wf = readText(resolveWorkflowMd(root, key));
   if (!wf) return "";
   const templates: Record<string, string> = {};
   for (const m of wf.matchAll(WF_RE)) {

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -56,6 +56,7 @@ interface PiExtensionInternals {
     agent: string,
     key: string | null,
   ) => string;
+  workflowBreadcrumbForTest: (root: string, key: string | null) => string;
 }
 
 function loadExtensionInternals(cwd = process.cwd()): PiExtensionInternals {
@@ -73,6 +74,7 @@ export {
   truncateUtf8,
   readContextInjectionLimits,
   buildContext as buildContextForTest,
+  workflowBreadcrumb as workflowBreadcrumbForTest,
 };
 `;
   const compiled = ts.transpileModule(source, {
@@ -329,6 +331,93 @@ describe("pi templates", () => {
     // turn one is already in the session history.
     expect(second.message).toBeUndefined();
     expect(handlers.has("context")).toBe(true);
+  });
+
+  it("resolves Pi workflow breadcrumbs by task, personal, team, then global", () => {
+    const root = createMinimalTrellisRoot();
+    const { workflowBreadcrumbForTest } = loadExtensionInternals(root);
+    const workflowsDir = join(root, ".trellis", "workflows");
+    mkdirSync(workflowsDir, { recursive: true });
+    const writeWorkflow = (id: string, marker: string) =>
+      writeFileSync(
+        join(workflowsDir, `${id}.md`),
+        [
+          "[workflow-state:no_task]",
+          marker,
+          "[/workflow-state:no_task]",
+          "[workflow-state:in_progress]",
+          marker,
+          "[/workflow-state:in_progress]",
+          "",
+        ].join("\n"),
+      );
+    writeWorkflow("team", "TEAM WORKFLOW");
+    writeWorkflow("personal", "PERSONAL WORKFLOW");
+    writeWorkflow("task", "TASK WORKFLOW");
+
+    expect(workflowBreadcrumbForTest(root, null)).toContain(
+      "No active task. First classify",
+    );
+
+    writeFileSync(
+      join(root, ".trellis", "config.yaml"),
+      'default_workflow: "team" # team default\n',
+    );
+    expect(workflowBreadcrumbForTest(root, null)).toContain("TEAM WORKFLOW");
+
+    writeFileSync(join(root, ".trellis", ".developer"), "workflow=personal\n");
+    expect(workflowBreadcrumbForTest(root, null)).toContain(
+      "PERSONAL WORKFLOW",
+    );
+
+    const taskDir = join(root, ".trellis", "tasks", "07-28-pi-workflow");
+    mkdirSync(taskDir, { recursive: true });
+    writeFileSync(
+      join(taskDir, "task.json"),
+      JSON.stringify({
+        id: "07-28-pi-workflow",
+        status: "in_progress",
+        workflow: "task",
+      }),
+    );
+    mkdirSync(join(root, ".trellis", ".runtime", "sessions"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, ".trellis", ".runtime", "sessions", "pi-test.json"),
+      JSON.stringify({ current_task: "tasks/07-28-pi-workflow" }),
+    );
+    expect(workflowBreadcrumbForTest(root, "pi-test")).toContain(
+      "TASK WORKFLOW",
+    );
+
+    writeFileSync(
+      join(taskDir, "task.json"),
+      JSON.stringify({
+        id: "07-28-pi-workflow",
+        status: "in_progress",
+        workflow: "../../outside",
+      }),
+    );
+    const warning = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    expect(workflowBreadcrumbForTest(root, "pi-test")).toContain(
+      "PERSONAL WORKFLOW",
+    );
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+
+    writeFileSync(join(root, ".trellis", ".developer"), "workflow=missing\n");
+    expect(workflowBreadcrumbForTest(root, null)).toContain("TEAM WORKFLOW");
+
+    writeFileSync(
+      join(root, ".trellis", "config.yaml"),
+      "# default_workflow: team\n",
+    );
+    expect(workflowBreadcrumbForTest(root, null)).toContain(
+      "No active task. First classify",
+    );
   });
 
   it("delivers task context changes as persisted messages, not systemPrompt churn", () => {


### PR DESCRIPTION
## Summary

- resolve Pi workflow breadcrumbs with the shared task → personal → team → global precedence
- reject invalid or missing workflow variants and fall through safely
- document Pi parity and remove Pi from the beta limitation list

## Verification

- `env -u TRELLIS_DISABLE_HOOKS pnpm test` (core: 333 passed, 1 skipped; CLI: 1706 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm pack --dry-run`
- built CLI installed into a temporary project with `--pi`
- real Pi Agent 0.80.6 runs returned the expected team, personal, and task workflow markers

Docs: https://github.com/mindfold-ai/docs/pull/27