### PR TITLE
fix(scripts): bound polyrepo Git context scan

### DIFF
--- a/.trellis/scripts/common/git.py
+++ b/.trellis/scripts/common/git.py
@@ -10,11 +10,17 @@ import subprocess
 from pathlib import Path
 
 
-def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
+def run_git(
+    args: list[str],
+    cwd: Path | None = None,
+    timeout: float | None = None,
+) -> tuple[int, str, str]:
     """Run a git command and return (returncode, stdout, stderr).
 
     Uses UTF-8 encoding with -c i18n.logOutputEncoding=UTF-8 to ensure
-    consistent output across all platforms (Windows, macOS, Linux).
+    consistent output across all platforms (Windows, macOS, Linux). Callers
+    may provide a timeout for best-effort probes; normal Git operations remain
+    unbounded by default.
     """
     try:
         git_args = ["git", "-c", "i18n.logOutputEncoding=UTF-8"] + args
@@ -25,6 +31,7 @@ def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
             text=True,
             encoding="utf-8",
             errors="replace",
+            timeout=timeout,
         )
         return result.returncode, result.stdout, result.stderr
     except Exception as e:

--- a/.trellis/scripts/common/session_context.py
+++ b/.trellis/scripts/common/session_context.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from .active_task import resolve_context_key
@@ -64,11 +65,17 @@ _POLYREPO_IGNORED_DIRS = {
     "__pycache__",
 }
 _POLYREPO_SCAN_MAX_DEPTH = 2
+_POLYREPO_SCAN_MAX_REPOS = 8
+_GIT_PROBE_TIMEOUT_SECONDS = 2.0
 
 
 def _is_git_worktree(path: Path) -> bool:
     """Return True when path is inside a Git worktree."""
