### PR TITLE
fix(omp): deduplicate shared task context files

### DIFF
--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -309,6 +309,10 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       jsonlNames = ["implement.jsonl", "check.jsonl"]; // main session: all
    }
 
+   // A file may be referenced by both manifests. Use the resolved real path so
+   // relative aliases and symlinked paths cannot consume the context budget twice.
+   const includedPaths = new Set<string>();
+
    for (const jsonlName of jsonlNames) {
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
@@ -330,9 +334,11 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!file) continue;
             const targetPath = resolveProjectFile(projectRoot, file, trustedRoots);
             if (!targetPath) continue;
+            if (includedPaths.has(targetPath)) continue;
             let content = "";
             try { content = readFileSync(targetPath, "utf-8"); } catch { }
             if (content.trim()) {
+               includedPaths.add(targetPath);
                fileChunks.push(`### ${file}\n\n${content.trim()}`);
             }
          } catch {

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -309,6 +309,10 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       jsonlNames = ["implement.jsonl", "check.jsonl"]; // main session: all
    }
 
+   // A file may be referenced by both manifests. Use the resolved real path so
+   // relative aliases and symlinked paths cannot consume the context budget twice.
+   const includedPaths = new Set<string>();
+
    for (const jsonlName of jsonlNames) {
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
@@ -330,9 +334,11 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!file) continue;
             const targetPath = resolveProjectFile(projectRoot, file, trustedRoots);
             if (!targetPath) continue;
+            if (includedPaths.has(targetPath)) continue;
             let content = "";
             try { content = readFileSync(targetPath, "utf-8"); } catch { }
             if (content.trim()) {
+               includedPaths.add(targetPath);
                fileChunks.push(`### ${file}\n\n${content.trim()}`);
             }
          } catch {

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
+import os from "node:os";
 import vm from "node:vm";
 import ts from "typescript";
 import {
@@ -17,6 +18,7 @@ const templateDir = path.resolve(__dirname, "../../src/templates/omp");
 type OmpEventHandler = (event: unknown, ctx?: unknown) => unknown;
 type OmpExtension = (pi: {
   on: (event: string, handler: OmpEventHandler) => void;
+  sendMessage?: (message: unknown) => Promise<void>;
 }) => void;
 
 function loadOmpExtension(): OmpExtension {
@@ -177,6 +179,82 @@ describe("omp templates", () => {
     // Agent-type-specific jsonl selection
     expect(extension).toContain("implement.jsonl");
     expect(extension).toContain("check.jsonl");
+  });
+
+  it("deduplicates files referenced by both main-session manifests", async () => {
+    const projectRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "trellis-omp-dedupe-"),
+    );
+    const taskDir = path.join(projectRoot, ".trellis", "tasks", "demo-task");
+    const sessionDir = path.join(
+      projectRoot,
+      ".trellis",
+      ".runtime",
+      "sessions",
+    );
+    const sharedFile = path.join(projectRoot, "docs", "shared.md");
+    const checkOnlyFile = path.join(projectRoot, "docs", "check-only.md");
+    const contextKey = "omp_session_dedupe";
+    const taskRef = ".trellis/tasks/demo-task";
+    const messages: { customType?: string; content?: string }[] = [];
+
+    try {
+      fs.mkdirSync(path.join(taskDir, "research"), { recursive: true });
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+      fs.writeFileSync(
+        path.join(taskDir, "task.json"),
+        JSON.stringify({
+          title: "OMP context dedupe",
+          status: "in_progress",
+        }),
+      );
+      fs.writeFileSync(sharedFile, "shared context body");
+      fs.writeFileSync(checkOnlyFile, "check-only context body");
+      fs.writeFileSync(
+        path.join(taskDir, "implement.jsonl"),
+        `${JSON.stringify({ file: "docs/shared.md" })}\n`,
+      );
+      fs.writeFileSync(
+        path.join(taskDir, "check.jsonl"),
+        `${JSON.stringify({ file: "./docs/../docs/shared.md" })}\n${JSON.stringify({ file: "docs/check-only.md" })}\n`,
+      );
+      fs.writeFileSync(
+        path.join(sessionDir, `${contextKey}.json`),
+        JSON.stringify({ current_task: taskRef }),
+      );
+
+      const handlers = new Map<string, OmpEventHandler>();
+      loadOmpExtension()({
+        on: (event, handler) => handlers.set(event, handler),
+        sendMessage: async (message) =>
+          messages.push(message as { customType?: string; content?: string }),
+      });
+      const sessionStart = handlers.get("session_start");
+      if (!sessionStart)
+        throw new Error("OMP extension did not register session_start");
+
+      await sessionStart(
+        {},
+        {
+          cwd: projectRoot,
+          sessionManager: { getSessionId: () => "session/dedupe" },
+          ui: { notify: () => undefined },
+        },
+      );
+
+      const taskContext = messages.find(
+        (message) => message.customType === "trellis-task-context",
+      );
+      expect(taskContext?.content).toContain("## implement.jsonl");
+      expect(taskContext?.content).toContain("## check.jsonl");
+      expect(taskContext?.content?.match(/shared context body/g)).toHaveLength(
+        1,
+      );
+      expect(taskContext?.content).toContain("check-only context body");
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it("no settings.json or Python hooks exist in the template directory", () => {


### PR DESCRIPTION
## 摘要

修复 OMP 主会话在同时读取 `implement.jsonl` 和 `check.jsonl` 时重复内联同一项目文件的问题。

## 背景

当两份 manifest 引用同一个文件时，Trellis 会在同一条 `trellis-task-context` 消息中重复展开文件正文，浪费上下文预算。不同的相对路径写法或符号链接也可能指向同一个实际文件。

## 实现

- 在构建 task context 时维护跨 manifest 共享的 canonical realpath 集合。
- 同一规范化项目路径只内联一次。
- 支持通过不同相对路径、`..` 路径或符号链接引用时保持去重。
- 保持不同路径的同内容文件独立展开，避免把内容哈希去重引入路径语义。
- 同步更新 OMP 根目录扩展和 CLI 安装模板。

## 测试

- OMP 模板定向测试：`14/14` 通过。
- CLI 完整测试：`1672/1672` 通过。
- Core 测试：`344` 通过，`1` 个既有跳过项。
- lint、typecheck、build 和 `git diff --check` 已通过。

## 关联

关联 Issue #532。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the same referenced file from appearing multiple times in task context, including when accessed through aliases or symbolic links.
  * Ensured unique files continue to be included as expected.
  * Improved task context accuracy and reduced unnecessary duplicate content across implementation and checking workflows.

* **Tests**
  * Added coverage verifying duplicate references are emitted only once while distinct files remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->