### PR TITLE
chore: prepare v0.6.12 release

### DIFF
--- a/packages/cli/src/migrations/manifests/0.6.12.json
+++ b/packages/cli/src/migrations/manifests/0.6.12.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.12",
+  "description": "Pi session isolation for concurrent windows.",
+  "breaking": false,
+  "recommendMigrate": false,
+  "changelog": "**Bug Fixes:**\n- fix(pi): isolate each main window by native Pi session ID and prevent normalized key collisions",
+  "migrations": [],
+  "notes": "Upgrade to 0.6.12, then run trellis update to refresh the Pi extension. No --migrate required."
+}


### PR DESCRIPTION
## Summary\n\n- add the v0.6.12 migration manifest for Pi concurrent-session isolation\n- publish matching English and Chinese changelog pages\n- point the docs changelog navigation at v0.6.12\n\n## Verification\n\n- pnpm build\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- manifest continuity and release preflight checks\n- packed CLI artifact and fresh trellis init --pi / trellis update --dry-run smoke test\n\nNo migration is required.\n\nRelease for #512.