-    rc, out, _ = run_git(["rev-parse", "--is-inside-work-tree"], cwd=path)
+    rc, out, _ = run_git(
+        ["rev-parse", "--is-inside-work-tree"],
+        cwd=path,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     return rc == 0 and out.strip().lower() == "true"
 
 
@@ -91,13 +98,27 @@ def _collect_git_repo_info(name: str, rel_path: str, repo_dir: Path) -> dict | N
     if not (repo_dir / ".git").exists():
         return None
 
-    _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_dir)
-    branch = branch_out.strip() or "unknown"
-
-    _, status_out, _ = run_git(["status", "--porcelain"], cwd=repo_dir)
+    status_rc, status_out, _ = run_git(
+        ["status", "--porcelain"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
+    if status_rc != 0:
+        return None
     changes = len([l for l in status_out.splitlines() if l.strip()])
 
-    _, log_out, _ = run_git(["log", "--oneline", "-5"], cwd=repo_dir)
+    _, branch_out, _ = run_git(
+        ["branch", "--show-current"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
+    branch = branch_out.strip() or "unknown"
+
+    _, log_out, _ = run_git(
+        ["log", "--oneline", "-5"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
     return {
         "name": name,
@@ -143,12 +164,16 @@ def _collect_root_git_info(repo_root: Path) -> dict:
 def _discover_child_git_repos(repo_root: Path) -> list[tuple[str, str]]:
     """Discover child Git repositories using the init-time polyrepo heuristic."""
     found: list[str] = []
+    overflow = False
 
     def is_candidate_dir(path: Path) -> bool:
         name = path.name
         return not name.startswith(".") and name not in _POLYREPO_IGNORED_DIRS
 
     def scan(rel_dir: Path, depth: int) -> None:
+        nonlocal overflow
+        if overflow:
+            return
         if depth >= _POLYREPO_SCAN_MAX_DEPTH:
             return
         abs_dir = repo_root / rel_dir
@@ -165,11 +190,23 @@ def _discover_child_git_repos(repo_root: Path) -> list[tuple[str, str]]:
                 rel_dir / child.name if rel_dir != Path(".") else Path(child.name)
             )
             if (child / ".git").exists():
+                if len(found) >= _POLYREPO_SCAN_MAX_REPOS:
+                    overflow = True
+                    return
                 found.append(child_rel.as_posix())
                 continue
             scan(child_rel, depth + 1)
 
     scan(Path("."), 0)
+    if overflow:
+        print(
+            "warning: found more than "
+            f"{_POLYREPO_SCAN_MAX_REPOS} child Git repositories; "
+            "skipping automatic Git status collection. Configure explicit "
+            "packages entries with path and git: true in .trellis/config.yaml.",
+            file=sys.stderr,
+        )
+        return []
     if len(found) < 2:
         return []
     return [(path.replace("/", "_"), path) for path in sorted(found)]

--- a/.trellis/scripts/common/session_context.py
+++ b/.trellis/scripts/common/session_context.py
@@ -105,7 +105,7 @@ def _collect_git_repo_info(name: str, rel_path: str, repo_dir: Path) -> dict | N
     )
     if status_rc != 0:
         return None
-    changes = len([l for l in status_out.splitlines() if l.strip()])
+    changes = len([line for line in status_out.splitlines() if line.strip()])
 
     _, branch_out, _ = run_git(
         ["branch", "--show-current"],
@@ -141,15 +141,31 @@ def _collect_root_git_info(repo_root: Path) -> dict:
             "recentCommits": [],
         }
 
-    _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+    _, branch_out, _ = run_git(
+        ["branch", "--show-current"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     branch = branch_out.strip() or "unknown"
 
-    _, status_out, _ = run_git(["status", "--porcelain"], cwd=repo_root)
+    _, status_out, _ = run_git(
+        ["status", "--porcelain"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     status_lines = [line for line in status_out.splitlines() if line.strip()]
 
-    _, short_out, _ = run_git(["status", "--short"], cwd=repo_root)
+    _, short_out, _ = run_git(
+        ["status", "--short"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
-    _, log_out, _ = run_git(["log", "--oneline", "-5"], cwd=repo_root)
+    _, log_out, _ = run_git(
+        ["log", "--oneline", "-5"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
     return {
         "isRepo": True,

--- a/.trellis/scripts/common/session_context.py
+++ b/.trellis/scripts/common/session_context.py
@@ -148,7 +148,7 @@ def _collect_root_git_info(repo_root: Path) -> dict:
     )
     branch = branch_out.strip() or "unknown"
 
-    _, status_out, _ = run_git(
+    status_rc, status_out, _ = run_git(
         ["status", "--porcelain"],
         cwd=repo_root,
         timeout=_GIT_PROBE_TIMEOUT_SECONDS,
@@ -170,7 +170,7 @@ def _collect_root_git_info(repo_root: Path) -> dict:
     return {
         "isRepo": True,
         "branch": branch,
-        "isClean": len(status_lines) == 0,
+        "isClean": status_rc == 0 and len(status_lines) == 0,
         "uncommittedChanges": len(status_lines),
         "statusShort": short_out.splitlines(),
         "recentCommits": _parse_recent_commits(log_out),

--- a/packages/cli/src/templates/trellis/scripts/common/git.py
+++ b/packages/cli/src/templates/trellis/scripts/common/git.py
@@ -10,11 +10,17 @@ import subprocess
 from pathlib import Path
 
 
-def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
+def run_git(
+    args: list[str],
+    cwd: Path | None = None,
+    timeout: float | None = None,
+) -> tuple[int, str, str]:
     """Run a git command and return (returncode, stdout, stderr).
 
     Uses UTF-8 encoding with -c i18n.logOutputEncoding=UTF-8 to ensure
-    consistent output across all platforms (Windows, macOS, Linux).
+    consistent output across all platforms (Windows, macOS, Linux). Callers
+    may provide a timeout for best-effort probes; normal Git operations remain
+    unbounded by default.
     """
     try:
         git_args = ["git", "-c", "i18n.logOutputEncoding=UTF-8"] + args
@@ -25,6 +31,7 @@ def run_git(args: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
             text=True,
             encoding="utf-8",
             errors="replace",
+            timeout=timeout,
         )
         return result.returncode, result.stdout, result.stderr
     except Exception as e:

--- a/packages/cli/src/templates/trellis/scripts/common/session_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/session_context.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from .active_task import resolve_context_key
@@ -64,11 +65,17 @@ _POLYREPO_IGNORED_DIRS = {
     "__pycache__",
 }
 _POLYREPO_SCAN_MAX_DEPTH = 2
+_POLYREPO_SCAN_MAX_REPOS = 8
+_GIT_PROBE_TIMEOUT_SECONDS = 2.0
 
 
 def _is_git_worktree(path: Path) -> bool:
     """Return True when path is inside a Git worktree."""
-    rc, out, _ = run_git(["rev-parse", "--is-inside-work-tree"], cwd=path)
+    rc, out, _ = run_git(
+        ["rev-parse", "--is-inside-work-tree"],
+        cwd=path,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     return rc == 0 and out.strip().lower() == "true"
 
 
@@ -91,13 +98,27 @@ def _collect_git_repo_info(name: str, rel_path: str, repo_dir: Path) -> dict | N
     if not (repo_dir / ".git").exists():
         return None
 
-    _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_dir)
-    branch = branch_out.strip() or "unknown"
-
-    _, status_out, _ = run_git(["status", "--porcelain"], cwd=repo_dir)
+    status_rc, status_out, _ = run_git(
+        ["status", "--porcelain"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
+    if status_rc != 0:
+        return None
     changes = len([l for l in status_out.splitlines() if l.strip()])
 
-    _, log_out, _ = run_git(["log", "--oneline", "-5"], cwd=repo_dir)
+    _, branch_out, _ = run_git(
+        ["branch", "--show-current"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
+    branch = branch_out.strip() or "unknown"
+
+    _, log_out, _ = run_git(
+        ["log", "--oneline", "-5"],
+        cwd=repo_dir,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
     return {
         "name": name,
@@ -143,12 +164,16 @@ def _collect_root_git_info(repo_root: Path) -> dict:
 def _discover_child_git_repos(repo_root: Path) -> list[tuple[str, str]]:
     """Discover child Git repositories using the init-time polyrepo heuristic."""
     found: list[str] = []
+    overflow = False
 
     def is_candidate_dir(path: Path) -> bool:
         name = path.name
         return not name.startswith(".") and name not in _POLYREPO_IGNORED_DIRS
 
     def scan(rel_dir: Path, depth: int) -> None:
+        nonlocal overflow
+        if overflow:
+            return
         if depth >= _POLYREPO_SCAN_MAX_DEPTH:
             return
         abs_dir = repo_root / rel_dir
@@ -165,11 +190,23 @@ def _discover_child_git_repos(repo_root: Path) -> list[tuple[str, str]]:
                 rel_dir / child.name if rel_dir != Path(".") else Path(child.name)
             )
             if (child / ".git").exists():
+                if len(found) >= _POLYREPO_SCAN_MAX_REPOS:
+                    overflow = True
+                    return
                 found.append(child_rel.as_posix())
                 continue
             scan(child_rel, depth + 1)
 
     scan(Path("."), 0)
+    if overflow:
+        print(
+            "warning: found more than "
+            f"{_POLYREPO_SCAN_MAX_REPOS} child Git repositories; "
+            "skipping automatic Git status collection. Configure explicit "
+            "packages entries with path and git: true in .trellis/config.yaml.",
+            file=sys.stderr,
+        )
+        return []
     if len(found) < 2:
         return []
     return [(path.replace("/", "_"), path) for path in sorted(found)]

--- a/packages/cli/src/templates/trellis/scripts/common/session_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/session_context.py
@@ -105,7 +105,7 @@ def _collect_git_repo_info(name: str, rel_path: str, repo_dir: Path) -> dict | N
     )
     if status_rc != 0:
         return None
-    changes = len([l for l in status_out.splitlines() if l.strip()])
+    changes = len([line for line in status_out.splitlines() if line.strip()])
 
     _, branch_out, _ = run_git(
         ["branch", "--show-current"],
@@ -141,15 +141,31 @@ def _collect_root_git_info(repo_root: Path) -> dict:
             "recentCommits": [],
         }
 
-    _, branch_out, _ = run_git(["branch", "--show-current"], cwd=repo_root)
+    _, branch_out, _ = run_git(
+        ["branch", "--show-current"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     branch = branch_out.strip() or "unknown"
 
-    _, status_out, _ = run_git(["status", "--porcelain"], cwd=repo_root)
+    _, status_out, _ = run_git(
+        ["status", "--porcelain"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
     status_lines = [line for line in status_out.splitlines() if line.strip()]
 
-    _, short_out, _ = run_git(["status", "--short"], cwd=repo_root)
+    _, short_out, _ = run_git(
+        ["status", "--short"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
-    _, log_out, _ = run_git(["log", "--oneline", "-5"], cwd=repo_root)
+    _, log_out, _ = run_git(
+        ["log", "--oneline", "-5"],
+        cwd=repo_root,
+        timeout=_GIT_PROBE_TIMEOUT_SECONDS,
+    )
 
     return {
         "isRepo": True,

--- a/packages/cli/src/templates/trellis/scripts/common/session_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/session_context.py
@@ -148,7 +148,7 @@ def _collect_root_git_info(repo_root: Path) -> dict:
     )
     branch = branch_out.strip() or "unknown"
 
-    _, status_out, _ = run_git(
+    status_rc, status_out, _ = run_git(
         ["status", "--porcelain"],
         cwd=repo_root,
         timeout=_GIT_PROBE_TIMEOUT_SECONDS,
@@ -170,7 +170,7 @@ def _collect_root_git_info(repo_root: Path) -> dict:
     return {
         "isRepo": True,
         "branch": branch,
-        "isClean": len(status_lines) == 0,
+        "isClean": status_rc == 0 and len(status_lines) == 0,
         "uncommittedChanges": len(status_lines),
         "statusShort": short_out.splitlines(),
         "recentCommits": _parse_recent_commits(log_out),

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -1527,7 +1527,14 @@ describe("regression: issue #252 polyrepo Git context", () => {
         "    raise subprocess.TimeoutExpired(args[0], kwargs.get('timeout'))",
         "subprocess.run = fake_run",
         "rc, out, err = run_git(['status'], timeout=0.25)",
-        "print(json.dumps({'rc': rc, 'out': out, 'err': err, **captured}))",
+        "from common import session_context",
+        "root_calls = []",
+        "def fake_git(args, cwd=None, timeout=None):",
+        "    root_calls.append({'args': args, 'timeout': timeout})",
+        "    return (0, 'true\\n' if args[0] == 'rev-parse' else '', '')",
+        "session_context.run_git = fake_git",
+        "session_context._collect_root_git_info(Path.cwd())",
+        "print(json.dumps({'rc': rc, 'out': out, 'err': err, 'rootCalls': root_calls, **captured}))",
         "",
       ].join("\n"),
       "utf-8",
@@ -1538,7 +1545,13 @@ describe("regression: issue #252 polyrepo Git context", () => {
         cwd: tmpDir,
         encoding: "utf-8",
       }),
-    ) as { rc: number; out: string; err: string; timeout: number };
+    ) as {
+      rc: number;
+      out: string;
+      err: string;
+      timeout: number;
+      rootCalls: { args: string[]; timeout: number }[];
+    };
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -1548,6 +1561,14 @@ describe("regression: issue #252 polyrepo Git context", () => {
       }),
     );
     expect(result.err).toContain("timed out");
+    expect(result.rootCalls.map((call) => call.args[0])).toEqual([
+      "rev-parse",
+      "branch",
+      "status",
+      "status",
+      "log",
+    ]);
+    expect(result.rootCalls.every((call) => call.timeout === 2)).toBe(true);
   });
 
   it("marks JSON root Git state as non-repo instead of clean", () => {

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -1531,10 +1531,12 @@ describe("regression: issue #252 polyrepo Git context", () => {
         "root_calls = []",
         "def fake_git(args, cwd=None, timeout=None):",
         "    root_calls.append({'args': args, 'timeout': timeout})",
+        "    if args == ['status', '--porcelain']:",
+        "        return (1, '', 'timed out')",
         "    return (0, 'true\\n' if args[0] == 'rev-parse' else '', '')",
         "session_context.run_git = fake_git",
-        "session_context._collect_root_git_info(Path.cwd())",
-        "print(json.dumps({'rc': rc, 'out': out, 'err': err, 'rootCalls': root_calls, **captured}))",
+        "root_info = session_context._collect_root_git_info(Path.cwd())",
+        "print(json.dumps({'rc': rc, 'out': out, 'err': err, 'rootCalls': root_calls, 'rootInfo': root_info, **captured}))",
         "",
       ].join("\n"),
       "utf-8",
@@ -1551,6 +1553,7 @@ describe("regression: issue #252 polyrepo Git context", () => {
       err: string;
       timeout: number;
       rootCalls: { args: string[]; timeout: number }[];
+      rootInfo: { isClean: boolean };
     };
 
     expect(result).toEqual(
@@ -1569,6 +1572,7 @@ describe("regression: issue #252 polyrepo Git context", () => {
       "log",
     ]);
     expect(result.rootCalls.every((call) => call.timeout === 2)).toBe(true);
+    expect(result.rootInfo.isClean).toBe(false);
   });
 
   it("marks JSON root Git state as non-repo instead of clean", () => {

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -1482,6 +1482,74 @@ describe("regression: issue #252 polyrepo Git context", () => {
     expect(output).toContain("init module b");
   });
 
+  it("skips automatic Git status when too many child repos are discovered", () => {
+    writeConfigYaml("# no packages configured\n");
+    for (let i = 0; i < 9; i++) {
+      fs.mkdirSync(path.join(tmpDir, `repo-${i}`, ".git"), {
+        recursive: true,
+      });
+    }
+
+    const output = runSessionContext("text");
+    const rerun = spawnSync(
+      pythonCmd,
+      [path.join(tmpDir, "run-context.py")],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      },
+    );
+
+    expect(output).not.toContain("## GIT STATUS (repo-");
+    expect(rerun.status).toBe(0);
+    expect(rerun.stderr).toContain(
+      "found more than 8 child Git repositories",
+    );
+    expect(rerun.stderr).toContain(
+      "Configure explicit packages entries with path and git: true",
+    );
+  });
+
+  it("passes probe timeouts through the shared Git runner", () => {
+    const runnerPath = path.join(tmpDir, "run-git-timeout.py");
+    fs.writeFileSync(
+      runnerPath,
+      [
+        "import json",
+        "import subprocess",
+        "import sys",
+        "from pathlib import Path",
+        "sys.path.insert(0, str(Path.cwd() / '.trellis' / 'scripts'))",
+        "from common.git import run_git",
+        "captured = {}",
+        "def fake_run(*args, **kwargs):",
+        "    captured['timeout'] = kwargs.get('timeout')",
+        "    raise subprocess.TimeoutExpired(args[0], kwargs.get('timeout'))",
+        "subprocess.run = fake_run",
+        "rc, out, err = run_git(['status'], timeout=0.25)",
+        "print(json.dumps({'rc': rc, 'out': out, 'err': err, **captured}))",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = JSON.parse(
+      execSync(`${pythonCmd} ${JSON.stringify(runnerPath)}`, {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }),
+    ) as { rc: number; out: string; err: string; timeout: number };
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        rc: 1,
+        out: "",
+        timeout: 0.25,
+      }),
+    );
+    expect(result.err).toContain("timed out");
+  });
+
   it("marks JSON root Git state as non-repo instead of clean", () => {
     writeConfigYaml(
       [


### PR DESCRIPTION
## Summary

- stop automatic polyrepo discovery after eight child repositories and direct large workspaces to explicit package configuration
- bound best-effort Git status probes to two seconds without changing normal Git command behavior
- add regressions for the repository cap and timeout forwarding

## Version and timing audit

Issue #491 was opened on 2026-07-29 after stable 0.6.10 was published and reproduces on 0.6.10. The same unbounded scan is present in 0.7.0-beta.1 and in main before this change.

## Verification

- `uv run --python 3.9 python -m py_compile ...`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm test` (333 core passed, 1 skipped; 1597 CLI passed)

Closes #491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Git probing from hanging by adding optional timeouts to the shared Git runner and enforcing bounded timeouts for branch/status/log and worktree checks.
  * Improved Git “clean” detection using `status --porcelain` results, and hardened polyrepo auto-discovery with a max-repo cap that emits a stderr warning and skips automatic Git status collection when exceeded.

* **Tests**
  * Extended regression coverage to verify timeout propagation through Git probes and the resulting root Git state, including timeout failure messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->