### PR TITLE
fix(hooks): decode stdin as UTF-8

### DIFF
--- a/.claude/hooks/inject-subagent-context.py
+++ b/.claude/hooks/inject-subagent-context.py
@@ -32,6 +32,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 # IMPORTANT: Force stdout to use UTF-8 on Windows
 # This fixes UnicodeEncodeError when outputting non-ASCII characters
 if sys.platform.startswith("win"):

--- a/.cursor/hooks/inject-shell-session-context.py
+++ b/.cursor/hooks/inject-shell-session-context.py
@@ -17,6 +17,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 
 DIR_WORKFLOW = ".trellis"
 DIR_RUNTIME = ".runtime"

--- a/.cursor/hooks/inject-subagent-context.py
+++ b/.cursor/hooks/inject-subagent-context.py
@@ -32,6 +32,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 # IMPORTANT: Force stdout to use UTF-8 on Windows
 # This fixes UnicodeEncodeError when outputting non-ASCII characters
 if sys.platform.startswith("win"):

--- a/packages/cli/src/templates/claude/hooks/statusline.py
+++ b/packages/cli/src/templates/claude/hooks/statusline.py
@@ -22,6 +22,14 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 # Fix: Windows Python defaults to GBK encoding, which corrupts UTF-8
 # characters like the middle dot (·). Wrap stdout/stderr with UTF-8.
 if sys.platform == "win32":

--- a/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
@@ -17,6 +17,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 
 DIR_WORKFLOW = ".trellis"
 DIR_RUNTIME = ".runtime"

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -32,6 +32,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Hook hosts send UTF-8 JSON regardless of the process locale.
+_stdin_reconfigure = getattr(sys.stdin, "reconfigure", None)
+if callable(_stdin_reconfigure):
+    try:
+        _stdin_reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
 # IMPORTANT: Force stdout to use UTF-8 on Windows
 # This fixes UnicodeEncodeError when outputting non-ASCII characters
 if sys.platform.startswith("win"):

--- a/packages/cli/test/regression.test.ts
+++ b/packages/cli/test/regression.test.ts
@@ -1750,6 +1750,31 @@ describe("regression: current-task path normalization", () => {
     });
   }
 
