### PR TITLE
fix(pi): support max thinking for subagents

### DIFF
--- a/.pi/extensions/trellis/index.ts
+++ b/.pi/extensions/trellis/index.ts
@@ -275,7 +275,7 @@ function summaryText(text: string) {
   return `${text.trim().replace(/[。.!?…]+$/u, "")}...`;
 }
 function splitModelThinking(model?: string, fallbackThinking?: string) {
-  const m = model?.match(/^(.*):(off|minimal|low|medium|high|xhigh)$/i);
+  const m = model?.match(/^(.*):(off|minimal|low|medium|high|xhigh|max)$/i);
   return {
     model: m ? m[1] : model,
     thinking: (m?.[2] ?? fallbackThinking)?.toLowerCase(),
@@ -637,12 +637,12 @@ function resolveRunCfg(
   agentCfg: AgentConfig,
   inheritedThinking?: string,
 ): PiRunConfig {
-  const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
+  const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
   const normalize = (v: unknown): string | undefined => {
     const s = typeof v === "string" && v.trim() ? v.trim().toLowerCase() : "";
     return THINKING_LEVELS.includes(s) ? s : undefined;
   };
-  const suffixRe = /:(off|minimal|low|medium|high|xhigh)$/i;
+  const suffixRe = /:(off|minimal|low|medium|high|xhigh|max)$/i;
   const inputModel = str(input.model);
   const agentModel = agentCfg.model;
   const rawModel = inputModel ?? agentModel;
@@ -1441,7 +1441,7 @@ export default function trellisExtension(pi: {
           type: "string",
           description:
             "Optional Pi thinking level override for the child sub-agent process.",
-          enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+          enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
         },
       },
     },

--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -297,7 +297,7 @@ function summaryText(text: string) {
   return `${text.trim().replace(/[。.!?…]+$/u, "")}...`;
 }
 function splitModelThinking(model?: string, fallbackThinking?: string) {
-  const m = model?.match(/^(.*):(off|minimal|low|medium|high|xhigh)$/i);
+  const m = model?.match(/^(.*):(off|minimal|low|medium|high|xhigh|max)$/i);
   return {
     model: m ? m[1] : model,
     thinking: (m?.[2] ?? fallbackThinking)?.toLowerCase(),
@@ -660,12 +660,12 @@ function resolveRunCfg(
   inheritedThinking?: string,
   inheritedModel?: string,
 ): PiRunConfig {
-  const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
+  const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
   const normalize = (v: unknown): string | undefined => {
     const s = typeof v === "string" && v.trim() ? v.trim().toLowerCase() : "";
     return THINKING_LEVELS.includes(s) ? s : undefined;
   };
-  const suffixRe = /:(off|minimal|low|medium|high|xhigh)$/i;
+  const suffixRe = /:(off|minimal|low|medium|high|xhigh|max)$/i;
   const inputModel = str(input.model);
   const agentModel = agentCfg.model;
   const rawModel = inputModel ?? agentModel ?? str(inheritedModel);
@@ -1768,7 +1768,7 @@ export default function trellisExtension(pi: {
           type: "string",
           description:
             "Optional Pi thinking level override for the child sub-agent process.",
-          enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+          enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
         },
       },
     },

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -80,28 +80,16 @@ interface PiExtensionInternals {
   ) => string;
 }
 
-function loadExtensionInternals(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = {},
-): PiExtensionInternals {
-  const source = `${getExtensionTemplate()}
+type MaxThinkingInternals = Pick<
+  PiExtensionInternals,
+  "buildPiArgs" | "resolveRunCfg" | "splitModelThinking"
+>;
 
-export {
-  normalizeAgent,
-  isTrellisAgent,
-  parseAgentFM,
-  buildPiArgs,
-  splitModelThinking,
-  resolveRunCfg,
-  contextModelRef,
-  cmdHasTrellisCtx,
-  shellQuote,
-  trellisExtension,
-  truncateUtf8,
-  readContextInjectionLimits,
-  buildContext as buildContextForTest,
-};
-`;
+function evaluateExtension<T>(
+  source: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): T {
   const compiled = ts.transpileModule(source, {
     compilerOptions: {
       esModuleInterop: true,
@@ -125,7 +113,46 @@ export {
     require,
   });
   vm.runInContext(compiled, sandbox);
-  return moduleObject.exports as unknown as PiExtensionInternals;
+  return moduleObject.exports as T;
+}
+
+function loadExtensionInternals(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = {},
+): PiExtensionInternals {
+  const source = `${getExtensionTemplate()}
+
+export {
+  normalizeAgent,
+  isTrellisAgent,
+  parseAgentFM,
+  buildPiArgs,
+  splitModelThinking,
+  resolveRunCfg,
+  contextModelRef,
+  cmdHasTrellisCtx,
+  shellQuote,
+  trellisExtension,
+  truncateUtf8,
+  readContextInjectionLimits,
+  buildContext as buildContextForTest,
+};
+`;
+  return evaluateExtension<PiExtensionInternals>(source, cwd, env);
+}
+
+function loadMaxThinkingInternals(
+  extensionSource: string,
+): MaxThinkingInternals {
+  const source = `${extensionSource}
+
+export { buildPiArgs, resolveRunCfg, splitModelThinking };
+`;
+  return evaluateExtension<MaxThinkingInternals>(
+    source,
+    process.cwd(),
+    {},
+  );
 }
 
 function createMinimalTrellisRoot(): string {
@@ -558,31 +585,38 @@ fallbackModels:
   });
 
   it("supports max thinking for GPT-5.6 subagents (#470)", () => {
-    const { buildPiArgs, resolveRunCfg, splitModelThinking } =
-      loadExtensionInternals();
     const agentCfg: AgentConfig = {
       model: "openai/gpt-5.6-sol",
       thinking: "max",
       fallbackModels: [],
     };
+    const dogfoodExtension = readFileSync(
+      join(process.cwd(), "..", "..", ".pi", "extensions", "trellis", "index.ts"),
+      "utf-8",
+    );
 
-    const config = resolveRunCfg({}, agentCfg);
-    expect(config).toEqual({
-      model: "openai/gpt-5.6-sol:max",
-      thinking: "max",
-    });
-    expect(buildPiArgs(config)).toEqual([
-      "--mode",
-      "json",
-      "-p",
-      "--no-session",
-      "--model",
-      "openai/gpt-5.6-sol:max",
-    ]);
-    expect(splitModelThinking(config.model)).toEqual({
-      model: "openai/gpt-5.6-sol",
-      thinking: "max",
-    });
+    for (const extensionSource of [getExtensionTemplate(), dogfoodExtension]) {
+      const { buildPiArgs, resolveRunCfg, splitModelThinking } =
+        loadMaxThinkingInternals(extensionSource);
+      const config = resolveRunCfg({}, agentCfg);
+
+      expect(config).toEqual({
+        model: "openai/gpt-5.6-sol:max",
+        thinking: "max",
+      });
+      expect(buildPiArgs(config)).toEqual([
+        "--mode",
+        "json",
+        "-p",
+        "--no-session",
+        "--model",
+        "openai/gpt-5.6-sol:max",
+      ]);
+      expect(splitModelThinking(config.model)).toEqual({
+        model: "openai/gpt-5.6-sol",
+        thinking: "max",
+      });
+    }
   });
 
   it("inherits the invoking Pi model after per-call and agent defaults", () => {

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -47,6 +47,10 @@ interface PiExtensionInternals {
   isTrellisAgent: (root: string, agent: string) => boolean;
   parseAgentFM: (content: string) => AgentConfig;
   buildPiArgs: (config: PiRunConfig) => string[];
+  splitModelThinking: (
+    model?: string,
+    fallbackThinking?: string,
+  ) => { model?: string; thinking?: string };
   resolveRunCfg: (
     input: { model?: string; thinking?: string },
     agentCfg: AgentConfig,
@@ -87,6 +91,7 @@ export {
   isTrellisAgent,
   parseAgentFM,
   buildPiArgs,
+  splitModelThinking,
   resolveRunCfg,
   contextModelRef,
   cmdHasTrellisCtx,
@@ -220,7 +225,7 @@ describe("pi templates", () => {
       'enum: ["single", "parallel", "chain"]',
     );
     expect(extension).toContain(
-      'enum: ["off", "minimal", "low", "medium", "high", "xhigh"]',
+      'enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"]',
     );
 
     // Dispatch protocol carries the "Active task: <path>" prefix rule.
@@ -550,6 +555,34 @@ fallbackModels:
       "--tools",
       "Read,Write,Bash,find,Grep",
     ]);
+  });
+
+  it("supports max thinking for GPT-5.6 subagents (#470)", () => {
+    const { buildPiArgs, resolveRunCfg, splitModelThinking } =
+      loadExtensionInternals();
+    const agentCfg: AgentConfig = {
+      model: "openai/gpt-5.6-sol",
+      thinking: "max",
+      fallbackModels: [],
+    };
+
+    const config = resolveRunCfg({}, agentCfg);
+    expect(config).toEqual({
+      model: "openai/gpt-5.6-sol:max",
+      thinking: "max",
+    });
+    expect(buildPiArgs(config)).toEqual([
+      "--mode",
+      "json",
+      "-p",
+      "--no-session",
+      "--model",
+      "openai/gpt-5.6-sol:max",
+    ]);
+    expect(splitModelThinking(config.model)).toEqual({
+      model: "openai/gpt-5.6-sol",
+      thinking: "max",
+    });
   });
 
   it("inherits the invoking Pi model after per-call and agent defaults", () => {


### PR DESCRIPTION
## Summary

- accept `max` in the `trellis_subagent` thinking schema
- preserve `max` through Pi run configuration and model suffix parsing
- keep the dogfood Pi extension aligned with the generated template
- add a GPT-5.6 regression test covering config resolution, CLI args, and display parsing

## Root cause

Trellis hard-coded Pi thinking levels through `xhigh` in four paths, so `thinking: max` was dropped before spawning the child process even though current Pi supports it.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (CLI: 1598 passed; core pre-commit suite: 333 passed, 1 skipped)

Closes #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `max` as a supported subagent thinking level.
  * Subagent model strings can now include the `:max` suffix.
  * The `trellis_subagent` tool parameters now include `max` in the allowed `thinking` options.
* **Bug Fixes**
  * Improved normalization and parsing of subagent thinking-level settings to handle `max` consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->