### PR TITLE
fix(channel): enforce idle timeout after completed turns

### DIFF
--- a/packages/cli/src/commands/channel/supervisor/idle.ts
+++ b/packages/cli/src/commands/channel/supervisor/idle.ts
@@ -21,7 +21,6 @@ import type { ShutdownController } from "./shutdown.js";
 
 export interface SupervisorIdleProbe {
   isShuttingDown(): boolean;
-  hasTerminalEvent(): boolean;
 }
 
 export interface IdleTimerHandle {
@@ -70,11 +69,7 @@ export function scheduleSupervisorIdleTimer(
   const fire = (): void => {
     timer = undefined;
     if (cancelled) return;
-    if (
-      shutdown.isShuttingDown() ||
-      shutdown.hasTerminalEvent() ||
-      isChildExited()
-    ) {
+    if (shutdown.isShuttingDown() || isChildExited()) {
       return;
     }
     log.write(

--- a/packages/cli/test/commands/channel-supervisor-idle.test.ts
+++ b/packages/cli/test/commands/channel-supervisor-idle.test.ts
@@ -130,6 +130,23 @@ describe("scheduleSupervisorIdleTimer", () => {
     vi.advanceTimersByTime(5000);
     expect(shutdown.request).not.toHaveBeenCalled();
   });
+
+  it("still fires after a completed turn emits a terminal event", () => {
+    const shutdown = fakeShutdown();
+    shutdown.hasTerminalEvent.mockReturnValue(true);
+    scheduleSupervisorIdleTimer({
+      idleTimeoutMs: 1000,
+      shutdown,
+      isChildExited: () => false,
+      log: silentLog,
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(shutdown.request).toHaveBeenCalledWith(
+      "SIGTERM",
+      "idle-timeout",
+    );
+  });
 });
 
 describe("TurnTracker hooks", () => {


### PR DESCRIPTION
## Summary

- allow the supervisor idle timer to fire after a turn emits done or error
- keep the existing shutdown-in-progress and child-exited guards
- add regression coverage for a completed turn remaining idle

## Verification

- core and CLI builds
- CLI typecheck and lint
- full test suite: core 333 passed, CLI 1595 passed

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved idle-timeout handling so shutdown requests still occur when a completed turn emits a terminal event.
  - Prevented idle timers from being skipped unless shutdown is already in progress or the child process has exited.
- **Tests**
  - Added coverage confirming idle-timeout shutdown behavior in terminal-event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->