### PR TITLE
fix(cli): validate archived task context paths

### DIFF
--- a/.trellis/scripts/common/task_context.py
+++ b/.trellis/scripts/common/task_context.py
@@ -25,7 +25,7 @@ from .config import get_context_injection_limits
 from .git import branch_exists_locally
 from .io import read_json
 from .log import Colors, colored
-from .paths import FILE_TASK_JSON, get_repo_root
+from .paths import DIR_ARCHIVE, DIR_TASKS, DIR_WORKFLOW, FILE_TASK_JSON, get_repo_root
 from .task_utils import resolve_task_dir
 
 # Extensions that look like code rather than spec/research docs. Entries with
@@ -170,6 +170,59 @@ def _is_exempt_from_code_file_warning(file_path: str, task_rel: str) -> bool:
     return False
 
 
+def _resolve_context_entry_path(
+    file_path: str, repo_root: Path, task_dir: Path | None
+) -> Path | None:
+    """Resolve a JSONL entry, binding archived self-references to the archive copy.
+
+    Exact historical self-references are remapped only for archived tasks.
+    ``None`` means the remapped path traversed or resolved outside that archive.
+    """
+    repo_path = repo_root / file_path
+    if task_dir is None:
+        return repo_path
+
+    try:
+        task_parts = task_dir.absolute().relative_to(repo_root.absolute()).parts
+    except ValueError:
+        return repo_path
+
+    archive_prefix = (DIR_WORKFLOW, DIR_TASKS, DIR_ARCHIVE)
+    if len(task_parts) != 5 or task_parts[:3] != archive_prefix:
+        return repo_path
+
+    year_month = task_parts[3]
+    if (
+        len(year_month) != 7
+        or year_month[4] != "-"
+        or not year_month[:4].isdigit()
+        or not year_month[5:].isdigit()
+    ):
+        return repo_path
+
+    historical_root = f"{DIR_WORKFLOW}/{DIR_TASKS}/{task_dir.name}"
+    posix_path = file_path.replace("\\", "/")
+    if posix_path == historical_root:
+        relative_parts: tuple[str, ...] = ()
+    elif posix_path.startswith(f"{historical_root}/"):
+        relative_path = posix_path[len(historical_root) + 1 :]
+        if relative_path.endswith("/"):
+            relative_path = relative_path[:-1]
+        relative_parts = tuple(relative_path.split("/")) if relative_path else ()
+        if any(part in ("", ".", "..") for part in relative_parts):
+            return None
+    else:
+        return repo_path
+
+    try:
+        archive_root = task_dir.resolve()
+        resolved_path = task_dir.joinpath(*relative_parts).resolve()
+        resolved_path.relative_to(archive_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved_path
+
+
 def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = None) -> int:
     """Validate a single JSONL file.
 
@@ -220,14 +273,14 @@ def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = N
             continue
 
         real_entries += 1
-        full_path = repo_root / file_path
+        full_path = _resolve_context_entry_path(file_path, repo_root, task_dir)
         if entry_type == "directory":
-            if not full_path.is_dir():
+            if full_path is None or not full_path.is_dir():
                 print(f"  {colored(f'{file_name}:{line_num}: Directory not found: {file_path}', Colors.RED)}")
                 errors += 1
             continue
 
-        if not full_path.is_file():
+        if full_path is None or not full_path.is_file():
             print(f"  {colored(f'{file_name}:{line_num}: File not found: {file_path}', Colors.RED)}")
             errors += 1
             continue

--- a/.trellis/scripts/common/task_context.py
+++ b/.trellis/scripts/common/task_context.py
@@ -183,7 +183,7 @@ def _resolve_context_entry_path(
         return repo_path
 
     try:
-        task_parts = task_dir.absolute().relative_to(repo_root.absolute()).parts
+        task_parts = task_dir.resolve().relative_to(repo_root.resolve()).parts
     except ValueError:
         return repo_path
 

--- a/.trellis/spec/cli/backend/platform-integration.md
+++ b/.trellis/spec/cli/backend/platform-integration.md
@@ -1236,6 +1236,7 @@ Optional `type: "directory"` is supported for directory entries. Consumers ignor
 | Seed detection            | Every jsonl consumer                            | Row without a `file` key is treated as non-entry and skipped.                      |
 | Empty-file tolerance      | hook / prelude / plugin readers                 | Missing or seed-only jsonl is tolerated; task artifacts still load.                |
 | Context order             | hook / prelude / Pi extension / OpenCode plugin | jsonl entries → `prd.md` → `design.md` if present → `implement.md` if present.     |
+| Archived self-references  | `task_context.py` validation                    | Preserve JSONL bytes. For an archived task, remap only exact `.trellis/tasks/<same-task-name>/...` references into that archive copy. Other paths retain repo-root resolution. |
 
 ### Validation & Error Matrix
 
@@ -1243,6 +1244,9 @@ Optional `type: "directory"` is supported for directory entries. Consumers ignor
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------- |
 | `implement.jsonl` has only seed row                    | `cmd_validate` reports 0 errors; `cmd_list_context` prints "(no curated entries yet — only seed row)" | Exit 0                  |
 | `implement.jsonl` entry points at non-existent file    | `cmd_validate` prints "File not found: …" per row                                                     | Exit 1                  |
+| Archived self-reference exists in the archive copy     | Resolve inside `.trellis/tasks/archive/<year-month>/<same-task-name>/`; do not rewrite the manifest        | Exit 0                  |
+| Archived self-reference is absent from the archive copy | Report it missing even if an active task with the same name has recreated the path                         | Exit 1                  |
+| Archived self-reference traverses or follows a symlink outside the archive | Reject it as missing; never fall back to the historical active-task path                    | Exit 1                  |
 | Lightweight task has only `prd.md`                     | Valid planning state; SessionStart / continue can ask for start review                                | No error                |
 | Complex task is missing `design.md` or `implement.md`  | Stay in planning; ask user to complete missing planning artifacts                                     | Hook / command guidance |
 | Sub-agent platform detected, but jsonl seed is missing | Context readers fall back to task artifacts and warn where applicable                                 | No create failure       |
@@ -1250,8 +1254,10 @@ Optional `type: "directory"` is supported for directory entries. Consumers ignor
 ### Good / Base / Bad Cases
 
 - **Good**: complex task has `prd.md`, `design.md`, `implement.md`, and curated jsonl manifests. Context consumers load jsonl entries first, then all three artifacts.
+- **Good (archived)**: a moved task keeps its JSONL byte-for-byte; validation binds exact historical self-references to files or directories inside its archive copy while unrelated repository paths still resolve from the repository root.
 - **Base**: lightweight task has only `prd.md`. SessionStart / continue treats this as a valid planning state and may ask for start review.
 - **Bad**: complex task has only `prd.md` plus seed-only jsonl. SessionStart / continue must keep the task in planning; it must not treat jsonl file existence as implementation readiness.
+- **Bad (archived)**: validation resolves a historical self-reference through a recreated active task, or accepts `..` / a symlink that escapes the archived task directory.
 
 ### Wrong vs Correct
 
@@ -1282,11 +1288,18 @@ def planning_next_action(task_dir: Path, is_complex: bool, inline_mode: bool) ->
 
 The route depends on task intent, artifact presence, and execution mode. Missing optional artifacts are skipped for lightweight tasks, but complex tasks cannot enter implementation until their planning artifacts are complete.
 
+For archived validation, resolving every JSONL path as `repo_root / file_path`
+is wrong because a preserved self-reference points at the task's former active
+location. Resolve only the exact same-task prefix against the archived task
+directory, require its canonical target to stay within that directory, and
+leave every unrelated path on normal repository-root resolution.
+
 ### Tests Required
 
 - **Create behavior**: `task.py create` creates default `prd.md` and seeds jsonl only on sub-agent-capable platforms.
 - **Consumer tolerance**: `inject-subagent-context.py` skips seed rows and still injects task artifacts.
 - **Validate seed**: `task.py validate` treats seed-only jsonl as 0 errors.
+- **Validate archive binding**: cover archived self files and directories, unrelated paths, a missing archive copy with a recreated active task, traversal, symlink escape, and unchanged active-task behavior.
 - **List-context seed**: `task.py list-context` prints "no curated entries yet" for seed-only jsonl.
 - **Artifact gates**: workflow-state, SessionStart, and continue distinguish PRD-only lightweight tasks from complex tasks that still need `design.md` / `implement.md`.
 

--- a/packages/cli/src/templates/trellis/scripts/common/task_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_context.py
@@ -25,7 +25,7 @@ from .config import get_context_injection_limits
 from .git import branch_exists_locally
 from .io import read_json
 from .log import Colors, colored
-from .paths import FILE_TASK_JSON, get_repo_root
+from .paths import DIR_ARCHIVE, DIR_TASKS, DIR_WORKFLOW, FILE_TASK_JSON, get_repo_root
 from .task_utils import resolve_task_dir
 
 # Extensions that look like code rather than spec/research docs. Entries with
@@ -170,6 +170,59 @@ def _is_exempt_from_code_file_warning(file_path: str, task_rel: str) -> bool:
     return False
 
 
+def _resolve_context_entry_path(
+    file_path: str, repo_root: Path, task_dir: Path | None
+) -> Path | None:
+    """Resolve a JSONL entry, binding archived self-references to the archive copy.
+
+    Exact historical self-references are remapped only for archived tasks.
+    ``None`` means the remapped path traversed or resolved outside that archive.
+    """
+    repo_path = repo_root / file_path
+    if task_dir is None:
+        return repo_path
+
+    try:
+        task_parts = task_dir.absolute().relative_to(repo_root.absolute()).parts
+    except ValueError:
+        return repo_path
+
+    archive_prefix = (DIR_WORKFLOW, DIR_TASKS, DIR_ARCHIVE)
+    if len(task_parts) != 5 or task_parts[:3] != archive_prefix:
+        return repo_path
+
+    year_month = task_parts[3]
+    if (
+        len(year_month) != 7
+        or year_month[4] != "-"
+        or not year_month[:4].isdigit()
+        or not year_month[5:].isdigit()
+    ):
+        return repo_path
+
+    historical_root = f"{DIR_WORKFLOW}/{DIR_TASKS}/{task_dir.name}"
+    posix_path = file_path.replace("\\", "/")
+    if posix_path == historical_root:
+        relative_parts: tuple[str, ...] = ()
+    elif posix_path.startswith(f"{historical_root}/"):
+        relative_path = posix_path[len(historical_root) + 1 :]
+        if relative_path.endswith("/"):
+            relative_path = relative_path[:-1]
+        relative_parts = tuple(relative_path.split("/")) if relative_path else ()
+        if any(part in ("", ".", "..") for part in relative_parts):
+            return None
+    else:
+        return repo_path
+
+    try:
+        archive_root = task_dir.resolve()
+        resolved_path = task_dir.joinpath(*relative_parts).resolve()
+        resolved_path.relative_to(archive_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved_path
+
+
 def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = None) -> int:
     """Validate a single JSONL file.
 
