### PR TITLE
fix(channel): drain stdout before supervisor exit

### DIFF
--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -29,7 +29,10 @@ import { workerFile } from "./store/paths.js";
 import { scheduleSupervisorIdleTimer } from "./supervisor/idle.js";
 import { runInboxWatcher } from "./supervisor/inbox.js";
 import { createShutdown, type ShutdownReason } from "./supervisor/shutdown.js";
-import { startStdoutPump } from "./supervisor/stdout.js";
+import {
+  createStdoutDrainControl,
+  startStdoutPump,
+} from "./supervisor/stdout.js";
 import { TurnTracker } from "./supervisor/turns.js";
 import { scheduleSupervisorTimeoutWarning } from "./supervisor/warning.js";
 
@@ -239,15 +242,7 @@ export async function runSupervisor(
       : {}),
   });
 
-  let resolveStdoutReady!: (processLines: boolean) => void;
-  const stdoutReady = new Promise<boolean>((resolve) => {
-    resolveStdoutReady = resolve;
-  });
-  const stdoutDrainAbort = new AbortController();
-  const abortStdoutDrain = (): void => {
-    resolveStdoutReady(false);
-    stdoutDrainAbort.abort();
-  };
+  const stdoutDrain = createStdoutDrainControl();
   const idleTimerRef: {
     current?: ReturnType<typeof scheduleSupervisorIdleTimer>;
   } = {};
@@ -269,8 +264,8 @@ export async function runSupervisor(
     log,
     shutdown,
     turnTracker,
-    processLines: stdoutReady,
-    signal: stdoutDrainAbort.signal,
+    processLines: stdoutDrain.processLines,
+    signal: stdoutDrain.signal,
   });
 
   // Gate the `spawned` event behind whichever child lifecycle event fires
