### PR TITLE
fix(channel): surface Codex turn failures

### DIFF
--- a/packages/cli/src/commands/channel/adapters/codex.ts
+++ b/packages/cli/src/commands/channel/adapters/codex.ts
@@ -56,6 +56,8 @@ export interface CodexCtx {
   finalMessageSeen: boolean;
   /** Codex may send turn/completed before the final agentMessage item. */
   pendingDone: boolean;
+  /** Prevent duplicate terminal errors when Codex reports one failure twice. */
+  terminalErrorSeen: boolean;
   /** Last-known thread id (used to scope future requests). */
   threadId?: string;
   /** Monotonic outbound id allocator. */
@@ -68,6 +70,7 @@ export function createCodexCtx(): CodexCtx {
     items: new Map(),
     finalMessageSeen: false,
     pendingDone: false,
+    terminalErrorSeen: false,
     nextId: 1,
   };
 }
@@ -241,13 +244,49 @@ function handleNotification(msg: JsonRpcInbound, ctx: CodexCtx): ParseResult {
       return handleItemCompleted(msg, ctx);
     case "item/agentMessage/delta":
       return handleAgentMessageDelta(msg, ctx);
-    case "turn/completed":
+    case "turn/completed": {
+      const turn = isObject(msg.params?.turn) ? msg.params.turn : undefined;
+      if (turn?.status === "failed") {
+        ctx.pendingDone = false;
+        if (ctx.terminalErrorSeen) return { events: [] };
+        ctx.terminalErrorSeen = true;
+        return {
+          events: [
+            {
+              kind: "error",
+              payload: {
+                message: errorMessage(turn.error, "Codex turn failed"),
+              },
+            },
+          ],
+        };
+      }
+      if (ctx.terminalErrorSeen) return { events: [] };
       if (ctx.finalMessageSeen) {
         ctx.pendingDone = false;
         return { events: [{ kind: "done", payload: {} }] };
       }
       ctx.pendingDone = true;
       return { events: [] };
+    }
+    case "error": {
+      const params = msg.params ?? {};
+      const message = errorMessage(params.error, "Codex app-server error");
+      if (params.willRetry === true) {
+        return {
+          events: [
+            {
+              kind: "progress",
+              payload: { detail: { kind: "warning", message } },
+            },
+          ],
+        };
+      }
+      if (ctx.terminalErrorSeen) return { events: [] };
+      ctx.terminalErrorSeen = true;
+      ctx.pendingDone = false;
+      return { events: [{ kind: "error", payload: { message } }] };
+    }
     case "turn/aborted":
       return {
         events: [{ kind: "error", payload: { message: "turn aborted" } }],
@@ -555,6 +594,18 @@ function isObject(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null && !Array.isArray(x);
 }
 
+function errorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "string" && error.trim()) return error;
+  if (
+    isObject(error) &&
+    typeof error.message === "string" &&
+    error.message.trim()
+  ) {
+    return error.message;
+  }
+  return fallback;
+}
+
 // ── Outbound helpers ──
 
 export function encodeCodexRequest(
@@ -580,6 +631,7 @@ export function encodeCodexUserMessage(
   }
   ctx.finalMessageSeen = false;
   ctx.pendingDone = false;
+  ctx.terminalErrorSeen = false;
   return encodeCodexRequest(
     ctx,
     "turn/start",

--- a/packages/cli/test/commands/channel-codex-adapter.test.ts
+++ b/packages/cli/test/commands/channel-codex-adapter.test.ts
@@ -195,6 +195,59 @@ describe("Codex channel adapter", () => {
     expect(completed.events).toEqual([{ kind: "done", payload: {} }]);
   });
 
+  it("emits an error when a turn fails without a final answer", () => {
+    const result = parse({
+      method: "turn/completed",
+      params: {
+        turn: {
+          status: "failed",
+          error: { message: "Model is not available" },
+        },
+      },
+    });
+
+    expect(result.events).toEqual([
+      {
+        kind: "error",
+        payload: { message: "Model is not available" },
+      },
+    ]);
+  });
+
+  it("does not emit duplicate errors for the same failed turn", () => {
+    const ctx = createCodexCtx();
+    const notification = parse(
+      {
+        method: "error",
+        params: {
+          error: { message: "Request failed with status 400" },
+          willRetry: false,
+        },
+      },
+      ctx,
+    );
+    const completed = parse(
+      {
+        method: "turn/completed",
+        params: {
+          turn: {
+            status: "failed",
+            error: { message: "Request failed with status 400" },
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(notification.events).toEqual([
+      {
+        kind: "error",
+        payload: { message: "Request failed with status 400" },
+      },
+    ]);
+    expect(completed.events).toEqual([]);
+  });
+
   describe("sandbox override (#413)", () => {
     it("defaults to workspace-write when no sandbox is given", () => {
       const params = buildCodexThreadStartParams("/tmp/proj");

--- a/packages/cli/test/commands/channel-codex-adapter.test.ts
+++ b/packages/cli/test/commands/channel-codex-adapter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCodexThreadStartParams,
   createCodexCtx,
+  encodeCodexUserMessage,
   parseCodexLine,
   parseCodexSandboxMode,
 } from "../../src/commands/channel/adapters/codex.js";
@@ -246,6 +247,33 @@ describe("Codex channel adapter", () => {
       },
     ]);
     expect(completed.events).toEqual([]);
+  });
+
+  it("deduplicates failures in reverse order and resets for the next turn", () => {
+    const ctx = createCodexCtx();
+    const completed = {
+      method: "turn/completed",
+      params: {
+        turn: {
+          status: "failed",
+          error: { message: "Request failed with status 400" },
+        },
+      },
+    };
+    const notification = {
+      method: "error",
+      params: {
+        error: { message: "Request failed with status 400" },
+        willRetry: false,
+      },
+    };
+
+    expect(parse(completed, ctx).events).toHaveLength(1);
+    expect(parse(notification, ctx).events).toEqual([]);
+
+    ctx.threadId = "thread-1";
+    encodeCodexUserMessage(ctx, "try again");
+    expect(parse(notification, ctx).events).toHaveLength(1);
   });
 
   describe("sandbox override (#413)", () => {


### PR DESCRIPTION
## Summary

- emit a channel error when Codex reports a failed turn without a final answer
- surface non-retryable app-server error notifications
- deduplicate paired error and turn-completed failure notifications

## Verification

- core build
- CLI build, typecheck, and lint
- full CLI test suite: 1593 tests

Closes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed Codex turns by normalizing and displaying clear, user-facing error messages.
  * Prevented duplicate error notifications for the same failed turn, including support for out-of-order lifecycle events.
  * Added retry warnings when Codex reports an error that may be retried.
  * Ensured correct completion reporting when a final message has already been received.
* **Tests**
  * Added Vitest coverage for failed-turn error behavior, de-duplication, and per-turn state reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->