### PR TITLE
ci: validate all Python scripts on 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'pnpm-workspace.yaml'
       - 'package.json'
       - 'marketplace'
+      - '**/*.py'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - 'pnpm-workspace.yaml'
       - 'package.json'
       - 'marketplace'
+      - '**/*.py'
       - '.github/workflows/ci.yml'
 
 jobs:
@@ -41,6 +43,11 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Check Python 3.9 syntax
+        run: |
+          export PYTHONPYCACHEPREFIX="$RUNNER_TEMP/trellis-pycache"
+          git ls-files -z --recurse-submodules '*.py' | xargs -0 python -m py_compile
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -51,6 +58,9 @@ jobs:
 
       - name: Typecheck (core + cli)
         run: pnpm typecheck
+
+      - name: Typecheck Python
+        run: pnpm --filter @mindfoldhq/trellis lint:py
 
       - name: Lint (core + cli)
         run: pnpm lint

--- a/.trellis/spec/cli/unit-test/index.md
+++ b/.trellis/spec/cli/unit-test/index.md
@@ -55,7 +55,7 @@ Do **not** maintain a manual coverage table — always run `pnpm test:coverage` 
 | Stage | What Runs | Rationale |
 |-------|-----------|-----------|
 | **pre-commit** (husky) | `lint-staged` (eslint + prettier) | Keep fast; don't add tests here or developers will skip with `--no-verify` |
-| **CI** (GitHub Actions, PR gate) | Pin Python 3.9 → `pnpm typecheck` → `pnpm lint` → `pnpm build` → `pnpm test` | Run the full suite with the minimum supported Python so shipped-script syntax regressions cannot hide behind a newer runner |
+| **CI** (GitHub Actions, PR gate) | Pin Python 3.9 → compile every tracked `.py` file → TypeScript + Python typecheck → `pnpm lint` → `pnpm build` → `pnpm test` | Parse all shipped scripts with the real minimum interpreter before running the suite, then enforce `basedpyright` so syntax and type regressions cannot hide in unexecuted templates |
 
 **When to reconsider**: If total test time exceeds 5 minutes, split into fast (unit) and slow (integration) stages. Currently unnecessary.
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,7 +6,7 @@
   ],
   "exclude": ["**/node_modules", "**/__pycache__", "dist"],
   "typeCheckingMode": "standard",
-  "pythonVersion": "3.10",
+  "pythonVersion": "3.9",
   "reportMissingImports": true,
   "reportMissingTypeStubs": false,
   "reportUnusedVariable": true,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,7 +2,7 @@
   "include": [
     ".trellis/scripts/**/*.py",
     ".claude/hooks/**/*.py",
-    "packages/cli/src/templates/**/*.py",
+    "packages/cli/src/templates/**/*.py"
   ],
   "exclude": ["**/node_modules", "**/__pycache__", "dist"],
   "typeCheckingMode": "standard",
@@ -10,5 +10,5 @@
   "reportMissingImports": true,
   "reportMissingTypeStubs": false,
   "reportUnusedVariable": true,
-  "reportUnusedImport": "warning",
+  "reportUnusedImport": "warning"
 }


### PR DESCRIPTION
## Summary

- compile every tracked Python file with the minimum supported Python 3.9 interpreter in CI
- run the existing `basedpyright` check as a required CI step
- align `pyrightconfig.json` with the documented Python 3.9 minimum
- trigger CI when any tracked Python file changes

## Why

The regression in #476 passed because CI only parsed Python files reached by tests, while unexecuted templates could contain syntax accepted by newer interpreters. The repository already pinned Python 3.9 and already depended on `basedpyright`, but neither provided a complete enforced static gate.

The new syntax step uses the actual Python 3.9 compiler over every tracked `.py` file, including submodules, so Python 3.12-only syntax cannot hide in a template.

## Validation

- all 74 tracked Python files parse on Python 3.9, 3.10, 3.11, and 3.12
- the same Python 3.9 compiler probe rejects the old v0.6.9 `task_context.py`
- `pnpm --filter @mindfoldhq/trellis lint:py`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

Related to #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Continuous integration now validates Python 3.9 syntax by compiling all tracked Python files.
  * CI runs TypeScript and Python checks before linting, building, and executing the test suite.

* **Chores**
  * CI includes a Python-focused lint step.
  * Python static analysis is configured to target Python 3.9 compatibility.
  * CI documentation was updated to reflect the new validation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->