@@ -220,14 +273,14 @@ def _validate_jsonl(jsonl_file: Path, repo_root: Path, task_dir: Path | None = N
             continue
 
         real_entries += 1
-        full_path = repo_root / file_path
+        full_path = _resolve_context_entry_path(file_path, repo_root, task_dir)
         if entry_type == "directory":
-            if not full_path.is_dir():
+            if full_path is None or not full_path.is_dir():
                 print(f"  {colored(f'{file_name}:{line_num}: Directory not found: {file_path}', Colors.RED)}")
                 errors += 1
             continue
 
-        if not full_path.is_file():
+        if full_path is None or not full_path.is_file():
             print(f"  {colored(f'{file_name}:{line_num}: File not found: {file_path}', Colors.RED)}")
             errors += 1
             continue

--- a/packages/cli/src/templates/trellis/scripts/common/task_context.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_context.py
@@ -183,7 +183,7 @@ def _resolve_context_entry_path(
         return repo_path
 
     try:
-        task_parts = task_dir.absolute().relative_to(repo_root.absolute()).parts
+        task_parts = task_dir.resolve().relative_to(repo_root.resolve()).parts
     except ValueError:
         return repo_path
 

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -7,7 +7,7 @@
  *   - `src/templates/shared-hooks/inject-subagent-context.py` — truncation,
  *     total-budget degradation, UTF-8 safety
  *   - `src/templates/trellis/scripts/common/task_context.py` — `task.py
- *     validate` hygiene warnings
+ *     validate` path resolution and hygiene warnings
  *
  * Scripts are stamped into a fresh temp dir and exercised through the real
  * `python3` interpreter (no mocking of file I/O or config parsing).
@@ -118,6 +118,33 @@ function makeTask(tmp: string, dirName: string): string {
     "utf-8",
   );
   return taskDir;
+}
+
+function makeArchivedTask(tmp: string, dirName: string): string {
+  const activeTaskDir = makeTask(tmp, dirName);
+  const archivedTaskDir = path.join(
+    tmp,
+    ".trellis",
+    "tasks",
+    "archive",
+    "2026-08",
+    dirName,
+  );
+  fs.mkdirSync(path.dirname(archivedTaskDir), { recursive: true });
+  fs.renameSync(activeTaskDir, archivedTaskDir);
+  return archivedTaskDir;
+}
+
+function runTaskValidate(
+  tmp: string,
+  taskDir: string,
+): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync(
+    "python3",
+    [path.join(tmp, ".trellis", "scripts", "task.py"), "validate", taskDir],
+    { cwd: tmp, encoding: "utf-8" },
+  );
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr };
 }
 
 describe.skipIf(!hasPython())(
@@ -596,21 +623,6 @@ print("all-valid")
     });
 
     describe("task.py validate: JSONL hygiene warnings", () => {
-      function runValidate(
-        taskDir: string,
-      ): { status: number | null; stdout: string; stderr: string } {
-        const r = spawnSync(
-          "python3",
-          [
-            path.join(tmp, ".trellis", "scripts", "task.py"),
-            "validate",
-            taskDir,
-          ],
-          { cwd: tmp, encoding: "utf-8" },
-        );
-        return { status: r.status, stdout: r.stdout, stderr: r.stderr };
-      }
-
       it("warns (does not error) on a jsonl entry that looks like a code file", () => {
         const taskDir = makeTask(tmp, "task-code-warn");
         fs.mkdirSync(path.join(tmp, "src"), { recursive: true });
@@ -624,7 +636,7 @@ print("all-valid")
           JSON.stringify({ file: "src/index.ts", reason: "wrong" }) + "\n",
           "utf-8",
         );
-        const { status, stdout } = runValidate(taskDir);
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
         expect(status).toBe(0);
         expect(stdout).toContain(
           "implement.jsonl:1: Warning: src/index.ts looks like a code file — " +
@@ -650,7 +662,7 @@ print("all-valid")
           }) + "\n",
           "utf-8",
         );
-        const { status, stdout } = runValidate(taskDir);
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
         expect(status).toBe(0);
         expect(stdout).not.toContain("looks like a code file");
       });
@@ -671,7 +683,7 @@ print("all-valid")
           tmp,
           ["context_injection:", "  max_file_bytes: 100"].join("\n"),
         );
-        const { status, stdout } = runValidate(taskDir);
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
         expect(status).toBe(0);
         expect(stdout).toContain(
           "implement.jsonl:1: Warning: oversized.md is 200 bytes, " +
@@ -696,9 +708,193 @@ print("all-valid")
           }) + "\n",
           "utf-8",
         );
-        const { status, stdout } = runValidate(taskDir);
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
         expect(status).toBe(0);
         expect(stdout).not.toContain("Warning:");
+        expect(stdout).toContain("All validations passed");
+      });
+    });
+
+    describe("task.py validate: archived task paths (#518)", () => {
+      const taskName = "08-04-archive-validator-repro";
+      const historicalEvidence = `.trellis/tasks/${taskName}/research/evidence.md`;
+
+      it("#1 validates an archived task self-file without rewriting its manifest", () => {
+        const taskDir = makeArchivedTask(tmp, taskName);
+        fs.mkdirSync(path.join(taskDir, "research"), { recursive: true });
+        fs.writeFileSync(
+          path.join(taskDir, "research", "evidence.md"),
+          "archived evidence\n",
+          "utf-8",
+        );
+        fs.mkdirSync(path.join(tmp, "docs"), { recursive: true });
+        fs.writeFileSync(
+          path.join(tmp, "docs", "reference.md"),
+          "repository documentation\n",
+          "utf-8",
+        );
+        const manifestPath = path.join(taskDir, "implement.jsonl");
+        const manifest =
+          [
+            JSON.stringify({ file: historicalEvidence, reason: "evidence" }),
+            JSON.stringify({
+              file: "docs/reference.md",
+              reason: "repository documentation",
+            }),
+          ].join("\n") + "\n";
+        fs.writeFileSync(manifestPath, manifest, "utf-8");
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("implement.jsonl: ✓ (2 entries)");
+        expect(stdout).toContain("All validations passed");
+        expect(fs.readFileSync(manifestPath, "utf-8")).toBe(manifest);
+      });
+
+      it("#2 validates an archived task self-directory", () => {
+        const taskDir = makeArchivedTask(tmp, taskName);
+        fs.mkdirSync(path.join(taskDir, "research"), { recursive: true });
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({
+            file: `.trellis/tasks/${taskName}/research/`,
+            type: "directory",
+            reason: "research directory",
+          }) + "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("All validations passed");
+      });
+
+      it("#3 keeps an unrelated missing task reference as an error", () => {
+        const taskDir = makeArchivedTask(tmp, taskName);
+        const missingPath =
+          ".trellis/tasks/another-task/research/missing.md";
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: missingPath, reason: "other task" }) + "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(1);
+        expect(stdout).toContain(`File not found: ${missingPath}`);
+      });
+
+      it("#4 does not fall back to a recreated active task when the archive copy is missing", () => {
+        const taskDir = makeArchivedTask(tmp, taskName);
+        const activeTaskDir = makeTask(tmp, taskName);
+        fs.mkdirSync(path.join(activeTaskDir, "research"), { recursive: true });
+        fs.writeFileSync(
+          path.join(activeTaskDir, "research", "evidence.md"),
+          "active evidence only\n",
+          "utf-8",
+        );
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: historicalEvidence, reason: "evidence" }) +
+            "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(1);
+        expect(stdout).toContain(`File not found: ${historicalEvidence}`);
+      });
+
+      it("#5 rejects traversal in an archived self-reference without active-task fallback", () => {
+        const taskDir = makeArchivedTask(tmp, taskName);
+        const activeTaskDir = makeTask(tmp, taskName);
+        fs.mkdirSync(path.join(activeTaskDir, "research"), { recursive: true });
+        fs.writeFileSync(
+          path.join(activeTaskDir, "research", "active-only.md"),
+          "active evidence only\n",
+          "utf-8",
+        );
+        const traversalPath =
+          `.trellis/tasks/${taskName}/../${taskName}/research/active-only.md`;
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: traversalPath, reason: "traversal" }) + "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(1);
+        expect(stdout).toContain(`File not found: ${traversalPath}`);
+      });
+
+      it.skipIf(process.platform === "win32")(
+        "#6 rejects a symlink that escapes the archived task",
+        () => {
+          const taskDir = makeArchivedTask(tmp, taskName);
+          const activeTaskDir = makeTask(tmp, taskName);
+          const activeEvidence = path.join(
+            activeTaskDir,
+            "research",
+            "evidence.md",
+          );
+          fs.mkdirSync(path.dirname(activeEvidence), { recursive: true });
+          fs.writeFileSync(activeEvidence, "active evidence only\n", "utf-8");
+          const archivedEvidence = path.join(
+            taskDir,
+            "research",
+            "evidence.md",
+          );
+          fs.mkdirSync(path.dirname(archivedEvidence), { recursive: true });
+          fs.symlinkSync(activeEvidence, archivedEvidence);
+          fs.writeFileSync(
+            path.join(taskDir, "implement.jsonl"),
+            JSON.stringify({ file: historicalEvidence, reason: "evidence" }) +
+              "\n",
+            "utf-8",
+          );
+
+          const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+          expect(status).toBe(1);
+          expect(stdout).toContain(`File not found: ${historicalEvidence}`);
+        },
+      );
+
+      it("#7 leaves active-task and unrelated repository path validation unchanged", () => {
+        const taskDir = makeTask(tmp, taskName);
+        fs.mkdirSync(path.join(taskDir, "research"), { recursive: true });
+        fs.writeFileSync(
+          path.join(taskDir, "research", "evidence.md"),
+          "active evidence\n",
+          "utf-8",
+        );
+        fs.mkdirSync(path.join(tmp, "docs"), { recursive: true });
+        fs.writeFileSync(
+          path.join(tmp, "docs", "reference.md"),
+          "repository documentation\n",
+          "utf-8",
+        );
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          [
+            JSON.stringify({ file: historicalEvidence, reason: "evidence" }),
+            JSON.stringify({
+              file: "docs/reference.md",
+              reason: "repository documentation",
+            }),
+          ].join("\n") + "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(tmp, taskDir);
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("implement.jsonl: ✓ (2 entries)");
         expect(stdout).toContain("All validations passed");
       });
     });

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -144,6 +144,7 @@ function runTaskValidate(
     [path.join(tmp, ".trellis", "scripts", "task.py"), "validate", taskDir],
     { cwd: tmp, encoding: "utf-8" },
   );
+  if (r.error) throw r.error;
   return { status: r.status, stdout: r.stdout, stderr: r.stderr };
 }
 
@@ -719,7 +720,7 @@ print("all-valid")
       const taskName = "08-04-archive-validator-repro";
       const historicalEvidence = `.trellis/tasks/${taskName}/research/evidence.md`;
 
-      it("#1 validates an archived task self-file without rewriting its manifest", () => {
+      it("#1 resolves a ..-spelled archived task without rewriting", () => {
         const taskDir = makeArchivedTask(tmp, taskName);
         fs.mkdirSync(path.join(taskDir, "research"), { recursive: true });
         fs.writeFileSync(
@@ -744,7 +745,11 @@ print("all-valid")
           ].join("\n") + "\n";
         fs.writeFileSync(manifestPath, manifest, "utf-8");
 
-        const { status, stdout } = runTaskValidate(tmp, taskDir);
+        const taskDirWithParentSegment = `${taskDir}${path.sep}..${path.sep}${taskName}`;
+        const { status, stdout } = runTaskValidate(
+          tmp,
+          taskDirWithParentSegment,
+        );
 
         expect(status).toBe(0);
         expect(stdout).toContain("implement.jsonl: ✓ (2 entries)");
@@ -895,6 +900,46 @@ print("all-valid")
 
         expect(status).toBe(0);
         expect(stdout).toContain("implement.jsonl: ✓ (2 entries)");
+        expect(stdout).toContain("All validations passed");
+      });
+
+      it("#8 falls back to repository-root resolution for a malformed archive year-month", () => {
+        const archivedTaskDir = makeArchivedTask(tmp, taskName);
+        const malformedArchiveTaskDir = path.join(
+          tmp,
+          ".trellis",
+          "tasks",
+          "archive",
+          "2026-8",
+          taskName,
+        );
+        fs.mkdirSync(path.dirname(malformedArchiveTaskDir), {
+          recursive: true,
+        });
+        fs.renameSync(archivedTaskDir, malformedArchiveTaskDir);
+
+        const activeTaskDir = makeTask(tmp, taskName);
+        const activeEvidence = path.join(
+          activeTaskDir,
+          "research",
+          "evidence.md",
+        );
+        fs.mkdirSync(path.dirname(activeEvidence), { recursive: true });
+        fs.writeFileSync(activeEvidence, "active evidence\n", "utf-8");
+        fs.writeFileSync(
+          path.join(malformedArchiveTaskDir, "implement.jsonl"),
+          JSON.stringify({ file: historicalEvidence, reason: "evidence" }) +
+            "\n",
+          "utf-8",
+        );
+
+        const { status, stdout } = runTaskValidate(
+          tmp,
+          malformedArchiveTaskDir,
+        );
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("implement.jsonl: ✓ (1 entries)");
         expect(stdout).toContain("All validations passed");
       });
     });


### PR DESCRIPTION
## Summary

- remap exact historical same-task JSONL references when validating archived tasks without rewriting their manifests
- keep archived references bound to the archive copy and reject traversal or symlink escapes
- preserve repo-root resolution for active tasks and unrelated paths, with synchronized live/template implementations and focused regression coverage

## Root Cause

Task archiving moves the task directory while preserving `implement.jsonl` and `check.jsonl` byte-for-byte. Validation still resolved every `file` entry as `repo_root / file_path`, so historical self-references pointed at the former active-task location. That produced false missing-file errors and could incorrectly accept a recreated active task with the same name.

## Test Plan

- `corepack pnpm@10.32.1 --filter @mindfoldhq/trellis exec vitest run test/scripts/context-injection-limits.integration.test.ts`
- Python 3.9 compile check across all tracked Python files
- `pnpm typecheck`
- `pnpm --filter @mindfoldhq/trellis lint:py`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

Fixes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of archived task references in JSONL context files.
  * Archived self-references now resolve correctly within the archived task copy.
  * Invalid, missing, path-traversing, and symlink-escaping references are rejected.
  * Preserved existing resolution behavior for active tasks and repository paths.

* **Documentation**
  * Added guidance and examples covering archived-task path validation and hygiene warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->