### PR TITLE
fix(pi): inherit the invoking session model in subagents

### DIFF
--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -20,6 +20,10 @@ interface PiToolResult {
 }
 interface PiExtensionContext {
   hasUI?: boolean;
+  model?: {
+    provider?: string;
+    id?: string;
+  };
   sessionManager?: {
     getSessionId?: () => string;
     getSessionFile?: () => string | undefined;
@@ -654,6 +658,7 @@ function resolveRunCfg(
   input: SubagentInput,
   agentCfg: AgentConfig,
   inheritedThinking?: string,
+  inheritedModel?: string,
 ): PiRunConfig {
   const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
   const normalize = (v: unknown): string | undefined => {
@@ -663,7 +668,7 @@ function resolveRunCfg(
   const suffixRe = /:(off|minimal|low|medium|high|xhigh)$/i;
   const inputModel = str(input.model);
   const agentModel = agentCfg.model;
-  const rawModel = inputModel ?? agentModel;
+  const rawModel = inputModel ?? agentModel ?? str(inheritedModel);
   const inputSuffixThinking = normalize(inputModel?.match(suffixRe)?.[1]);
   const agentSuffixThinking = normalize(agentModel?.match(suffixRe)?.[1]);
   const baseModel = rawModel?.replace(suffixRe, "");
@@ -676,6 +681,12 @@ function resolveRunCfg(
   if (baseModel && thinking && thinking !== "off")
     return { model: `${baseModel}:${thinking}`, thinking, tools: agentCfg.tools };
   return { model: baseModel || rawModel, thinking, tools: agentCfg.tools };
+}
+
+function contextModelRef(ctx?: PiExtensionContext): string | undefined {
+  const provider = str(ctx?.model?.provider);
+  const modelId = str(ctx?.model?.id);
+  return provider && modelId ? `${provider}/${modelId}` : undefined;
 }
 
 function buildPiArgs(cfg: PiRunConfig): string[] {
@@ -1502,11 +1513,17 @@ async function runSubagent(
   signal?: AbortSignal,
   onUpdate?: (r: PiToolResult) => void,
   inheritedThinking?: string,
+  inheritedModel?: string,
 ): Promise<{ output: string; details: ProgressDetails; failed: boolean }> {
   const agentName = normalizeAgent(input.agent);
   const agentRaw = readText(join(root, ".pi", "agents", `${agentName}.md`));
   const agentCfg = parseAgentFM(agentRaw);
-  const runCfg = resolveRunCfg(input, agentCfg, inheritedThinking);
+  const runCfg = resolveRunCfg(
+    input,
+    agentCfg,
+    inheritedThinking,
+    inheritedModel,
+  );
   const mode = input.mode ?? "single";
   const startedAt = Date.now();
   const details: ProgressDetails = {
@@ -1811,6 +1828,7 @@ export default function trellisExtension(pi: {
       };
       const key = getKey(cleanInput, ctx);
       const inheritedThinking = pi.getThinkingLevel?.();
+      const inheritedModel = contextModelRef(ctx);
       const result = await runSubagent(
         root,
         cleanInput,
@@ -1818,6 +1836,7 @@ export default function trellisExtension(pi: {
         signal,
         onUpdate,
         inheritedThinking,
+        inheritedModel,
       );
       return {
         content: [{ type: "text", text: result.output }],

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createRequire } from "node:module";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,6 +32,16 @@ interface ContextInjectionLimits {
   max_total_bytes: number;
 }
 
+interface RegisteredPiTool {
+  execute: (
+    id: string,
+    input: { agent?: string; prompt?: string },
+    signal?: AbortSignal,
+    onUpdate?: (result: unknown) => void,
+    ctx?: { model?: { provider?: string; id?: string } },
+  ) => Promise<{ content: { type: "text"; text: string }[] }>;
+}
+
 interface PiExtensionInternals {
   normalizeAgent: (agent: string | undefined) => string;
   isTrellisAgent: (root: string, agent: string) => boolean;
@@ -41,13 +51,21 @@ interface PiExtensionInternals {
     input: { model?: string; thinking?: string },
     agentCfg: AgentConfig,
     inheritedThinking?: string,
+    inheritedModel?: string,
   ) => PiRunConfig;
+  contextModelRef: (ctx?: {
+    model?: { provider?: string; id?: string };
+  }) => string | undefined;
   cmdHasTrellisCtx: (cmd: string) => boolean;
   shellQuote: (v: string) => string;
   trellisExtension: (pi: {
     registerTool?: (tool: unknown) => void;
     registerShortcut?: (key: string, opts: unknown) => void;
-    on?: (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
+    getThinkingLevel?: () => string;
+    on?: (
+      event: string,
+      handler: (event: unknown, ctx?: unknown) => unknown,
+    ) => void;
   }) => void;
   truncateUtf8: (buf: Buffer, cap: number) => Buffer;
   readContextInjectionLimits: (repoRoot: string) => ContextInjectionLimits;
@@ -58,7 +76,10 @@ interface PiExtensionInternals {
   ) => string;
 }
 
-function loadExtensionInternals(cwd = process.cwd()): PiExtensionInternals {
+function loadExtensionInternals(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = {},
+): PiExtensionInternals {
   const source = `${getExtensionTemplate()}
 
 export {
@@ -67,6 +88,7 @@ export {
   parseAgentFM,
   buildPiArgs,
   resolveRunCfg,
+  contextModelRef,
   cmdHasTrellisCtx,
   shellQuote,
   trellisExtension,
@@ -85,7 +107,7 @@ export {
   const require = createRequire(import.meta.url);
   const moduleObject: { exports: Record<string, unknown> } = { exports: {} };
   const sandboxProcess = Object.create(process) as NodeJS.Process;
-  const sandboxEnv = { ...process.env };
+  const sandboxEnv = { ...process.env, ...env };
   delete sandboxEnv.TRELLIS_SUBAGENT_CHILD;
   Object.defineProperty(sandboxProcess, "cwd", { value: () => cwd });
   Object.defineProperty(sandboxProcess, "env", { value: sandboxEnv });
@@ -530,8 +552,9 @@ fallbackModels:
     ]);
   });
 
-  it("resolveRunCfg lets per-call input override agent frontmatter defaults", () => {
-    const { resolveRunCfg } = loadExtensionInternals();
+  it("inherits the invoking Pi model after per-call and agent defaults", () => {
+    const { buildPiArgs, contextModelRef, resolveRunCfg } =
+      loadExtensionInternals();
 
     const agentCfg: AgentConfig = {
       model: "anthropic/claude-sonnet-4",
@@ -545,24 +568,107 @@ fallbackModels:
       resolveRunCfg(
         { model: "openai/gpt-5", thinking: "xhigh" },
         agentCfg,
+        "medium",
+        "google/gemini-2.5-pro",
       ),
-    ).toEqual({ model: "openai/gpt-5:xhigh", thinking: "xhigh", tools: agentCfg.tools });
+    ).toEqual({
+      model: "openai/gpt-5:xhigh",
+      thinking: "xhigh",
+      tools: agentCfg.tools,
+    });
 
-    // No overrides → fall back to agent config
-    expect(resolveRunCfg({}, agentCfg)).toEqual({
+    // Agent config wins over the invoking session model.
+    expect(
+      resolveRunCfg({}, agentCfg, "medium", "google/gemini-2.5-pro"),
+    ).toEqual({
       model: "anthropic/claude-sonnet-4:high",
       thinking: "high",
       tools: agentCfg.tools,
     });
 
-    // Inherited thinking is the last fallback
-    expect(
-      resolveRunCfg(
-        {},
-        { model: "gpt-5", fallbackModels: [] },
-        "medium",
-      ),
-    ).toEqual({ model: "gpt-5:medium", thinking: "medium" });
+    // With no stronger model, use the provider-qualified invoking session model.
+    const inheritedModel = contextModelRef({
+      model: { provider: "openai-proxy", id: "gpt-5.6-sol" },
+    });
+    const inheritedCfg = resolveRunCfg(
+      {},
+      { fallbackModels: [] },
+      "xhigh",
+      inheritedModel,
+    );
+    expect(inheritedCfg).toEqual({
+      model: "openai-proxy/gpt-5.6-sol:xhigh",
+      thinking: "xhigh",
+    });
+    expect(buildPiArgs(inheritedCfg)).toEqual([
+      "--mode",
+      "json",
+      "-p",
+      "--no-session",
+      "--model",
+      "openai-proxy/gpt-5.6-sol:xhigh",
+    ]);
+
+    // Incomplete context preserves the previous no-model behavior.
+    expect(contextModelRef()).toBeUndefined();
+    expect(contextModelRef({ model: { id: "gpt-5.6-sol" } })).toBeUndefined();
+  });
+
+  it("passes the invoking Pi model to the spawned child process", async () => {
+    const root = createMinimalTrellisRoot();
+    const agentDir = join(root, ".pi", "agents");
+    const fakeCli = join(root, "fake-pi.cjs");
+    const capturedArgs = join(root, "child-args.json");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "trellis-implement.md"),
+      "---\nname: trellis-implement\n---\nImplement the task.\n",
+    );
+    writeFileSync(
+      fakeCli,
+      [
+        'const { writeFileSync } = require("node:fs");',
+        `writeFileSync(${JSON.stringify(capturedArgs)}, JSON.stringify(process.argv.slice(2)));`,
+        'process.stdout.write(JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "fake child ok" }] } }) + "\\n");',
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const { trellisExtension } = loadExtensionInternals(root, {
+        TRELLIS_PI_CLI_JS: fakeCli,
+      });
+      let registeredTool: RegisteredPiTool | undefined;
+      trellisExtension({
+        registerTool(tool) {
+          registeredTool = tool as RegisteredPiTool;
+        },
+        getThinkingLevel: () => "xhigh",
+      });
+      expect(registeredTool).toBeDefined();
+      if (!registeredTool)
+        throw new Error("trellis_subagent was not registered");
+
+      const result = await registeredTool.execute(
+        "model-inheritance-test",
+        { agent: "trellis-implement", prompt: "Implement the task" },
+        undefined,
+        undefined,
+        { model: { provider: "openai-proxy", id: "gpt-5.6-sol" } },
+      );
+
+      expect(result.content[0]?.text).toBe("fake child ok");
+      expect(JSON.parse(readFileSync(capturedArgs, "utf-8"))).toEqual([
+        "--mode",
+        "json",
+        "-p",
+        "--no-session",
+        "--model",
+        "openai-proxy/gpt-5.6-sol:xhigh",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("cmdHasTrellisCtx detects already-prefixed bash commands", () => {


### PR DESCRIPTION
## Summary

- derive a provider-qualified model reference from the invoking Pi tool context
- use the invoking session model as the fallback for child Pi processes
- preserve existing per-call and agent-frontmatter model overrides
- add resolver-level and subprocess regression coverage

## Problem

Pi persists model changes to shared user settings, while an already-running Pi window retains its active model in session state.

The Trellis Pi extension starts each subagent as a separate Pi process. When neither the tool call nor agent frontmatter specifies a model, Trellis does not pass `--model` to that process. The child therefore reads the latest shared default instead of inheriting the model of the Pi session that dispatched it.

This allows model selection to leak across concurrently running Pi windows:

1. Window A is running `openai-proxy/gpt-5.6-sol`.
2. Window B changes its model to `anthropic-proxy/claude-opus-5`.
3. Window A dispatches a Trellis subagent.
4. The child unexpectedly uses Claude because Window B most recently updated the shared default.

## Fix

Read the active model from the Pi tool execution context and pass its provider-qualified reference into the existing child-process configuration resolver.

The resulting model precedence is:

1. model specified in the `trellis_subagent` call
2. model specified in `.pi/agents/trellis-*.md` frontmatter
3. model of the Pi session invoking the tool

The existing thinking-level precedence remains unchanged. If the context does not provide both a provider and model ID, Trellis preserves the previous no-model behavior.

## Relationship to #442 and #459

This is related to, but not a duplicate of, #442 or #459.

Those issues concern Codex native subagents and the ability to pin different models through `.codex/agents/trellis-*.toml`. This PR only changes the Pi integration. Pi already supports explicit overrides through tool arguments and agent Markdown frontmatter; this bug affects the default behavior when no override is configured.

## Reproduction

The issue was reproduced through the actual extension registration, tool execution, and child-process spawn path using official npm artifacts. The invoking session was `openai-proxy/gpt-5.6-sol:xhigh`, the shared default was `anthropic-proxy/claude-opus-5`, and no explicit child model was configured.

| Build | Child model argument | Effective child model |
| --- | --- | --- |
| npm latest `0.6.10` | none | `anthropic-proxy/claude-opus-5` |
| npm beta `0.7.0-beta.1` | none | `anthropic-proxy/claude-opus-5` |
| patched branch | `--model openai-proxy/gpt-5.6-sol:xhigh` | `openai-proxy/gpt-5.6-sol` |

No paid model request was made during this reproduction. The extension and subprocess path used a recording child CLI, and model-selection precedence was verified against Pi `0.83.0` source.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @mindfoldhq/trellis test test/templates/pi.test.ts`
- `LC_ALL=C.UTF-8 LANG=C.UTF-8 pnpm test`
- `git diff --check`
- `gitnexus detect-changes --scope compare --base-ref main`
  - risk: low
  - affected processes: 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subagents now inherit the invoking Pi model when no specific model is provided.
  * Model overrides continue to take precedence at the per-call and agent configuration levels.
  * Incomplete model information is handled safely.

* **Bug Fixes**
  * Ensured the selected invoking model is passed correctly to spawned child processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->