### PR TITLE
fix(omp): refresh task context after file changes

### DIFF
--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join, dirname, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -282,6 +282,49 @@ function buildSessionContext(projectRoot: string, contextKey: string | null): st
 
 type AgentType = "trellis-implement" | "trellis-check" | "trellis-research" | null;
 
+function taskContextJsonlNames(agentType?: AgentType): string[] {
+   if (agentType === "trellis-implement") return ["implement.jsonl"];
+   if (agentType === "trellis-check") return ["check.jsonl"];
+   if (agentType === "trellis-research") return [];
+   return ["implement.jsonl", "check.jsonl"];
+}
+
+function taskContextInputPaths(projectRoot: string, taskDir: string, agentType?: AgentType): string[] {
+   const trustedRoots = resolveTrustedRoots(projectRoot);
+   const paths = new Set<string>([join(taskDir, "prd.md"), join(taskDir, "info.md")]);
+   for (const jsonlName of taskContextJsonlNames(agentType)) {
+      const jsonlPath = join(taskDir, jsonlName);
+      paths.add(jsonlPath);
+      if (!existsSync(jsonlPath)) continue;
+      let lines: string[];
+      try { lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/); } catch { continue; }
+      for (const line of lines) {
+         try {
+            const row = JSON.parse(line.trim()) as Record<string, unknown>;
+            const file = typeof row.file === "string" ? row.file.trim() : "";
+            const candidatePath = file ? resolve(projectRoot, file) : "";
+            if (candidatePath && isInsideRoot(resolve(projectRoot), candidatePath)) paths.add(candidatePath);
+            const targetPath = file ? resolveProjectFile(projectRoot, file, trustedRoots) : null;
+            if (targetPath) paths.add(targetPath);
+         } catch {
+            // Seed rows and malformed lines do not contribute referenced files.
+         }
+      }
+   }
+   return [...paths];
+}
+
+function taskContextSignature(projectRoot: string, taskDir: string, agentType?: AgentType): string {
+   return taskContextInputPaths(projectRoot, taskDir, agentType).map((filePath) => {
+      try {
+         const stat = statSync(filePath);
+         return `${filePath}:${stat.mtimeMs}:${stat.ctimeMs}:${stat.size}`;
+      } catch {
+         return `${filePath}:missing`;
+      }
+   }).join("\n");
+}
+
 function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
    const parts: string[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
@@ -298,16 +341,7 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    if (info.trim()) parts.push(`## Info\n\n${info.trim()}`);
 
    // Determine which jsonl files to read based on agent type
-   let jsonlNames: string[];
-   if (agentType === "trellis-implement") {
-      jsonlNames = ["implement.jsonl"];
-   } else if (agentType === "trellis-check") {
-      jsonlNames = ["check.jsonl"];
-   } else if (agentType === "trellis-research") {
-      jsonlNames = []; // research agent gets only prd + info
-   } else {
-      jsonlNames = ["implement.jsonl", "check.jsonl"]; // main session: all
-   }
+   const jsonlNames = taskContextJsonlNames(agentType);
 
    // A file may be referenced by both manifests. Use the resolved real path so
    // relative aliases and symlinked paths cannot consume the context budget twice.
@@ -443,6 +477,14 @@ function detectAgentType(): AgentType {
    return null;
 }
 
+interface TaskContextCache {
+   projectRoot: string;
+   taskDir: string;
+   agentType: AgentType;
+   signature: string;
+   content: string;
+}
+
 // ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
@@ -452,6 +494,7 @@ export default function(pi: ExtensionAPI): void {
    const turnCache = new TurnContextCache();
    const agentType = detectAgentType();
    const isSubAgent = agentType !== null;
+   let taskContextCache: TaskContextCache | null = null;
 
    // Tracks compaction boundaries — context handler skips scanning when no
    // compaction has occurred since last injection.
@@ -464,6 +507,16 @@ export default function(pi: ExtensionAPI): void {
       return key;
    };
 
+   const getTaskContext = (taskDir: string, root: string): string => {
+      const signature = taskContextSignature(root, taskDir, agentType);
+      if (taskContextCache?.projectRoot === root && taskContextCache.taskDir === taskDir && taskContextCache.agentType === agentType && taskContextCache.signature === signature) {
+         return taskContextCache.content;
+      }
+      const content = buildTaskContext(root, taskDir, agentType);
+      taskContextCache = { projectRoot: root, taskDir, agentType, signature, content };
+      return content;
+   };
+
    pi.on("session_start", async (_event, ctx) => {
       projectRoot = findProjectRoot(ctx.cwd);
       const contextKey = rememberContextKey(ctx);
@@ -474,7 +527,7 @@ export default function(pi: ExtensionAPI): void {
          // Sub-agent: inject precise task context once
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = buildTaskContext(projectRoot, taskDir, agentType);
+            const taskContext = getTaskContext(taskDir, projectRoot);
             if (taskContext) {
                await pi.sendMessage({
                   customType: "trellis-task-context",
@@ -496,7 +549,7 @@ export default function(pi: ExtensionAPI): void {
 
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = buildTaskContext(projectRoot, taskDir);
+            const taskContext = getTaskContext(taskDir, projectRoot);
             if (taskContext) {
                await pi.sendMessage({
                   customType: "trellis-task-context",
@@ -541,25 +594,49 @@ export default function(pi: ExtensionAPI): void {
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
 
-      // Fast path: no compaction since last injection — message is still present
-      if (lastInjectionTs > lastCompactionTs) return;
+      const messages = event.messages as { role?: string; customType?: string; content?: string }[];
+      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+      const currentTaskContext = taskDir ? getTaskContext(taskDir, projectRoot) : "";
+      const taskContextIndexes = messages
+         .map((message, index) => message.customType === "trellis-task-context" ? index : -1)
+         .filter((index) => index >= 0);
+      const existingTaskContext = taskContextIndexes.length > 0
+         ? messages[taskContextIndexes[0]]?.content ?? ""
+         : "";
+      const taskContextChanged = existingTaskContext !== currentTaskContext || taskContextIndexes.length > 1;
+      let projectedMessages = messages;
+      if (taskContextChanged) {
+         const replacement = currentTaskContext
+            ? { role: "custom" as const, customType: "trellis-task-context", content: currentTaskContext, display: false, timestamp: Date.now() }
+            : null;
+         let replaced = false;
+         projectedMessages = messages.flatMap((message) => {
+            if (message.customType !== "trellis-task-context") return [message];
+            if (replaced || !replacement) return [];
+            replaced = true;
+            return [replacement];
+         });
+         if (replacement && !replaced) projectedMessages.push(replacement);
+      }
+
+      // Fast path: no task change and no compaction — all persisted context is current.
+      if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
 
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) return;
+      if (!cached.workflowMsg) return taskContextChanged ? { messages: projectedMessages } : undefined;
 
       // Post-compaction: reverse-scan to confirm absence before injecting
-      const messages = event.messages as { role?: string; customType?: string }[];
-      for (let i = messages.length - 1; i >= 0; i--) {
-         if (messages[i].role === "custom" && messages[i].customType === "trellis-workflow-state") {
+      for (let i = projectedMessages.length - 1; i >= 0; i--) {
+         if (projectedMessages[i].role === "custom" && projectedMessages[i].customType === "trellis-workflow-state") {
             lastInjectionTs = Date.now();
-            return;
+            return taskContextChanged ? { messages: projectedMessages } : undefined;
          }
       }
 
       lastInjectionTs = Date.now();
       return {
          messages: [
-            ...event.messages,
+            ...projectedMessages,
             {
                role: "custom" as const,
                customType: "trellis-workflow-state",

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join, dirname, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -282,6 +282,49 @@ function buildSessionContext(projectRoot: string, contextKey: string | null): st
 
 type AgentType = "trellis-implement" | "trellis-check" | "trellis-research" | null;
 
+function taskContextJsonlNames(agentType?: AgentType): string[] {
+   if (agentType === "trellis-implement") return ["implement.jsonl"];
+   if (agentType === "trellis-check") return ["check.jsonl"];
+   if (agentType === "trellis-research") return [];
+   return ["implement.jsonl", "check.jsonl"];
+}
+
+function taskContextInputPaths(projectRoot: string, taskDir: string, agentType?: AgentType): string[] {
+   const trustedRoots = resolveTrustedRoots(projectRoot);
+   const paths = new Set<string>([join(taskDir, "prd.md"), join(taskDir, "info.md")]);
+   for (const jsonlName of taskContextJsonlNames(agentType)) {
+      const jsonlPath = join(taskDir, jsonlName);
+      paths.add(jsonlPath);
+      if (!existsSync(jsonlPath)) continue;
+      let lines: string[];
+      try { lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/); } catch { continue; }
+      for (const line of lines) {
+         try {
+            const row = JSON.parse(line.trim()) as Record<string, unknown>;
+            const file = typeof row.file === "string" ? row.file.trim() : "";
+            const candidatePath = file ? resolve(projectRoot, file) : "";
+            if (candidatePath && isInsideRoot(resolve(projectRoot), candidatePath)) paths.add(candidatePath);
+            const targetPath = file ? resolveProjectFile(projectRoot, file, trustedRoots) : null;
+            if (targetPath) paths.add(targetPath);
+         } catch {
+            // Seed rows and malformed lines do not contribute referenced files.
+         }
+      }
+   }
+   return [...paths];
+}
+
+function taskContextSignature(projectRoot: string, taskDir: string, agentType?: AgentType): string {
+   return taskContextInputPaths(projectRoot, taskDir, agentType).map((filePath) => {
+      try {
+         const stat = statSync(filePath);
+         return `${filePath}:${stat.mtimeMs}:${stat.ctimeMs}:${stat.size}`;
+      } catch {
+         return `${filePath}:missing`;
+      }
+   }).join("\n");
+}
+
 function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
    const parts: string[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
@@ -298,16 +341,7 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    if (info.trim()) parts.push(`## Info\n\n${info.trim()}`);
 
    // Determine which jsonl files to read based on agent type
-   let jsonlNames: string[];
-   if (agentType === "trellis-implement") {
-      jsonlNames = ["implement.jsonl"];
-   } else if (agentType === "trellis-check") {
-      jsonlNames = ["check.jsonl"];
-   } else if (agentType === "trellis-research") {
-      jsonlNames = []; // research agent gets only prd + info
-   } else {
-      jsonlNames = ["implement.jsonl", "check.jsonl"]; // main session: all
-   }
+   const jsonlNames = taskContextJsonlNames(agentType);
 
    // A file may be referenced by both manifests. Use the resolved real path so
    // relative aliases and symlinked paths cannot consume the context budget twice.
@@ -443,6 +477,14 @@ function detectAgentType(): AgentType {
    return null;
 }
 
+interface TaskContextCache {
+   projectRoot: string;
+   taskDir: string;
+   agentType: AgentType;
+   signature: string;
+   content: string;
+}
+
 // ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
@@ -452,6 +494,7 @@ export default function(pi: ExtensionAPI): void {
    const turnCache = new TurnContextCache();
    const agentType = detectAgentType();
    const isSubAgent = agentType !== null;
+   let taskContextCache: TaskContextCache | null = null;
 
    // Tracks compaction boundaries — context handler skips scanning when no
    // compaction has occurred since last injection.
@@ -464,6 +507,16 @@ export default function(pi: ExtensionAPI): void {
       return key;
    };
 
+   const getTaskContext = (taskDir: string, root: string): string => {
+      const signature = taskContextSignature(root, taskDir, agentType);
+      if (taskContextCache?.projectRoot === root && taskContextCache.taskDir === taskDir && taskContextCache.agentType === agentType && taskContextCache.signature === signature) {
+         return taskContextCache.content;
+      }
+      const content = buildTaskContext(root, taskDir, agentType);
+      taskContextCache = { projectRoot: root, taskDir, agentType, signature, content };
+      return content;
+   };
+
    pi.on("session_start", async (_event, ctx) => {
       projectRoot = findProjectRoot(ctx.cwd);
       const contextKey = rememberContextKey(ctx);
@@ -474,7 +527,7 @@ export default function(pi: ExtensionAPI): void {
          // Sub-agent: inject precise task context once
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = buildTaskContext(projectRoot, taskDir, agentType);
+            const taskContext = getTaskContext(taskDir, projectRoot);
             if (taskContext) {
                await pi.sendMessage({
                   customType: "trellis-task-context",
@@ -496,7 +549,7 @@ export default function(pi: ExtensionAPI): void {
 
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = buildTaskContext(projectRoot, taskDir);
+            const taskContext = getTaskContext(taskDir, projectRoot);
             if (taskContext) {
                await pi.sendMessage({
                   customType: "trellis-task-context",
@@ -541,25 +594,49 @@ export default function(pi: ExtensionAPI): void {
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
 
-      // Fast path: no compaction since last injection — message is still present
-      if (lastInjectionTs > lastCompactionTs) return;
+      const messages = event.messages as { role?: string; customType?: string; content?: string }[];
+      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+      const currentTaskContext = taskDir ? getTaskContext(taskDir, projectRoot) : "";
+      const taskContextIndexes = messages
+         .map((message, index) => message.customType === "trellis-task-context" ? index : -1)
+         .filter((index) => index >= 0);
+      const existingTaskContext = taskContextIndexes.length > 0
+         ? messages[taskContextIndexes[0]]?.content ?? ""
+         : "";
+      const taskContextChanged = existingTaskContext !== currentTaskContext || taskContextIndexes.length > 1;
+      let projectedMessages = messages;
+      if (taskContextChanged) {
+         const replacement = currentTaskContext
+            ? { role: "custom" as const, customType: "trellis-task-context", content: currentTaskContext, display: false, timestamp: Date.now() }
+            : null;
+         let replaced = false;
+         projectedMessages = messages.flatMap((message) => {
+            if (message.customType !== "trellis-task-context") return [message];
+            if (replaced || !replacement) return [];
+            replaced = true;
+            return [replacement];
+         });
+         if (replacement && !replaced) projectedMessages.push(replacement);
+      }
+
+      // Fast path: no task change and no compaction — all persisted context is current.
+      if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
 
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) return;
+      if (!cached.workflowMsg) return taskContextChanged ? { messages: projectedMessages } : undefined;
 
       // Post-compaction: reverse-scan to confirm absence before injecting
-      const messages = event.messages as { role?: string; customType?: string }[];
-      for (let i = messages.length - 1; i >= 0; i--) {
-         if (messages[i].role === "custom" && messages[i].customType === "trellis-workflow-state") {
+      for (let i = projectedMessages.length - 1; i >= 0; i--) {
+         if (projectedMessages[i].role === "custom" && projectedMessages[i].customType === "trellis-workflow-state") {
             lastInjectionTs = Date.now();
-            return;
+            return taskContextChanged ? { messages: projectedMessages } : undefined;
          }
       }
 
       lastInjectionTs = Date.now();
       return {
          messages: [
-            ...event.messages,
+            ...projectedMessages,
             {
                role: "custom" as const,
                customType: "trellis-workflow-state",

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
@@ -252,6 +253,74 @@ describe("omp templates", () => {
         1,
       );
       expect(taskContext?.content).toContain("check-only context body");
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes task context when a referenced file changes mid-session", async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-omp-refresh-"));
+    const taskDir = path.join(projectRoot, ".trellis", "tasks", "demo-task");
+    const sessionsDir = path.join(projectRoot, ".trellis", ".runtime", "sessions");
+    const referencedFile = path.join(projectRoot, "docs", "changing.md");
+    const messages: { customType?: string; content?: string }[] = [];
+
+    try {
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.dirname(referencedFile), { recursive: true });
+      fs.writeFileSync(path.join(taskDir, "task.json"), JSON.stringify({ status: "in_progress" }));
+      fs.writeFileSync(referencedFile, "old context body");
+      fs.writeFileSync(
+        path.join(taskDir, "implement.jsonl"),
+        `${JSON.stringify({ file: "docs/changing.md" })}\n${JSON.stringify({ file: "docs/created-later.md" })}\n`,
+      );
+      fs.writeFileSync(
+        path.join(sessionsDir, "omp_session_refresh.json"),
+        JSON.stringify({ current_task: ".trellis/tasks/demo-task" }),
+      );
+
+      const handlers = new Map<string, OmpEventHandler>();
+      loadOmpExtension()({
+        on: (event, handler) => handlers.set(event, handler),
+        sendMessage: async (message) => messages.push(message as { customType?: string; content?: string }),
+      });
+      const sessionStart = handlers.get("session_start");
+      const context = handlers.get("context");
+      if (!sessionStart || !context) throw new Error("OMP extension did not register required handlers");
+      const ctx = {
+        cwd: projectRoot,
+        sessionManager: { getSessionId: () => "session/refresh" },
+        ui: { notify: () => undefined },
+      };
+
+      await sessionStart({}, ctx);
+      const initial = messages.find((message) => message.customType === "trellis-task-context");
+      expect(initial?.content).toContain("old context body");
+      expect(initial?.content).not.toContain("created later body");
+
+      fs.writeFileSync(referencedFile, "new context body");
+      fs.writeFileSync(path.join(projectRoot, "docs", "created-later.md"), "created later body");
+      const result = await context(
+        {
+          messages: [
+            { role: "custom", customType: "trellis-task-context", content: initial?.content },
+            { role: "custom", customType: "trellis-workflow-state", content: "workflow" },
+          ],
+        },
+        ctx,
+      ) as { messages?: { customType?: string; content?: string }[] } | undefined;
+
+      const refreshed = result?.messages?.filter(
+        (message) => message.customType === "trellis-task-context",
+      ) ?? [];
+      expect(refreshed).toHaveLength(1);
+      expect(refreshed[0]?.content).toContain("new context body");
+      expect(refreshed[0]?.content).toContain("created later body");
+      expect(refreshed[0]?.content).not.toContain("old context body");
+
+      const unchanged = await context({ messages: result?.messages }, ctx);
+      expect(unchanged).toBeUndefined();
     } finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
     }

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -299,7 +299,7 @@ describe("omp templates", () => {
       expect(initial?.content).toContain("old context body");
       expect(initial?.content).not.toContain("created later body");
 
-      fs.writeFileSync(referencedFile, "new context body");
+      fs.writeFileSync(referencedFile, "new context body with changed size");
       fs.writeFileSync(path.join(projectRoot, "docs", "created-later.md"), "created later body");
       const result = await context(
         {
@@ -315,7 +315,7 @@ describe("omp templates", () => {
         (message) => message.customType === "trellis-task-context",
       ) ?? [];
       expect(refreshed).toHaveLength(1);
-      expect(refreshed[0]?.content).toContain("new context body");
+      expect(refreshed[0]?.content).toContain("new context body with changed size");
       expect(refreshed[0]?.content).toContain("created later body");
       expect(refreshed[0]?.content).not.toContain("old context body");
 


### PR DESCRIPTION
## 摘要

修复 OMP 会话启动后任务上下文不随文件修改刷新的问题。

## 背景

OMP 原先只在 `session_start` 时读取当前 task 的 `prd.md`、`info.md` 以及 manifest 引用的文件，并通过持久化的 `trellis-task-context` 消息注入。会话继续后，文件即使已经更新，模型仍可能看到启动时的旧快照，与工具读取到的新文件冲突。

## 实现

- 为 task context 建立输入文件签名，包含 `mtime`、`ctime` 和大小。
- 未发生变化时复用当前会话内的上下文缓存，不重复读取和投影。
- 发现 task artifact、JSONL manifest 或引用文件变化时，重新构建 task context。
- 在 OMP 的 `context` 投影阶段替换旧的 `trellis-task-context`，避免把新旧正文同时发送给模型。
- 支持启动时缺失、会话中后来创建的 manifest 引用文件。
- 同步更新 OMP 项目扩展与 CLI 安装模板。

## 测试

- OMP 模板定向测试：`14/14` 通过。
- Core 测试：`344` 通过，`1` 个跳过项。
- CLI 完整测试：`1672/1672` 通过。
- lint、typecheck、build 和 `git diff --check` 已通过。

## 关联

关联 Issue #533。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task context now refreshes automatically when referenced files change or new files are added.
  * Stale or duplicate task-context messages are replaced or removed.
  * Updated context is consistently applied across main sessions and sub-agent sessions.
  * Workflow state remains available after context compaction.
  * Unchanged context is no longer unnecessarily reinjected, improving session efficiency.
  * Task context is removed cleanly when the active task is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->