### PR TITLE
chore(release): prepare v0.6.11

### DIFF
--- a/packages/cli/src/migrations/manifests/0.6.11.json
+++ b/packages/cli/src/migrations/manifests/0.6.11.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.11",
+  "description": "Reliable Pi and Codex subagents, UTF-8 hooks, bounded polyrepo scans, and accurate platform detection.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Bug Fixes:**\n- fix(pi): inherit the invoking session model in subagents and support max thinking\n- fix(channel): surface Codex turn failures and enforce idle timeouts after completed turns\n- fix(hooks): decode hook input as UTF-8 independently of the host locale\n- fix(scripts): cap automatic polyrepo discovery and bound best-effort Git status probes\n- fix(cli): detect configured platforms from Trellis-owned files\n**Internal:**\n- ci(python): compile every tracked Python file on Python 3.9 and run basedpyright",
+  "migrations": [],
+  "notes": "Upgrade to 0.6.11, then run trellis update to refresh Pi and hook templates. No --migrate required."
+}

--- a/packages/cli/src/migrations/manifests/0.7.0-beta.0.json
+++ b/packages/cli/src/migrations/manifests/0.7.0-beta.0.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.7.0-beta.0",
+  "description": "Path-scoped dynamic spec loading for Claude Code and Codex, plus layered workflow selection per task, developer, and team.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Enhancements:**\n- feat(hooks): deliver path-scoped specs dynamically through Claude Code PostToolUse and Codex PreToolUse hooks, with documented session reset handling\n- feat(workflow): save workflow variants and resolve task, developer, team, and global selections through one runtime chain",
+  "migrations": [],
+  "notes": "Run `trellis update` to install the new spec-injection hooks, workflow library support, and layered workflow resolver. No `--migrate` required."
+}

--- a/packages/cli/src/migrations/manifests/0.7.0-beta.1.json
+++ b/packages/cli/src/migrations/manifests/0.7.0-beta.1.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.7.0-beta.1",
+  "description": "Workflow scaffolding, Pi dynamic workflow selection, and OpenCode dynamic spec loading.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Enhancements:**\n- feat(workflow): add `trellis workflow create <workflow-id>` to scaffold a user-managed workflow variant and optionally select project and personal defaults\n- feat(pi): resolve task, personal, team, and global workflow selections in Pi breadcrumbs\n- feat(opencode): inject path-scoped governing specs before `write`, `edit`, and `apply_patch`, with model-visible block-and-retry delivery",
+  "migrations": [],
+  "notes": "Run `trellis update` to install the updated Pi extension and OpenCode dynamic spec plugin. No `--migrate` required."
+}


### PR DESCRIPTION
## Summary

- add the v0.6.11 release manifest
- restore the published v0.7.0-beta.0 and v0.7.0-beta.1 manifests required for migration continuity
- point the docs submodule at the merged English and Chinese v0.6.11 changelog

The restored beta manifests are historical release metadata only. This PR does not restore the reverted per-task workflow selection implementation to main.

## Validation

- manifest continuity: 141 local manifests, no new gaps
- release version alignment and packed CLI verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test (333 core passed, 1 skipped; 1586 CLI passed)
- docs lint and targeted Prettier check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release migration guidance for versions 0.6.11, 0.7.0-beta.0, and 0.7.0-beta.1.
  * Documented workflow scaffolding, dynamic workflow selection, and dynamic specification loading enhancements.
* **Documentation**
  * Updated the documentation site to a newer version.
  * Added instructions for applying the latest updates with `trellis update`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->