### PR TITLE
fix(codex): read platform skills from codex/skills/ not codex-skills/

### DIFF
--- a/packages/cli/src/templates/codex/index.ts
+++ b/packages/cli/src/templates/codex/index.ts
@@ -8,8 +8,7 @@
  * Directory structure:
  *   codex/
  *   ├── agents/         # Project-scoped Codex custom agents (.toml)
- *   ├── codex-skills/   # Codex-specific skills → .codex/skills/
- *   ├── skills/         # Shared skills → .agents/skills/
+ *   ├── skills/         # Codex-specific skills → .codex/skills/
  *   └── config.toml     # Project-scoped Codex config
  */
 
@@ -82,8 +81,8 @@ export function getAllAgents(): AgentTemplate[] {
 export function getAllCodexSkills(): SkillTemplate[] {
   const skills: SkillTemplate[] = [];
 
-  for (const name of listDirectories("codex-skills")) {
-    const content = readTemplate(`codex-skills/${name}/SKILL.md`);
+  for (const name of listDirectories("skills")) {
+    const content = readTemplate(`skills/${name}/SKILL.md`);
     skills.push({ name, content });
   }
 

--- a/packages/cli/test/templates/codex.test.ts
+++ b/packages/cli/test/templates/codex.test.ts
@@ -92,9 +92,13 @@ describe("codex native sub-agent hooks", () => {
 });
 
 describe("codex getAllCodexSkills (platform-specific)", () => {
-  it("returns empty after parallel removal", () => {
+  it("returns the platform skills installed to .codex/skills/", () => {
     const skills = getAllCodexSkills();
-    expect(skills).toEqual([]);
+    expect(skills.length).toBeGreaterThan(0);
+    expect(skills.map((s) => s.name)).toEqual(
+      expect.arrayContaining(["before-dev", "brainstorm", "break-loop", "check", "update-spec"]),
+    );
+    expect(skills[0].content).toContain("---");
   });
 });
 


### PR DESCRIPTION
## Problem

`getAllCodexSkills()` in `packages/cli/src/templates/codex/index.ts` lists `codex-skills` and reads `codex-skills/${name}/SKILL.md`, but the template directory was moved to `codex/skills/` (the 13 skills now live there). Since the move, the function always returns `[]`, so `trellis update` never writes the Codex platform skills to `.codex/skills/` even though it reports `Already up to date!`.

## Fix

Point both the directory listing and the read path at `skills/` (the actual template dir). Updated the doc comment and the regression test (it previously asserted the empty return, which baked in the bug).

## Verification

- `pnpm run typecheck` ✅
- `eslint` on changed files ✅
- `vitest run test/templates/codex.test.ts test/configurators/codex.test.ts` → 35/35 pass ✅
- Full suite: only the pre-existing `platforms.integration.test.ts` failures (3, unrelated, fail on clean main too)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Codex skill discovery to use the standard `skills/` directory.
  * Codex-specific skills are now correctly installed and recognized under `.codex/skills/`.
  * Updated skill validation to reflect the correct names and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->