@@ -307,7 +302,7 @@ export async function runSupervisor(
       // `exit` event that Node won't deliver.
       spawnFailed = true;
       settleSpawn();
-      abortStdoutDrain();
+      stdoutDrain.discard();
       void (async () => {
         try {
           await appendEvent(
@@ -363,7 +358,7 @@ export async function runSupervisor(
     void finalizeSupervisorExit({
       stdoutDrained,
       drainTimeoutMs: SHUTDOWN_GRACE_MS,
-      abortStdoutDrain,
+      abortStdoutDrain: stdoutDrain.abortReading,
       onDrainTimeout: () =>
         log.write(
           `[supervisor] stdout did not close within ${SHUTDOWN_GRACE_MS}ms; draining buffered lines and exiting\n`,
@@ -396,14 +391,14 @@ export async function runSupervisor(
   // off cleanup and can bail cleanly.
   await spawnSettled;
   if (spawnFailed) {
-    abortStdoutDrain();
+    stdoutDrain.discard();
     return;
   }
   // Codex #3 fix: if a signal/timeout requested shutdown while we were
   // waiting for spawn-settled, don't write a misleading `spawned` event;
   // let the in-flight `killed` append complete and bail.
   if (shutdown.isShuttingDown()) {
-    abortStdoutDrain();
+    stdoutDrain.discard();
     await shutdown.awaitFinalize();
     return;
   }
@@ -434,7 +429,7 @@ export async function runSupervisor(
       project,
     );
   } catch (err) {
-    abortStdoutDrain();
+    stdoutDrain.discard();
     throw err;
   }
 
@@ -449,7 +444,7 @@ export async function runSupervisor(
     log,
   });
   process.on("exit", () => idleTimerRef.current?.cancel());
-  resolveStdoutReady(true);
+  stdoutDrain.allowProcessing();
 
   // ── timeout guard (anti-zombie) ──
   if (config.timeoutMs && config.timeoutMs > 0) {

--- a/packages/cli/src/commands/channel/supervisor.ts
+++ b/packages/cli/src/commands/channel/supervisor.ts
@@ -84,6 +84,38 @@ interface ResolvedProviderPath {
 }
 
 /**
+ * Drain worker stdout before synthesising terminal state and removing the
+ * supervisor's runtime files.
+ */
+export async function finalizeSupervisorExit(args: {
+  stdoutDrained: Promise<void>;
+  drainTimeoutMs: number;
+  abortStdoutDrain: () => void;
+  onDrainTimeout?: () => void;
+  finalizeOnExit: () => Promise<void>;
+  cleanup: () => Promise<void>;
+  exit: () => void;
+}): Promise<void> {
+  const timer = setTimeout(() => {
+    try {
+      args.onDrainTimeout?.();
+    } catch {
+      // Logging must not prevent supervisor teardown.
+    }
+    try {
+      args.abortStdoutDrain();
+    } catch {
+      // Continue teardown even if the drain abort hook fails.
+    }
+  }, args.drainTimeoutMs);
+  await args.stdoutDrained.catch(() => undefined);
+  clearTimeout(timer);
+  await args.finalizeOnExit().catch(() => undefined);
+  await args.cleanup().catch(() => undefined);
+  args.exit();
+}
+
+/**
  * Resolve the real launch target for npm `.cmd` shims on Windows.
  *
  * @param provider CLI basename for the provider, such as `codex` or `claude`.
@@ -207,6 +239,40 @@ export async function runSupervisor(
       : {}),
   });
 
+  let resolveStdoutReady!: (processLines: boolean) => void;
+  const stdoutReady = new Promise<boolean>((resolve) => {
+    resolveStdoutReady = resolve;
+  });
+  const stdoutDrainAbort = new AbortController();
+  const abortStdoutDrain = (): void => {
+    resolveStdoutReady(false);
+    stdoutDrainAbort.abort();
+  };
+  const idleTimerRef: {
+    current?: ReturnType<typeof scheduleSupervisorIdleTimer>;
+  } = {};
+  const turnTracker = new TurnTracker({
+    onIdleExit: () => idleTimerRef.current?.pause(),
+    onIdleEnter: () => idleTimerRef.current?.reset(),
+  });
+
+  // Attach before any await. Node drains unread child stdio after `exit`, so
+  // attaching only after the durable `spawned` append can silently discard a
+  // fast worker's final output. Line processing stays gated until `spawned`
+  // is durable, preserving event-log order.
+  const stdoutDrained = startStdoutPump({
+    channelName,
+    workerName,
+    child,
+    adapter,
+    adapterCtx,
+    log,
+    shutdown,
+    turnTracker,
+    processLines: stdoutReady,
+    signal: stdoutDrainAbort.signal,
+  });
+
   // Gate the `spawned` event behind whichever child lifecycle event fires
   // first: `spawn` (success) or `error` (launch failure, e.g. ENOENT).
   // Without this gate the post-spawn path writes `spawned` even when the
@@ -241,6 +307,7 @@ export async function runSupervisor(
       // `exit` event that Node won't deliver.
       spawnFailed = true;
       settleSpawn();
+      abortStdoutDrain();
       void (async () => {
         try {
           await appendEvent(
@@ -293,11 +360,18 @@ export async function runSupervisor(
     // adapter never produced one (otherwise `wait --kind done` hangs),
     // and await any in-flight `killed` append from a concurrent shutdown
     // before exiting so the event doesn't race the process death.
-    void (async () => {
-      await shutdown.finalizeOnExit(code, sig).catch(() => undefined);
-      await cleanup(channelName, workerName).catch(() => undefined);
-      process.exit(0);
-    })();
+    void finalizeSupervisorExit({
+      stdoutDrained,
+      drainTimeoutMs: SHUTDOWN_GRACE_MS,
+      abortStdoutDrain,
+      onDrainTimeout: () =>
+        log.write(
+          `[supervisor] stdout did not close within ${SHUTDOWN_GRACE_MS}ms; draining buffered lines and exiting\n`,
+        ),
+      finalizeOnExit: () => shutdown.finalizeOnExit(code, sig),
+      cleanup: () => cleanup(channelName, workerName),
+      exit: () => process.exit(0),
+    });
   });
 
   // Signal handlers MUST be registered before any await so a SIGTERM
@@ -321,67 +395,61 @@ export async function runSupervisor(
   // so reaching this point with `spawnFailed=true` means we already kicked
   // off cleanup and can bail cleanly.
   await spawnSettled;
-  if (spawnFailed) return;
+  if (spawnFailed) {
+    abortStdoutDrain();
+    return;
+  }
   // Codex #3 fix: if a signal/timeout requested shutdown while we were
   // waiting for spawn-settled, don't write a misleading `spawned` event;
   // let the in-flight `killed` append complete and bail.
   if (shutdown.isShuttingDown()) {
+    abortStdoutDrain();
     await shutdown.awaitFinalize();
     return;
   }
 
-  fs.writeFileSync(
-    workerFile(channelName, workerName, "worker-pid", project),
-    String(child.pid),
-  );
+  try {
+    fs.writeFileSync(
+      workerFile(channelName, workerName, "worker-pid", project),
+      String(child.pid),
+    );
 
-  await appendEvent(
-    channelName,
-    {
-      kind: "spawned",
-      by: config.spawnedBy ?? "main",
-      as: workerName,
-      provider: config.provider,
-      pid: child.pid,
-      inboxPolicy: config.inboxPolicy ?? DEFAULT_INBOX_POLICY,
-      ...(config.agent ? { agent: config.agent } : {}),
-      ...(config.contextFiles && config.contextFiles.length > 0
-        ? { files: config.contextFiles }
-        : {}),
-      ...(config.contextManifests && config.contextManifests.length > 0
-        ? { manifests: config.contextManifests }
-        : {}),
-    },
-    project,
-  );
+    await appendEvent(
+      channelName,
+      {
+        kind: "spawned",
+        by: config.spawnedBy ?? "main",
+        as: workerName,
+        provider: config.provider,
+        pid: child.pid,
+        inboxPolicy: config.inboxPolicy ?? DEFAULT_INBOX_POLICY,
+        ...(config.agent ? { agent: config.agent } : {}),
+        ...(config.contextFiles && config.contextFiles.length > 0
+          ? { files: config.contextFiles }
+          : {}),
+        ...(config.contextManifests && config.contextManifests.length > 0
+          ? { manifests: config.contextManifests }
+          : {}),
+      },
+      project,
+    );
+  } catch (err) {
+    abortStdoutDrain();
+    throw err;
+  }
 
   // OOM-guard idle timer: start only after `spawned` is durable. Hooks
   // wired through the TurnTracker pause it mid-turn and reset it on
   // turn finish / interrupted (the same transitions that drive durable
   // `idleSince`). `<=0` short-circuits the timer to a no-op.
-  const idleTimer = scheduleSupervisorIdleTimer({
+  idleTimerRef.current = scheduleSupervisorIdleTimer({
     idleTimeoutMs: config.idleTimeoutMs ?? 0,
     shutdown,
     isChildExited: () => child.exitCode !== null || child.signalCode !== null,
     log,
   });
-  const turnTracker = new TurnTracker({
-    onIdleExit: () => idleTimer.pause(),
-    onIdleEnter: () => idleTimer.reset(),
-  });
-  process.on("exit", () => idleTimer.cancel());
-
-  // ── 1. stdout reader ──
-  startStdoutPump({
-    channelName,
-    workerName,
-    child,
-    adapter,
-    adapterCtx,
-    log,
-    shutdown,
-    turnTracker,
-  });
+  process.on("exit", () => idleTimerRef.current?.cancel());
+  resolveStdoutReady(true);
 
   // ── timeout guard (anti-zombie) ──
   if (config.timeoutMs && config.timeoutMs > 0) {

--- a/packages/cli/src/commands/channel/supervisor/stdout.ts
+++ b/packages/cli/src/commands/channel/supervisor/stdout.ts
@@ -24,6 +24,39 @@ import type { TurnOutcome, TurnTracker } from "./turns.js";
 type Child = ChildProcessByStdio<Writable, Readable, Readable>;
 
 /**
+ * Coordinate early stdout capture with the durable `spawned` event.
+ *
+ * Startup failures discard captured lines because no `spawned` event exists.
+ * Normal shutdown may stop waiting for inherited pipe owners, but must leave
+ * the processing decision to the in-flight `spawned` append so stdout events
+ * can never overtake it in events.jsonl.
+ */
+export function createStdoutDrainControl(): {
+  processLines: Promise<boolean>;
+  signal: AbortSignal;
+  allowProcessing: () => void;
+  discard: () => void;
+  abortReading: () => void;
+} {
+  let resolveProcessLines!: (processLines: boolean) => void;
+  const processLines = new Promise<boolean>((resolve) => {
+    resolveProcessLines = resolve;
+  });
+  const controller = new AbortController();
+
+  return {
+    processLines,
+    signal: controller.signal,
+    allowProcessing: () => resolveProcessLines(true),
+    discard: () => {
+      resolveProcessLines(false);
+      controller.abort();
+    },
+    abortReading: () => controller.abort(),
+  };
+}
+
+/**
  * 按行读取 stdout，并把非空行串行交给 onLine
  *
  * @param stream 子进程 stdout 可读流

--- a/packages/cli/src/commands/channel/supervisor/stdout.ts
+++ b/packages/cli/src/commands/channel/supervisor/stdout.ts
@@ -29,17 +29,20 @@ type Child = ChildProcessByStdio<Writable, Readable, Readable>;
  * @param stream 子进程 stdout 可读流
  * @param onLine stdout 单行处理器，按读取顺序串行执行
  * @param onError onLine 抛错时的错误处理器，也在同一队列中执行
- * @returns 无返回值
+ * @param signal 中止等待并排空已读取内容的可选信号
+ * @returns stdout 结束且所有已排队行处理完成后 resolved 的 Promise
  */
 export function pumpStdout(
   stream: Readable,
   onLine: (line: string) => Promise<void> | void,
   onError?: (err: Error) => Promise<void> | void,
-): void {
+  signal?: AbortSignal,
+): Promise<void> {
   let buf = "";
   let queue: Promise<void> = Promise.resolve();
   let pending = 0;
   let paused = false;
+  let finished = false;
 
   /**
    * 在有待处理行时暂停 stdout 读取
@@ -96,7 +99,7 @@ export function pumpStdout(
       .catch(() => undefined);
   };
 
-  stream.on("data", (chunk: Buffer) => {
+  const onData = (chunk: Buffer): void => {
     buf += chunk.toString("utf-8");
     let nl: number;
     while ((nl = buf.indexOf("\n")) !== -1) {
@@ -106,7 +109,41 @@ export function pumpStdout(
         enqueue(line);
       }
     }
+  };
+
+  let resolveFinished!: () => void;
+  const streamFinished = new Promise<void>((resolve) => {
+    resolveFinished = resolve;
   });
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    stream.off("data", onData);
+    stream.off("end", finish);
+    stream.off("close", finish);
+    signal?.removeEventListener("abort", finish);
+    if (buf.trim()) {
+      enqueue(buf);
+    }
+    buf = "";
+    resolveFinished();
+  };
+
+  stream.on("data", onData);
+  stream.once("end", finish);
+  stream.once("close", finish);
+  signal?.addEventListener("abort", finish, { once: true });
+
+  if (
+    signal?.aborted ||
+    stream.readableEnded ||
+    stream.closed ||
+    stream.destroyed
+  ) {
+    queueMicrotask(finish);
+  }
+
+  return streamFinished.then(() => queue);
 }
 
 /**
@@ -191,7 +228,9 @@ export function startStdoutPump(args: {
   log: { write: (data: string) => void };
   shutdown: ShutdownController;
   turnTracker?: TurnTracker;
-}): void {
+  processLines?: Promise<boolean>;
+  signal?: AbortSignal;
+}): Promise<void> {
   const {
     channelName,
     workerName,
@@ -201,10 +240,13 @@ export function startStdoutPump(args: {
     log,
     shutdown,
     turnTracker,
+    processLines,
+    signal,
   } = args;
-  pumpStdout(
+  const drained = pumpStdout(
     child.stdout,
     async (line: string) => {
+      if (processLines && !(await processLines)) return;
       log.write(line + "\n");
       const result = adapter.parseLine(line, adapterCtx);
       await applyParseResult(
@@ -224,5 +266,9 @@ export function startStdoutPump(args: {
         message: `stdout pipeline error: ${err.message}`,
       }).catch(() => undefined);
     },
+    signal,
   );
+  return processLines
+    ? Promise.all([drained, processLines]).then(() => undefined)
+    : drained;
 }

--- a/packages/cli/test/commands/channel.test.ts
+++ b/packages/cli/test/commands/channel.test.ts
@@ -19,6 +19,7 @@ import { finalizeSupervisorExit } from "../../src/commands/channel/supervisor.js
 import { runInboxWatcher } from "../../src/commands/channel/supervisor/inbox.js";
 import {
   applyParseResult,
+  createStdoutDrainControl,
   pumpStdout,
   startStdoutPump,
 } from "../../src/commands/channel/supervisor/stdout.js";
@@ -637,25 +638,39 @@ describe("channel stdout pump", () => {
     expect(settled).toBe(true);
   });
 
-  it("bounds an inherited stdout handle and drains its buffered tail", async () => {
-    const stream = new PassThrough();
-    const controller = new AbortController();
+  it("bounds an inherited stdout handle without bypassing the processing gate", async () => {
+    const control = createStdoutDrainControl();
+    const stdout = new PassThrough();
     const order: string[] = [];
-    const stdoutDrained = pumpStdout(
-      stream,
-      (line) => {
-        order.push(`line:${line}`);
-      },
-      undefined,
-      controller.signal,
-    );
-    stream.write("captured-tail");
+    const adapter = {
+      parseLine: vi.fn(() => ({ events: [] })),
+    };
+    const stdoutDrained = startStdoutPump({
+      channelName: "inherited-output",
+      workerName: "worker",
+      child: { stdout } as never,
+      adapter: adapter as never,
+      adapterCtx: undefined,
+      log: { write: (data) => order.push(`line:${data.trimEnd()}`) },
+      shutdown: { markTerminalEmitted: noop } as never,
+      processLines: control.processLines,
+      signal: control.signal,
+    });
+    stdout.write("captured-line\ncaptured-tail");
 
-    await finalizeSupervisorExit({
+    let timeoutReached!: () => void;
+    const timedOut = new Promise<void>((resolve) => {
+      timeoutReached = resolve;
+    });
+
+    const finalized = finalizeSupervisorExit({
       stdoutDrained,
       drainTimeoutMs: 10,
-      abortStdoutDrain: () => controller.abort(),
-      onDrainTimeout: () => order.push("timeout"),
+      abortStdoutDrain: control.abortReading,
+      onDrainTimeout: () => {
+        order.push("timeout");
+        timeoutReached();
+      },
       finalizeOnExit: async () => {
         order.push("finalize");
       },
@@ -666,15 +681,56 @@ describe("channel stdout pump", () => {
         order.push("exit");
       },
     });
-    stream.destroy();
+
+    await timedOut;
+    expect(order).toEqual(["timeout"]);
+
+    // The timeout stops waiting for inherited pipe owners, but line handling
+    // must still wait until the durable `spawned` event releases the gate.
+    control.allowProcessing();
+    await finalized;
+    stdout.destroy();
 
     expect(order).toEqual([
       "timeout",
+      "line:captured-line",
       "line:captured-tail",
       "finalize",
       "cleanup",
       "exit",
     ]);
+    expect(adapter.parseLine.mock.calls.map(([line]) => line)).toEqual([
+      "captured-line",
+      "captured-tail",
+    ]);
+  });
+
+  it("discards captured stdout when startup never becomes durable", async () => {
+    const control = createStdoutDrainControl();
+    const stdout = new PassThrough();
+    const logged: string[] = [];
+    const adapter = {
+      parseLine: vi.fn(() => ({ events: [] })),
+    };
+    const drained = startStdoutPump({
+      channelName: "failed-startup",
+      workerName: "worker",
+      child: { stdout } as never,
+      adapter: adapter as never,
+      adapterCtx: undefined,
+      log: { write: (data) => logged.push(data) },
+      shutdown: { markTerminalEmitted: noop } as never,
+      processLines: control.processLines,
+      signal: control.signal,
+    });
+    stdout.write("captured-line\ncaptured-tail");
+
+    control.discard();
+    await drained;
+    stdout.destroy();
+
+    expect(logged).toEqual([]);
+    expect(adapter.parseLine).not.toHaveBeenCalled();
   });
 
   it("retains a fast child's output while event processing is gated", async () => {

--- a/packages/cli/test/commands/channel.test.ts
+++ b/packages/cli/test/commands/channel.test.ts
@@ -1,3 +1,5 @@
+import { spawn as spawnChild } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,10 +15,12 @@ import {
 import { channelInterrupt } from "../../src/commands/channel/interrupt.js";
 import { channelMessages } from "../../src/commands/channel/messages.js";
 import { channelSend } from "../../src/commands/channel/send.js";
+import { finalizeSupervisorExit } from "../../src/commands/channel/supervisor.js";
 import { runInboxWatcher } from "../../src/commands/channel/supervisor/inbox.js";
 import {
   applyParseResult,
   pumpStdout,
+  startStdoutPump,
 } from "../../src/commands/channel/supervisor/stdout.js";
 import { TurnTracker } from "../../src/commands/channel/supervisor/turns.js";
 import {
@@ -603,6 +607,136 @@ describe("channel shared helpers", () => {
 });
 
 describe("channel stdout pump", () => {
+  it("waits for the event-processing gate when stdout is empty", async () => {
+    const stdout = new PassThrough();
+    let releaseLines!: (processLines: boolean) => void;
+    const processLines = new Promise<boolean>((resolve) => {
+      releaseLines = resolve;
+    });
+    const drained = startStdoutPump({
+      channelName: "silent-worker",
+      workerName: "worker",
+      child: { stdout } as never,
+      adapter: { parseLine: vi.fn() } as never,
+      adapterCtx: undefined,
+      log: { write: noop },
+      shutdown: { markTerminalEmitted: noop } as never,
+      processLines,
+    });
+    let settled = false;
+    void drained.then(() => {
+      settled = true;
+    });
+
+    stdout.end();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseLines(false);
+    await drained;
+    expect(settled).toBe(true);
+  });
+
+  it("bounds an inherited stdout handle and drains its buffered tail", async () => {
+    const stream = new PassThrough();
+    const controller = new AbortController();
+    const order: string[] = [];
+    const stdoutDrained = pumpStdout(
+      stream,
+      (line) => {
+        order.push(`line:${line}`);
+      },
+      undefined,
+      controller.signal,
+    );
+    stream.write("captured-tail");
+
+    await finalizeSupervisorExit({
+      stdoutDrained,
+      drainTimeoutMs: 10,
+      abortStdoutDrain: () => controller.abort(),
+      onDrainTimeout: () => order.push("timeout"),
+      finalizeOnExit: async () => {
+        order.push("finalize");
+      },
+      cleanup: async () => {
+        order.push("cleanup");
+      },
+      exit: () => {
+        order.push("exit");
+      },
+    });
+    stream.destroy();
+
+    expect(order).toEqual([
+      "timeout",
+      "line:captured-tail",
+      "finalize",
+      "cleanup",
+      "exit",
+    ]);
+  });
+
+  it("retains a fast child's output while event processing is gated", async () => {
+    const controller = new AbortController();
+    const child = spawnChild(
+      process.execPath,
+      ["-e", 'process.stdout.write("first\\nfinal-without-newline")'],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    let releaseLines!: (processLines: boolean) => void;
+    const processLines = new Promise<boolean>((resolve) => {
+      releaseLines = resolve;
+    });
+    const logged: string[] = [];
+    const adapter = {
+      parseLine: vi.fn(() => ({ events: [] })),
+    };
+
+    const drained = startStdoutPump({
+      channelName: "fast-output",
+      workerName: "worker",
+      child,
+      adapter: adapter as never,
+      adapterCtx: undefined,
+      log: { write: (data) => logged.push(data) },
+      shutdown: { markTerminalEmitted: noop } as never,
+      processLines,
+      signal: controller.signal,
+    });
+    await once(child, "exit");
+
+    expect(logged).toEqual([]);
+    expect(adapter.parseLine).not.toHaveBeenCalled();
+    const teardown: string[] = [];
+    const finalized = finalizeSupervisorExit({
+      stdoutDrained: drained,
+      drainTimeoutMs: 1_000,
+      abortStdoutDrain: () => controller.abort(),
+      finalizeOnExit: async () => {
+        teardown.push("finalize");
+      },
+      cleanup: async () => {
+        teardown.push("cleanup");
+      },
+      exit: () => {
+        teardown.push("exit");
+      },
+    });
+    await Promise.resolve();
+    expect(teardown).toEqual([]);
+
+    releaseLines(true);
+    await finalized;
+
+    expect(logged).toEqual(["first\n", "final-without-newline\n"]);
+    expect(adapter.parseLine.mock.calls.map(([line]) => line)).toEqual([
+      "first",
+      "final-without-newline",
+    ]);
+    expect(teardown).toEqual(["finalize", "cleanup", "exit"]);
+  });
+
   it("serializes high-frequency line handling in input order", async () => {
     const stream = new PassThrough();
     const lines = Array.from({ length: 800 }, (_, i) => `line-${i}`);


### PR DESCRIPTION
## Summary

- attach the worker stdout pump before asynchronous setup while holding event processing until the spawned event is durable
- drain queued lines and a final unterminated tail before terminal fallback and cleanup
- bound inherited stdout handles so supervisor teardown cannot wait indefinitely

Fixes #526

## Verification

- pnpm --filter @mindfoldhq/trellis exec vitest run test/commands/channel.test.ts
- pnpm --filter @mindfoldhq/trellis-core test
- pnpm --filter @mindfoldhq/trellis test
- pnpm build
- pnpm typecheck
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel supervisor shutdown to reliably drain pending output before exiting.
  * Prevented fast or buffered child-process output from being lost during startup and shutdown.
  * Added safeguards for stalled output streams and launch or event-processing failures.
  * Improved cleanup of runtime resources when supervisor operations fail.

* **Tests**
  * Added coverage for buffered output, delayed event processing, and bounded shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->