+  function runPythonWithLegacyStdinLocale(
+    relativeScriptPath: string,
+    input: string,
+  ): string {
+    const scriptPath = path.join(tmpDir, relativeScriptPath);
+    const result = spawnSync(
+      pythonCmd,
+      [
+        "-c",
+        "import runpy, sys; sys.stdout.reconfigure(encoding='utf-8', errors='replace'); runpy.run_path(sys.argv[1], run_name='__main__')",
+        scriptPath,
+      ],
+      {
+        cwd: tmpDir,
+        input,
+        encoding: "utf-8",
+        env: sessionEnv({ PYTHONIOENCODING: "gbk" }),
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error(result.stderr);
+    }
+    return result.stdout;
+  }
+
   function expectTemplateContent(
     content: string | undefined,
     label: string,
@@ -2824,11 +2849,11 @@ print(json.dumps({
     );
 
     const nowSecs = Math.floor(Date.now() / 1000);
-    const output = runPython(
+    const output = runPythonWithLegacyStdinLocale(
       path.join(".claude", "hooks", "statusline.py"),
       JSON.stringify({
         session_id: "status-a",
-        model: { display_name: "Test" },
+        model: { display_name: "中文模型" },
         context_window: { used_percentage: 1, context_window_size: 1000 },
         cost: { total_duration_ms: 0 },
         rate_limits: {
@@ -2845,6 +2870,7 @@ print(json.dumps({
     );
 
     expect(output).toContain("Session scoped task");
+    expect(output).toContain("中文模型");
     expect(output).toContain("[session]");
     expect(output).not.toContain("Issue 106 task");
     // Rate-limit display with reset countdown (opt-in statusline enhancement)
@@ -3045,20 +3071,37 @@ print(json.dumps({
     );
 
     const taskScriptPath = path.join(tmpDir, ".trellis", "scripts", "task.py");
-    const hookOutput = runPython(
+    const unicodeProbe = "测试质量。\n第二行";
+    const hookOutput = runPythonWithLegacyStdinLocale(
       path.join(".cursor", "hooks", "inject-shell-session-context.py"),
       JSON.stringify({
         cursor_version: "3.1.17",
         conversation_id: "cursor-shell-a",
         generation_id: "gen-a",
         cwd: tmpDir,
-        command: `${pythonCmd} ./.trellis/scripts/task.py start .trellis/tasks/issue-106 && ${pythonCmd} ./.trellis/scripts/task.py current --source`,
+        command: `${pythonCmd} ./.trellis/scripts/task.py start .trellis/tasks/issue-106 && ${pythonCmd} ./.trellis/scripts/task.py current --source && echo '${unicodeProbe}'`,
         hook_event_name: "beforeShellExecution",
       }),
     );
     expect(JSON.parse(hookOutput) as { permission?: string }).toMatchObject({
       permission: "allow",
     });
+    const [ticketName] = fs.readdirSync(
+      path.join(tmpDir, ".trellis", ".runtime", "cursor-shell"),
+    );
+    const ticket = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          tmpDir,
+          ".trellis",
+          ".runtime",
+          "cursor-shell",
+          ticketName,
+        ),
+        "utf-8",
+      ),
+    ) as { command: string };
+    expect(ticket.command).toContain(unicodeProbe);
 
     const startOutput = execSync(
       `${pythonCmd} ${JSON.stringify(taskScriptPath)} start ${JSON.stringify(".trellis/tasks/issue-106")}`,
@@ -3122,14 +3165,16 @@ print(json.dumps({
       ),
     );
 
-    const hookOutput = runPython(
+    const unicodePrompt =
+      "检查测试质量。\n第二行 TOKEN_CURSOR_HOOK_TEST";
+    const hookOutput = runPythonWithLegacyStdinLocale(
       path.join(".cursor", "hooks", "inject-subagent-context.py"),
       JSON.stringify({
         cursor_version: "3.2.11",
         hook_event_name: "preToolUse",
         tool_name: "Subagent",
         tool_input: {
-          prompt: "Report whether TOKEN_CURSOR_HOOK_TEST is visible.",
+          prompt: unicodePrompt,
           subagent_type: {
             custom: {
               name: "trellis-implement",
@@ -3152,7 +3197,7 @@ print(json.dumps({
     expect(prompt).toContain(
       "=== .trellis/tasks/issue-106/prd.md (Requirements) ===",
     );
-    expect(prompt).toContain("TOKEN_CURSOR_HOOK_TEST");
+    expect(prompt).toContain(unicodePrompt);
     expect(parsed.hookSpecificOutput?.updatedInput?.prompt).toBe(prompt);
   });
 


### PR DESCRIPTION
## Summary

- decode host-provided hook JSON as UTF-8 independently of the Python process locale
- cover sub-agent context injection, Cursor shell session bridging, and the optional Claude statusline
- update the repository's active Claude/Cursor hook copies and add GBK-locale regressions for CJK text plus the `。\n` boundary

## Version and timing audit

Issue #483 was opened on 2026-07-28 against 0.6.9, 27 minutes after 0.6.10 was published. Exact tag inspection confirms the bug remains in 0.6.10, 0.7.0-beta.1, and main before this change.

Earlier related fixes were partial:

- #67 configured UTF-8 for Trellis scripts importing `common`, not standalone hooks
- #163 configured statusline stdout/stderr, not stdin
- #277 used `python -X utf8` for one Codex hook command, not every installed hook host

## Verification

- Python 3.9 `py_compile` for all changed hook copies
- GBK-locale execution tests for all three affected hook paths
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm test` (333 core passed, 1 skipped; 1597 CLI passed)

Closes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of UTF-8 input across CLI hooks and statusline integrations.
  * Prevented non-ASCII characters from being corrupted when running under legacy or differing system locales.
  * Added graceful fallback behavior when UTF-8 input configuration is unavailable.

* **Tests**
  * Expanded Windows-style encoding coverage with Unicode content in statusline, shell execution, and subagent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->