### PR TITLE
fix(omp): bound Trellis task context injection

### DIFF
--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -311,13 +311,17 @@ function taskContextJsonlNames(agentType?: AgentType): string[] {
 
 function taskContextInputPaths(projectRoot: string, taskDir: string, agentType?: AgentType): string[] {
    const trustedRoots = resolveTrustedRoots(projectRoot);
-   const paths = new Set<string>([join(taskDir, "prd.md"), join(taskDir, "info.md")]);
+   const paths = new Set<string>([
+      join(projectRoot, ".trellis", "config.yaml"),
+      join(taskDir, "prd.md"),
+      join(taskDir, "info.md"),
+   ]);
    for (const jsonlName of taskContextJsonlNames(agentType)) {
       const jsonlPath = join(taskDir, jsonlName);
       paths.add(jsonlPath);
       if (!existsSync(jsonlPath)) continue;
-      let lines: string[];
-      try { lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/); } catch { continue; }
+      const displayPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
+      const { lines } = readJsonlLines(jsonlPath, displayPath);
       for (const line of lines) {
          try {
             const row = JSON.parse(line.trim()) as Record<string, unknown>;

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -413,47 +413,53 @@ function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits
 }
 
 class ContextBudget {
-   used: number;
+   private totalBytesUsed: number;
    private terminalSummaryEmitted = false;
    private stopped = false;
    constructor(private readonly maxTotalBytes: number, initialUsed = 0) {
-      this.used = initialUsed;
+      this.totalBytesUsed = initialUsed;
+   }
+
+   get used(): number {
+      return this.totalBytesUsed;
    }
 
    hasRoom(bytes: number): boolean {
-      return !this.stopped && (this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes);
+      return !this.stopped && (this.maxTotalBytes <= 0 || this.totalBytesUsed + bytes <= this.maxTotalBytes);
    }
 
-   emit(text: string): string {
+   emit(text: string): string | null {
       const bytes = Buffer.byteLength(text, "utf-8");
-      if (!this.hasRoom(bytes)) return "";
-      this.used += bytes;
+      if (!this.hasRoom(bytes)) return null;
+      this.totalBytesUsed += bytes;
       return text;
    }
 
-   emitCandidate(primary: string, fallback: string | null): string {
-      const direct = this.emit(primary);
-      if (direct) return direct;
+   emitCandidate(primary: string | null, fallback: string | null): string | null {
+      if (primary !== null) {
+         const direct = this.emit(primary);
+         if (direct !== null) return direct;
+      }
       if (fallback !== null) {
          const notice = this.emit(fallback);
-         if (notice) return notice;
+         if (notice !== null) return notice;
       }
       return this.emitTerminalSummary();
    }
 
-   private emitTerminalSummary(): string {
-      if (this.terminalSummaryEmitted) return "";
+   private emitTerminalSummary(): string | null {
+      if (this.terminalSummaryEmitted) return null;
       this.terminalSummaryEmitted = true;
       this.stopped = true;
       const summary = "[Trellis: context limit reached; omitted entries remain authoritative on disk and require_read paths above.]";
       if (this.maxTotalBytes <= 0) {
-         this.used += Buffer.byteLength(summary, "utf-8");
+         this.totalBytesUsed += Buffer.byteLength(summary, "utf-8");
          return summary;
       }
-      const remaining = this.maxTotalBytes - this.used;
-      if (remaining <= 0) return "";
+      const remaining = this.maxTotalBytes - this.totalBytesUsed;
+      if (remaining <= 0) return null;
       const bounded = truncateUtf8(Buffer.from(summary, "utf-8"), remaining).toString("utf-8");
-      this.used += Buffer.byteLength(bounded, "utf-8");
+      this.totalBytesUsed += Buffer.byteLength(bounded, "utf-8");
       return bounded;
    }
 }
@@ -481,7 +487,9 @@ function utf8Status(data: Buffer): Utf8Status {
 
       if (index + length > data.length) {
          for (let tail = index + 1; tail < data.length; tail++) {
-            if (data[tail]! < 0x80 || data[tail]! > 0xbf) return "invalid";
+            const min = tail === index + 1 ? secondMin : 0x80;
+            const max = tail === index + 1 ? secondMax : 0xbf;
+            if (data[tail]! < min || data[tail]! > max) return "invalid";
          }
          return "incomplete";
       }
@@ -524,13 +532,23 @@ function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; siz
       // validated before truncateUtf8 removes its incomplete suffix. The
       // descriptor keeps the read bounded if the path is replaced or grows.
       const data = Buffer.allocUnsafe(maxBytes + 4);
-      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const bytesRead = readFully(fd, data);
       return { data: data.subarray(0, bytesRead), size: fstatSync(fd).size };
    } catch {
       return null;
    } finally {
       if (fd !== null) closeSync(fd);
    }
+}
+
+function readFully(fd: number, buffer: Buffer): number {
+   let total = 0;
+   while (total < buffer.length) {
+      const bytesRead = readSync(fd, buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+   }
+   return total;
 }
 
 function omittedNotice(file: string, size: number | null, reason: string): string {
@@ -543,55 +561,28 @@ interface MaterializedFile {
    notice: string;
 }
 
-function materializeFile(
+function materialize(
    targetPath: string,
    displayPath: string,
    reason: string,
-   limits: ContextInjectionLimits,
+   maxBytes: number,
+   kind: "file" | "artifact",
 ): MaterializedFile {
-   const file = readFilePrefix(targetPath, limits.max_file_bytes);
+   const file = readFilePrefix(targetPath, maxBytes);
    if (!file) {
-      return { block: null, notice: omittedNotice(displayPath, null, "file is missing or unreadable") };
+      return { block: null, notice: omittedNotice(displayPath, null, `${kind} is missing or unreadable`) };
    }
    const { data, size } = file;
    const encodingStatus = utf8Status(data);
    if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
-      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`) };
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 ${kind}: ${reason}`) };
    }
-   const truncated = truncateUtf8(data, limits.max_file_bytes);
+   const truncated = truncateUtf8(data, maxBytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
-      content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
-   }
-   return {
-      block: `### ${displayPath} [${status}]\n\n${content}`,
-      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
-   };
-}
-
-function materializeArtifact(
-   targetPath: string,
-   displayPath: string,
-   reason: string,
-   limits: ContextInjectionLimits,
-): MaterializedFile {
-   const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
-   if (!file) {
-      return { block: null, notice: omittedNotice(displayPath, null, "artifact is missing or unreadable") };
-   }
-   const { data, size } = file;
-   const encodingStatus = utf8Status(data);
-   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
-      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`) };
-   }
-   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
-   let content = truncated.toString("utf-8");
-   let status: "inline" | "truncated" = "inline";
-   if (truncated.length < size) {
-      status = "truncated";
-      content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
+      content += `\n[Trellis: truncated at ${maxBytes} bytes — read ${displayPath} for the full content]`;
    }
    return {
       block: `### ${displayPath} [${status}]\n\n${content}`,
@@ -604,7 +595,7 @@ function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string
    try {
       fd = openSync(jsonlPath, "r");
       const data = Buffer.allocUnsafe(MAX_JSONL_BYTES + 1);
-      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const bytesRead = readFully(fd, data);
       const size = fstatSync(fd).size;
       if (bytesRead > MAX_JSONL_BYTES || size > MAX_JSONL_BYTES) {
          return {
@@ -633,30 +624,30 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
    const suffix = "\n</task-context>";
    const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) return "";
    const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
 
-   const emit = (text: string, fallback: string | null = null): string => budget.emitCandidate(text, fallback);
-   const appendCandidate = (primary: string, fallback: string | null = null): void => {
+   const appendCandidate = (primary: string | null, fallback: string | null = null): void => {
       const separator = parts.length > 0 ? "\n\n" : "";
-      const output = emit(
-         primary ? separator + primary : "",
+      const output = budget.emitCandidate(
+         primary === null ? null : separator + primary,
          fallback === null ? null : separator + fallback,
       );
-      if (output) parts.push(output);
+      if (output !== null) parts.push(output);
    };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
    const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
    if (existsSync(prdPath)) {
-      const artifact = materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits);
-      appendCandidate(artifact.block ?? "", artifact.notice);
+      const artifact = materialize(prdPath, relativePrdPath, "Requirements document", limits.max_artifact_bytes, "artifact");
+      appendCandidate(artifact.block, artifact.notice);
    }
    const infoPath = join(taskDir, "info.md");
    const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
    if (existsSync(infoPath)) {
-      const artifact = materializeArtifact(infoPath, relativeInfoPath, "Task information", limits);
-      appendCandidate(artifact.block ?? "", artifact.notice);
+      const artifact = materialize(infoPath, relativeInfoPath, "Task information", limits.max_artifact_bytes, "artifact");
+      appendCandidate(artifact.block, artifact.notice);
    }
 
    // Determine which jsonl files to read based on agent type
@@ -690,15 +681,15 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            const materialized = materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits);
+            const materialized = materialize(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits.max_file_bytes, "file");
             const sectionPrefix = sectionHeaderEmitted
                ? "\n\n---\n\n"
                : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
-            const output = emit(
-               materialized.block ? `${sectionPrefix}${materialized.block}` : "",
+            const output = budget.emitCandidate(
+               materialized.block === null ? null : `${sectionPrefix}${materialized.block}`,
                `${sectionPrefix}${materialized.notice}`,
             );
-            if (output) {
+            if (output !== null) {
                fileChunks.push(output);
                sectionHeaderEmitted = true;
             }
@@ -712,9 +703,11 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 
    if (parts.length === 0) return "";
    const context = `${prefix}${parts.join("")}${suffix}`;
-   return limits.max_total_bytes > 0 && Buffer.byteLength(context, "utf-8") > limits.max_total_bytes
-      ? truncateUtf8(Buffer.from(context, "utf-8"), limits.max_total_bytes).toString("utf-8")
-      : context;
+   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes) return context;
+   const suffixBytes = Buffer.byteLength(suffix, "utf-8");
+   const bodyLimit = Math.max(0, limits.max_total_bytes - suffixBytes);
+   const body = truncateUtf8(Buffer.from(`${prefix}${parts.join("")}`, "utf-8"), bodyLimit).toString("utf-8");
+   return `${body}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { join, dirname, isAbsolute, relative, resolve } from "node:path";
+import { closeSync, existsSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
+import { join, dirname, basename, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 
@@ -175,6 +175,26 @@ function resolveProjectFile(
    }
 }
 
+function displayProjectPath(projectRoot: string, filePath: string, taskDir?: string): string {
+   const direct = relative(projectRoot, filePath).split("\\").join("/");
+   if (direct && !direct.startsWith("../") && !isAbsolute(direct)) return direct;
+   if (taskDir) {
+      const taskRelative = relative(projectRoot, taskDir).split("\\").join("/");
+      const taskLabel = taskRelative && !taskRelative.startsWith("../") && !isAbsolute(taskRelative)
+         ? taskRelative
+         : `.trellis/tasks/${basename(taskDir)}`;
+      const withinTask = relative(taskDir, filePath).split("\\").join("/");
+      if (withinTask && !withinTask.startsWith("../") && !isAbsolute(withinTask)) {
+         return `${taskLabel}/${withinTask}`;
+      }
+   }
+   try {
+      return relative(realpathSync(projectRoot), realpathSync(filePath)).split("\\").join("/");
+   } catch {
+      return relative(projectRoot, filePath).split("\\").join("/");
+   }
+}
+
 // ---------------------------------------------------------------------------
 // Active task resolution
 // ---------------------------------------------------------------------------
@@ -325,20 +345,243 @@ function taskContextSignature(projectRoot: string, taskDir: string, agentType?: 
    }).join("\n");
 }
 
+interface ContextInjectionLimits {
+   max_file_bytes: number;
+   max_artifact_bytes: number;
+   max_total_bytes: number;
+}
+
+const DEFAULT_CONTEXT_INJECTION_LIMITS: ContextInjectionLimits = {
+   max_file_bytes: 32768,
+   max_artifact_bytes: 65536,
+   max_total_bytes: 131072,
+};
+const MAX_JSONL_BYTES = 1024 * 1024;
+
+function stripInlineComment(value: string): string {
+   let quote: string | null = null;
+   for (let i = 0; i < value.length; i++) {
+      const char = value[i];
+      if (quote) {
+         if (char === quote) quote = null;
+         continue;
+      }
+      if (char === "'" || char === '"') {
+         quote = char;
+         continue;
+      }
+      if (char === "#" && (i === 0 || /\s/.test(value[i - 1]!))) {
+         return value.slice(0, i);
+      }
+   }
+   return value;
+}
+
+function unquoteYaml(value: string): string {
+   return value.length >= 2 && value[0] === value[value.length - 1] &&
+      (value[0] === "'" || value[0] === '"')
+      ? value.slice(1, -1)
+      : value;
+}
+
+function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits {
+   const limits = { ...DEFAULT_CONTEXT_INJECTION_LIMITS };
+   let config = "";
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return limits; }
+
+   let inSection = false;
+   let sectionIndent = -1;
+   for (const rawLine of config.split(/\r?\n/)) {
+      const trimmed = rawLine.trim();
+      if (!inSection) {
+         if (/^context_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+            inSection = true;
+            sectionIndent = rawLine.length - rawLine.trimStart().length;
+         }
+         continue;
+      }
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const indent = rawLine.length - rawLine.trimStart().length;
+      if (indent <= sectionIndent) break;
+      const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+      if (!match || !(match[1] in limits)) continue;
+      const rawValue = unquoteYaml(stripInlineComment(match[2]!).trim()).trim();
+      if (!/^\d+$/.test(rawValue)) continue;
+      (limits as unknown as Record<string, number>)[match[1]!] = Number.parseInt(rawValue, 10);
+   }
+   return limits;
+}
+
+class ContextBudget {
+   used = 0;
+   constructor(private readonly maxTotalBytes: number) {}
+
+   hasRoom(bytes: number): boolean {
+      return this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes;
+   }
+
+   add(bytes: number): void {
+      this.used += bytes;
+   }
+}
+
+function truncateUtf8(data: Buffer, cap: number): Buffer {
+   if (cap <= 0 || data.length <= cap) return data;
+   let end = cap;
+   while (end > 0 && (data[end - 1]! & 0xc0) === 0x80) end--;
+   if (end === 0) return Buffer.alloc(0);
+   const lead = data[end - 1]!;
+   if (lead & 0x80) {
+      let sequenceLength = 1;
+      if ((lead & 0xe0) === 0xc0) sequenceLength = 2;
+      else if ((lead & 0xf0) === 0xe0) sequenceLength = 3;
+      else if ((lead & 0xf8) === 0xf0) sequenceLength = 4;
+      if (end - 1 + sequenceLength > cap) end--;
+   }
+   return data.subarray(0, end);
+}
+
+function isUtf8(data: Buffer): boolean {
+   try {
+      const decoded = data.toString("utf-8");
+      return Buffer.from(decoded, "utf-8").equals(data);
+   } catch {
+      return false;
+   }
+}
+
+function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; size: number } | null {
+   let fd: number | null = null;
+   try {
+      const size = statSync(filePath).size;
+      if (maxBytes <= 0 || size <= maxBytes) {
+         return { data: readFileSync(filePath), size };
+      }
+      fd = openSync(filePath, "r");
+      // Read a few extra bytes so a UTF-8 sequence crossing the cap can be
+      // validated before truncateUtf8 removes its incomplete suffix.
+      const data = Buffer.allocUnsafe(maxBytes + 4);
+      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      return { data: data.subarray(0, bytesRead), size };
+   } catch {
+      return null;
+   } finally {
+      if (fd !== null) closeSync(fd);
+   }
+}
+
+function omittedNotice(file: string, size: number | null, reason: string): string {
+   const sizeText = size === null ? "unknown bytes" : `${size} bytes`;
+   return `### ${file} [omitted]\n\n[Trellis: omitted (${reason}) — ${file} (${sizeText}); required_read: ${file}]`;
+}
+
+function budgetedBlock(
+   budget: ContextBudget,
+   file: string,
+   content: string,
+   status: "inline" | "truncated",
+   size: number,
+   reason: string,
+): string {
+   const block = `### ${file} [${status}]\n\n${content}`;
+   if (budget.hasRoom(Buffer.byteLength(block, "utf-8"))) {
+      budget.add(Buffer.byteLength(block, "utf-8"));
+      return block;
+   }
+   const notice = omittedNotice(file, size, `total context limit reached: ${reason}`);
+   budget.add(Buffer.byteLength(notice, "utf-8"));
+   return notice;
+}
+
+function materializeFile(
+   targetPath: string,
+   displayPath: string,
+   reason: string,
+   limits: ContextInjectionLimits,
+   budget: ContextBudget,
+): string {
+   const file = readFilePrefix(targetPath, limits.max_file_bytes);
+   if (!file) {
+      return omittedNotice(displayPath, null, "file is missing or unreadable");
+   }
+   const { data, size } = file;
+   const truncated = truncateUtf8(data, limits.max_file_bytes);
+   if (truncated.includes(0) || !isUtf8(truncated)) {
+      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`);
+      budget.add(Buffer.byteLength(notice, "utf-8"));
+      return notice;
+   }
+   let content = truncated.toString("utf-8");
+   let status: "inline" | "truncated" = "inline";
+   if (truncated.length < size) {
+      status = "truncated";
+      content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
+   }
+   return budgetedBlock(budget, displayPath, content, status, size, reason);
+}
+
+function materializeArtifact(
+   targetPath: string,
+   displayPath: string,
+   reason: string,
+   limits: ContextInjectionLimits,
+   budget: ContextBudget,
+): string {
+   const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
+   if (!file) {
+      return omittedNotice(displayPath, null, "artifact is missing or unreadable");
+   }
+   const { data, size } = file;
+   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
+   if (truncated.includes(0) || !isUtf8(truncated)) {
+      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`);
+      budget.add(Buffer.byteLength(notice, "utf-8"));
+      return notice;
+   }
+   let content = truncated.toString("utf-8");
+   let status: "inline" | "truncated" = "inline";
+   if (truncated.length < size) {
+      status = "truncated";
+      content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
+   }
+   return budgetedBlock(budget, displayPath, content, status, size, reason);
+}
+
+function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string[]; omitted: string | null } {
+   let size: number;
+   try {
+      size = statSync(jsonlPath).size;
+   } catch {
+      return { lines: [], omitted: null };
+   }
+   if (size > MAX_JSONL_BYTES) {
+      return {
+         lines: [],
+         omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
+      };
+   }
+   try {
+      return { lines: readFileSync(jsonlPath, "utf-8").split(/\r?\n/), omitted: null };
+   } catch {
+      return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is missing or unreadable") };
+   }
+}
+
 function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
    const parts: string[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
+   const limits = readContextInjectionLimits(projectRoot);
+   const budget = new ContextBudget(limits.max_total_bytes);
 
    // prd.md and info.md — always included
-   let prd = "";
-   try { prd = readFileSync(join(taskDir, "prd.md"), "utf-8"); } catch { }
-   if (prd.trim()) parts.push(`## PRD\n\n${prd.trim()}`);
-
-   let info = "";
-   try { info = readFileSync(join(taskDir, "info.md"), "utf-8"); } catch { }
-   if (info.trim()) parts.push(`## Info\n\n${info.trim()}`);
+   const prdPath = join(taskDir, "prd.md");
+   const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
+   if (existsSync(prdPath)) parts.push(materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits, budget));
+   const infoPath = join(taskDir, "info.md");
+   const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
+   if (existsSync(infoPath)) parts.push(materializeArtifact(infoPath, relativeInfoPath, "Task information", limits, budget));
 
    // Determine which jsonl files to read based on agent type
    const jsonlNames = taskContextJsonlNames(agentType);
@@ -351,15 +594,15 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
 
-      let lines: string[];
-      try {
-         lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/);
-      } catch {
+      const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
+      const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
+      if (manifest.omitted) {
+         parts.push(`## ${jsonlName}\n\n${manifest.omitted}`);
          continue;
       }
 
       const fileChunks: string[] = [];
-      for (const line of lines) {
+      for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
          try {
@@ -369,12 +612,8 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             const targetPath = resolveProjectFile(projectRoot, file, trustedRoots);
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
-            let content = "";
-            try { content = readFileSync(targetPath, "utf-8"); } catch { }
-            if (content.trim()) {
-               includedPaths.add(targetPath);
-               fileChunks.push(`### ${file}\n\n${content.trim()}`);
-            }
+            includedPaths.add(targetPath);
+            fileChunks.push(materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits, budget));
          } catch {
             // seed rows and malformed lines are non-fatal
          }
@@ -386,7 +625,7 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    }
 
    return parts.length > 0
-      ? `<task-context>\n${parts.join("\n\n")}\n</task-context>`
+      ? `<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n${parts.join("\n\n")}\n</task-context>`
       : "";
 }
 

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { closeSync, existsSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
 import { join, dirname, basename, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -413,56 +413,119 @@ function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits
 }
 
 class ContextBudget {
-   used = 0;
-   constructor(private readonly maxTotalBytes: number) {}
+   used: number;
+   private terminalSummaryEmitted = false;
+   private stopped = false;
+   constructor(private readonly maxTotalBytes: number, initialUsed = 0) {
+      this.used = initialUsed;
+   }
 
    hasRoom(bytes: number): boolean {
-      return this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes;
+      return !this.stopped && (this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes);
    }
 
-   add(bytes: number): void {
+   emit(text: string): string {
+      const bytes = Buffer.byteLength(text, "utf-8");
+      if (!this.hasRoom(bytes)) return "";
       this.used += bytes;
+      return text;
    }
+
+   emitCandidate(primary: string, fallback: string | null): string {
+      const direct = this.emit(primary);
+      if (direct) return direct;
+      if (fallback !== null) {
+         const notice = this.emit(fallback);
+         if (notice) return notice;
+      }
+      return this.emitTerminalSummary();
+   }
+
+   private emitTerminalSummary(): string {
+      if (this.terminalSummaryEmitted) return "";
+      this.terminalSummaryEmitted = true;
+      this.stopped = true;
+      const summary = "[Trellis: context limit reached; omitted entries remain authoritative on disk and require_read paths above.]";
+      if (this.maxTotalBytes <= 0) {
+         this.used += Buffer.byteLength(summary, "utf-8");
+         return summary;
+      }
+      const remaining = this.maxTotalBytes - this.used;
+      if (remaining <= 0) return "";
+      const bounded = truncateUtf8(Buffer.from(summary, "utf-8"), remaining).toString("utf-8");
+      this.used += Buffer.byteLength(bounded, "utf-8");
+      return bounded;
+   }
+}
+
+type Utf8Status = "valid" | "incomplete" | "invalid";
+
+function utf8Status(data: Buffer): Utf8Status {
+   for (let index = 0; index < data.length; index++) {
+      const lead = data[index]!;
+      if (lead <= 0x7f) continue;
+
+      let length: number;
+      let secondMin = 0x80;
+      let secondMax = 0xbf;
+      if (lead >= 0xc2 && lead <= 0xdf) length = 2;
+      else if (lead >= 0xe0 && lead <= 0xef) {
+         length = 3;
+         if (lead === 0xe0) secondMin = 0xa0;
+         if (lead === 0xed) secondMax = 0x9f;
+      } else if (lead >= 0xf0 && lead <= 0xf4) {
+         length = 4;
+         if (lead === 0xf0) secondMin = 0x90;
+         if (lead === 0xf4) secondMax = 0x8f;
+      } else return "invalid";
+
+      if (index + length > data.length) {
+         for (let tail = index + 1; tail < data.length; tail++) {
+            if (data[tail]! < 0x80 || data[tail]! > 0xbf) return "invalid";
+         }
+         return "incomplete";
+      }
+      const second = data[index + 1]!;
+      if (second < secondMin || second > secondMax) return "invalid";
+      for (let continuation = index + 2; continuation < index + length; continuation++) {
+         const byte = data[continuation]!;
+         if (byte < 0x80 || byte > 0xbf) return "invalid";
+      }
+      index += length - 1;
+   }
+   return "valid";
 }
 
 function truncateUtf8(data: Buffer, cap: number): Buffer {
    if (cap <= 0 || data.length <= cap) return data;
-   let end = cap;
-   while (end > 0 && (data[end - 1]! & 0xc0) === 0x80) end--;
-   if (end === 0) return Buffer.alloc(0);
-   const lead = data[end - 1]!;
-   if (lead & 0x80) {
-      let sequenceLength = 1;
-      if ((lead & 0xe0) === 0xc0) sequenceLength = 2;
-      else if ((lead & 0xf0) === 0xe0) sequenceLength = 3;
-      else if ((lead & 0xf8) === 0xf0) sequenceLength = 4;
-      if (end - 1 + sequenceLength > cap) end--;
+   if (utf8Status(data.subarray(0, cap)) === "valid") return data.subarray(0, cap);
+   // A bounded read has already been validated as a complete UTF-8 stream.
+   // Only its final, incomplete code point may make the cap prefix invalid.
+   for (let end = cap - 1; end >= Math.max(0, cap - 4); end--) {
+      const candidate = data.subarray(0, end);
+      if (utf8Status(candidate) === "valid") return candidate;
    }
-   return data.subarray(0, end);
+   return Buffer.alloc(0);
 }
 
 function isUtf8(data: Buffer): boolean {
-   try {
-      const decoded = data.toString("utf-8");
-      return Buffer.from(decoded, "utf-8").equals(data);
-   } catch {
-      return false;
-   }
+   return utf8Status(data) === "valid";
 }
 
 function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; size: number } | null {
    let fd: number | null = null;
    try {
-      const size = statSync(filePath).size;
-      if (maxBytes <= 0 || size <= maxBytes) {
-         return { data: readFileSync(filePath), size };
-      }
       fd = openSync(filePath, "r");
+      if (maxBytes <= 0) {
+         const data = readFileSync(fd);
+         return { data, size: fstatSync(fd).size };
+      }
       // Read a few extra bytes so a UTF-8 sequence crossing the cap can be
-      // validated before truncateUtf8 removes its incomplete suffix.
+      // validated before truncateUtf8 removes its incomplete suffix. The
+      // descriptor keeps the read bounded if the path is replaced or grows.
       const data = Buffer.allocUnsafe(maxBytes + 4);
       const bytesRead = readSync(fd, data, 0, data.length, 0);
-      return { data: data.subarray(0, bytesRead), size };
+      return { data: data.subarray(0, bytesRead), size: fstatSync(fd).size };
    } catch {
       return null;
    } finally {
@@ -475,22 +538,9 @@ function omittedNotice(file: string, size: number | null, reason: string): strin
    return `### ${file} [omitted]\n\n[Trellis: omitted (${reason}) — ${file} (${sizeText}); required_read: ${file}]`;
 }
 
-function budgetedBlock(
-   budget: ContextBudget,
-   file: string,
-   content: string,
-   status: "inline" | "truncated",
-   size: number,
-   reason: string,
-): string {
-   const block = `### ${file} [${status}]\n\n${content}`;
-   if (budget.hasRoom(Buffer.byteLength(block, "utf-8"))) {
-      budget.add(Buffer.byteLength(block, "utf-8"));
-      return block;
-   }
-   const notice = omittedNotice(file, size, `total context limit reached: ${reason}`);
-   budget.add(Buffer.byteLength(notice, "utf-8"));
-   return notice;
+interface MaterializedFile {
+   block: string | null;
+   notice: string;
 }
 
 function materializeFile(
@@ -498,26 +548,27 @@ function materializeFile(
    displayPath: string,
    reason: string,
    limits: ContextInjectionLimits,
-   budget: ContextBudget,
-): string {
+): MaterializedFile {
    const file = readFilePrefix(targetPath, limits.max_file_bytes);
    if (!file) {
-      return omittedNotice(displayPath, null, "file is missing or unreadable");
+      return { block: null, notice: omittedNotice(displayPath, null, "file is missing or unreadable") };
    }
    const { data, size } = file;
-   const truncated = truncateUtf8(data, limits.max_file_bytes);
-   if (truncated.includes(0) || !isUtf8(truncated)) {
-      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`);
-      budget.add(Buffer.byteLength(notice, "utf-8"));
-      return notice;
+   const encodingStatus = utf8Status(data);
+   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`) };
    }
+   const truncated = truncateUtf8(data, limits.max_file_bytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
       content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
    }
-   return budgetedBlock(budget, displayPath, content, status, size, reason);
+   return {
+      block: `### ${displayPath} [${status}]\n\n${content}`,
+      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
+   };
 }
 
 function materializeArtifact(
@@ -525,45 +576,51 @@ function materializeArtifact(
    displayPath: string,
    reason: string,
    limits: ContextInjectionLimits,
-   budget: ContextBudget,
-): string {
+): MaterializedFile {
    const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
    if (!file) {
-      return omittedNotice(displayPath, null, "artifact is missing or unreadable");
+      return { block: null, notice: omittedNotice(displayPath, null, "artifact is missing or unreadable") };
    }
    const { data, size } = file;
-   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
-   if (truncated.includes(0) || !isUtf8(truncated)) {
-      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`);
-      budget.add(Buffer.byteLength(notice, "utf-8"));
-      return notice;
+   const encodingStatus = utf8Status(data);
+   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`) };
    }
+   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
       content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
    }
-   return budgetedBlock(budget, displayPath, content, status, size, reason);
+   return {
+      block: `### ${displayPath} [${status}]\n\n${content}`,
+      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
+   };
 }
 
 function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string[]; omitted: string | null } {
-   let size: number;
+   let fd: number | null = null;
    try {
-      size = statSync(jsonlPath).size;
+      fd = openSync(jsonlPath, "r");
+      const data = Buffer.allocUnsafe(MAX_JSONL_BYTES + 1);
+      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const size = fstatSync(fd).size;
+      if (bytesRead > MAX_JSONL_BYTES || size > MAX_JSONL_BYTES) {
+         return {
+            lines: [],
+            omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
+         };
+      }
+      const content = data.subarray(0, bytesRead);
+      if (!isUtf8(content)) {
+         return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is not valid UTF-8") };
+      }
+      return { lines: content.toString("utf-8").split(/\r?\n/), omitted: null };
    } catch {
-      return { lines: [], omitted: null };
-   }
-   if (size > MAX_JSONL_BYTES) {
-      return {
-         lines: [],
-         omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
-      };
-   }
-   try {
-      return { lines: readFileSync(jsonlPath, "utf-8").split(/\r?\n/), omitted: null };
-   } catch {
-      return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is missing or unreadable") };
+      return { lines: [], omitted: omittedNotice(displayPath, null, "manifest is missing or unreadable") };
+   } finally {
+      if (fd !== null) closeSync(fd);
    }
 }
 
@@ -573,15 +630,34 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
    const limits = readContextInjectionLimits(projectRoot);
-   const budget = new ContextBudget(limits.max_total_bytes);
+   const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
+   const suffix = "\n</task-context>";
+   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+
+   const emit = (text: string, fallback: string | null = null): string => budget.emitCandidate(text, fallback);
+   const appendCandidate = (primary: string, fallback: string | null = null): void => {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const output = emit(
+         primary ? separator + primary : "",
+         fallback === null ? null : separator + fallback,
+      );
+      if (output) parts.push(output);
+   };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
    const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
-   if (existsSync(prdPath)) parts.push(materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits, budget));
+   if (existsSync(prdPath)) {
+      const artifact = materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits);
+      appendCandidate(artifact.block ?? "", artifact.notice);
+   }
    const infoPath = join(taskDir, "info.md");
    const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
-   if (existsSync(infoPath)) parts.push(materializeArtifact(infoPath, relativeInfoPath, "Task information", limits, budget));
+   if (existsSync(infoPath)) {
+      const artifact = materializeArtifact(infoPath, relativeInfoPath, "Task information", limits);
+      appendCandidate(artifact.block ?? "", artifact.notice);
+   }
 
    // Determine which jsonl files to read based on agent type
    const jsonlNames = taskContextJsonlNames(agentType);
@@ -597,11 +673,12 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
       const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
       if (manifest.omitted) {
-         parts.push(`## ${jsonlName}\n\n${manifest.omitted}`);
+         appendCandidate(`## ${jsonlName}\n\n${manifest.omitted}`);
          continue;
       }
 
       const fileChunks: string[] = [];
+      let sectionHeaderEmitted = false;
       for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
@@ -613,20 +690,31 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            fileChunks.push(materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits, budget));
+            const materialized = materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits);
+            const sectionPrefix = sectionHeaderEmitted
+               ? "\n\n---\n\n"
+               : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
+            const output = emit(
+               materialized.block ? `${sectionPrefix}${materialized.block}` : "",
+               `${sectionPrefix}${materialized.notice}`,
+            );
+            if (output) {
+               fileChunks.push(output);
+               sectionHeaderEmitted = true;
+            }
          } catch {
             // seed rows and malformed lines are non-fatal
          }
       }
 
-      if (fileChunks.length > 0) {
-         parts.push(`## ${jsonlName}\n\n${fileChunks.join("\n\n---\n\n")}`);
-      }
+      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
    }
 
-   return parts.length > 0
-      ? `<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n${parts.join("\n\n")}\n</task-context>`
-      : "";
+   if (parts.length === 0) return "";
+   const context = `${prefix}${parts.join("")}${suffix}`;
+   return limits.max_total_bytes > 0 && Buffer.byteLength(context, "utf-8") > limits.max_total_bytes
+      ? truncateUtf8(Buffer.from(context, "utf-8"), limits.max_total_bytes).toString("utf-8")
+      : context;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -311,13 +311,17 @@ function taskContextJsonlNames(agentType?: AgentType): string[] {
 
 function taskContextInputPaths(projectRoot: string, taskDir: string, agentType?: AgentType): string[] {
    const trustedRoots = resolveTrustedRoots(projectRoot);
-   const paths = new Set<string>([join(taskDir, "prd.md"), join(taskDir, "info.md")]);
+   const paths = new Set<string>([
+      join(projectRoot, ".trellis", "config.yaml"),
+      join(taskDir, "prd.md"),
+      join(taskDir, "info.md"),
+   ]);
    for (const jsonlName of taskContextJsonlNames(agentType)) {
       const jsonlPath = join(taskDir, jsonlName);
       paths.add(jsonlPath);
       if (!existsSync(jsonlPath)) continue;
-      let lines: string[];
-      try { lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/); } catch { continue; }
+      const displayPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
+      const { lines } = readJsonlLines(jsonlPath, displayPath);
       for (const line of lines) {
          try {
             const row = JSON.parse(line.trim()) as Record<string, unknown>;

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -413,47 +413,53 @@ function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits
 }
 
 class ContextBudget {
-   used: number;
+   private totalBytesUsed: number;
    private terminalSummaryEmitted = false;
    private stopped = false;
    constructor(private readonly maxTotalBytes: number, initialUsed = 0) {
-      this.used = initialUsed;
+      this.totalBytesUsed = initialUsed;
+   }
+
+   get used(): number {
+      return this.totalBytesUsed;
    }
 
    hasRoom(bytes: number): boolean {
-      return !this.stopped && (this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes);
+      return !this.stopped && (this.maxTotalBytes <= 0 || this.totalBytesUsed + bytes <= this.maxTotalBytes);
    }
 
-   emit(text: string): string {
+   emit(text: string): string | null {
       const bytes = Buffer.byteLength(text, "utf-8");
-      if (!this.hasRoom(bytes)) return "";
-      this.used += bytes;
+      if (!this.hasRoom(bytes)) return null;
+      this.totalBytesUsed += bytes;
       return text;
    }
 
-   emitCandidate(primary: string, fallback: string | null): string {
-      const direct = this.emit(primary);
-      if (direct) return direct;
+   emitCandidate(primary: string | null, fallback: string | null): string | null {
+      if (primary !== null) {
+         const direct = this.emit(primary);
+         if (direct !== null) return direct;
+      }
       if (fallback !== null) {
          const notice = this.emit(fallback);
-         if (notice) return notice;
+         if (notice !== null) return notice;
       }
       return this.emitTerminalSummary();
    }
 
-   private emitTerminalSummary(): string {
-      if (this.terminalSummaryEmitted) return "";
+   private emitTerminalSummary(): string | null {
+      if (this.terminalSummaryEmitted) return null;
       this.terminalSummaryEmitted = true;
       this.stopped = true;
       const summary = "[Trellis: context limit reached; omitted entries remain authoritative on disk and require_read paths above.]";
       if (this.maxTotalBytes <= 0) {
-         this.used += Buffer.byteLength(summary, "utf-8");
+         this.totalBytesUsed += Buffer.byteLength(summary, "utf-8");
          return summary;
       }
-      const remaining = this.maxTotalBytes - this.used;
-      if (remaining <= 0) return "";
+      const remaining = this.maxTotalBytes - this.totalBytesUsed;
+      if (remaining <= 0) return null;
       const bounded = truncateUtf8(Buffer.from(summary, "utf-8"), remaining).toString("utf-8");
-      this.used += Buffer.byteLength(bounded, "utf-8");
+      this.totalBytesUsed += Buffer.byteLength(bounded, "utf-8");
       return bounded;
    }
 }
@@ -481,7 +487,9 @@ function utf8Status(data: Buffer): Utf8Status {
 
       if (index + length > data.length) {
          for (let tail = index + 1; tail < data.length; tail++) {
-            if (data[tail]! < 0x80 || data[tail]! > 0xbf) return "invalid";
+            const min = tail === index + 1 ? secondMin : 0x80;
+            const max = tail === index + 1 ? secondMax : 0xbf;
+            if (data[tail]! < min || data[tail]! > max) return "invalid";
          }
          return "incomplete";
       }
@@ -524,13 +532,23 @@ function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; siz
       // validated before truncateUtf8 removes its incomplete suffix. The
       // descriptor keeps the read bounded if the path is replaced or grows.
       const data = Buffer.allocUnsafe(maxBytes + 4);
-      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const bytesRead = readFully(fd, data);
       return { data: data.subarray(0, bytesRead), size: fstatSync(fd).size };
    } catch {
       return null;
    } finally {
       if (fd !== null) closeSync(fd);
    }
+}
+
+function readFully(fd: number, buffer: Buffer): number {
+   let total = 0;
+   while (total < buffer.length) {
+      const bytesRead = readSync(fd, buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+   }
+   return total;
 }
 
 function omittedNotice(file: string, size: number | null, reason: string): string {
@@ -543,55 +561,28 @@ interface MaterializedFile {
    notice: string;
 }
 
-function materializeFile(
+function materialize(
    targetPath: string,
    displayPath: string,
    reason: string,
-   limits: ContextInjectionLimits,
+   maxBytes: number,
+   kind: "file" | "artifact",
 ): MaterializedFile {
-   const file = readFilePrefix(targetPath, limits.max_file_bytes);
+   const file = readFilePrefix(targetPath, maxBytes);
    if (!file) {
-      return { block: null, notice: omittedNotice(displayPath, null, "file is missing or unreadable") };
+      return { block: null, notice: omittedNotice(displayPath, null, `${kind} is missing or unreadable`) };
    }
    const { data, size } = file;
    const encodingStatus = utf8Status(data);
    if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
-      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`) };
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 ${kind}: ${reason}`) };
    }
-   const truncated = truncateUtf8(data, limits.max_file_bytes);
+   const truncated = truncateUtf8(data, maxBytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
-      content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
-   }
-   return {
-      block: `### ${displayPath} [${status}]\n\n${content}`,
-      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
-   };
-}
-
-function materializeArtifact(
-   targetPath: string,
-   displayPath: string,
-   reason: string,
-   limits: ContextInjectionLimits,
-): MaterializedFile {
-   const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
-   if (!file) {
-      return { block: null, notice: omittedNotice(displayPath, null, "artifact is missing or unreadable") };
-   }
-   const { data, size } = file;
-   const encodingStatus = utf8Status(data);
-   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
-      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`) };
-   }
-   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
-   let content = truncated.toString("utf-8");
-   let status: "inline" | "truncated" = "inline";
-   if (truncated.length < size) {
-      status = "truncated";
-      content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
+      content += `\n[Trellis: truncated at ${maxBytes} bytes — read ${displayPath} for the full content]`;
    }
    return {
       block: `### ${displayPath} [${status}]\n\n${content}`,
@@ -604,7 +595,7 @@ function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string
    try {
       fd = openSync(jsonlPath, "r");
       const data = Buffer.allocUnsafe(MAX_JSONL_BYTES + 1);
-      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const bytesRead = readFully(fd, data);
       const size = fstatSync(fd).size;
       if (bytesRead > MAX_JSONL_BYTES || size > MAX_JSONL_BYTES) {
          return {
@@ -633,30 +624,30 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
    const suffix = "\n</task-context>";
    const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) return "";
    const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
 
-   const emit = (text: string, fallback: string | null = null): string => budget.emitCandidate(text, fallback);
-   const appendCandidate = (primary: string, fallback: string | null = null): void => {
+   const appendCandidate = (primary: string | null, fallback: string | null = null): void => {
       const separator = parts.length > 0 ? "\n\n" : "";
-      const output = emit(
-         primary ? separator + primary : "",
+      const output = budget.emitCandidate(
+         primary === null ? null : separator + primary,
          fallback === null ? null : separator + fallback,
       );
-      if (output) parts.push(output);
+      if (output !== null) parts.push(output);
    };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
    const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
    if (existsSync(prdPath)) {
-      const artifact = materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits);
-      appendCandidate(artifact.block ?? "", artifact.notice);
+      const artifact = materialize(prdPath, relativePrdPath, "Requirements document", limits.max_artifact_bytes, "artifact");
+      appendCandidate(artifact.block, artifact.notice);
    }
    const infoPath = join(taskDir, "info.md");
    const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
    if (existsSync(infoPath)) {
-      const artifact = materializeArtifact(infoPath, relativeInfoPath, "Task information", limits);
-      appendCandidate(artifact.block ?? "", artifact.notice);
+      const artifact = materialize(infoPath, relativeInfoPath, "Task information", limits.max_artifact_bytes, "artifact");
+      appendCandidate(artifact.block, artifact.notice);
    }
 
    // Determine which jsonl files to read based on agent type
@@ -690,15 +681,15 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            const materialized = materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits);
+            const materialized = materialize(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits.max_file_bytes, "file");
             const sectionPrefix = sectionHeaderEmitted
                ? "\n\n---\n\n"
                : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
-            const output = emit(
-               materialized.block ? `${sectionPrefix}${materialized.block}` : "",
+            const output = budget.emitCandidate(
+               materialized.block === null ? null : `${sectionPrefix}${materialized.block}`,
                `${sectionPrefix}${materialized.notice}`,
             );
-            if (output) {
+            if (output !== null) {
                fileChunks.push(output);
                sectionHeaderEmitted = true;
             }
@@ -712,9 +703,11 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 
    if (parts.length === 0) return "";
    const context = `${prefix}${parts.join("")}${suffix}`;
-   return limits.max_total_bytes > 0 && Buffer.byteLength(context, "utf-8") > limits.max_total_bytes
-      ? truncateUtf8(Buffer.from(context, "utf-8"), limits.max_total_bytes).toString("utf-8")
-      : context;
+   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes) return context;
+   const suffixBytes = Buffer.byteLength(suffix, "utf-8");
+   const bodyLimit = Math.max(0, limits.max_total_bytes - suffixBytes);
+   const body = truncateUtf8(Buffer.from(`${prefix}${parts.join("")}`, "utf-8"), bodyLimit).toString("utf-8");
+   return `${body}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { join, dirname, isAbsolute, relative, resolve } from "node:path";
+import { closeSync, existsSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
+import { join, dirname, basename, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 
@@ -175,6 +175,26 @@ function resolveProjectFile(
    }
 }
 
+function displayProjectPath(projectRoot: string, filePath: string, taskDir?: string): string {
+   const direct = relative(projectRoot, filePath).split("\\").join("/");
+   if (direct && !direct.startsWith("../") && !isAbsolute(direct)) return direct;
+   if (taskDir) {
+      const taskRelative = relative(projectRoot, taskDir).split("\\").join("/");
+      const taskLabel = taskRelative && !taskRelative.startsWith("../") && !isAbsolute(taskRelative)
+         ? taskRelative
+         : `.trellis/tasks/${basename(taskDir)}`;
+      const withinTask = relative(taskDir, filePath).split("\\").join("/");
+      if (withinTask && !withinTask.startsWith("../") && !isAbsolute(withinTask)) {
+         return `${taskLabel}/${withinTask}`;
+      }
+   }
+   try {
+      return relative(realpathSync(projectRoot), realpathSync(filePath)).split("\\").join("/");
+   } catch {
+      return relative(projectRoot, filePath).split("\\").join("/");
+   }
+}
+
 // ---------------------------------------------------------------------------
 // Active task resolution
 // ---------------------------------------------------------------------------
@@ -325,20 +345,243 @@ function taskContextSignature(projectRoot: string, taskDir: string, agentType?: 
    }).join("\n");
 }
 
+interface ContextInjectionLimits {
+   max_file_bytes: number;
+   max_artifact_bytes: number;
+   max_total_bytes: number;
+}
+
+const DEFAULT_CONTEXT_INJECTION_LIMITS: ContextInjectionLimits = {
+   max_file_bytes: 32768,
+   max_artifact_bytes: 65536,
+   max_total_bytes: 131072,
+};
+const MAX_JSONL_BYTES = 1024 * 1024;
+
+function stripInlineComment(value: string): string {
+   let quote: string | null = null;
+   for (let i = 0; i < value.length; i++) {
+      const char = value[i];
+      if (quote) {
+         if (char === quote) quote = null;
+         continue;
+      }
+      if (char === "'" || char === '"') {
+         quote = char;
+         continue;
+      }
+      if (char === "#" && (i === 0 || /\s/.test(value[i - 1]!))) {
+         return value.slice(0, i);
+      }
+   }
+   return value;
+}
+
+function unquoteYaml(value: string): string {
+   return value.length >= 2 && value[0] === value[value.length - 1] &&
+      (value[0] === "'" || value[0] === '"')
+      ? value.slice(1, -1)
+      : value;
+}
+
+function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits {
+   const limits = { ...DEFAULT_CONTEXT_INJECTION_LIMITS };
+   let config = "";
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return limits; }
+
+   let inSection = false;
+   let sectionIndent = -1;
+   for (const rawLine of config.split(/\r?\n/)) {
+      const trimmed = rawLine.trim();
+      if (!inSection) {
+         if (/^context_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+            inSection = true;
+            sectionIndent = rawLine.length - rawLine.trimStart().length;
+         }
+         continue;
+      }
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const indent = rawLine.length - rawLine.trimStart().length;
+      if (indent <= sectionIndent) break;
+      const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+      if (!match || !(match[1] in limits)) continue;
+      const rawValue = unquoteYaml(stripInlineComment(match[2]!).trim()).trim();
+      if (!/^\d+$/.test(rawValue)) continue;
+      (limits as unknown as Record<string, number>)[match[1]!] = Number.parseInt(rawValue, 10);
+   }
+   return limits;
+}
+
+class ContextBudget {
+   used = 0;
+   constructor(private readonly maxTotalBytes: number) {}
+
+   hasRoom(bytes: number): boolean {
+      return this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes;
+   }
+
+   add(bytes: number): void {
+      this.used += bytes;
+   }
+}
+
+function truncateUtf8(data: Buffer, cap: number): Buffer {
+   if (cap <= 0 || data.length <= cap) return data;
+   let end = cap;
+   while (end > 0 && (data[end - 1]! & 0xc0) === 0x80) end--;
+   if (end === 0) return Buffer.alloc(0);
+   const lead = data[end - 1]!;
+   if (lead & 0x80) {
+      let sequenceLength = 1;
+      if ((lead & 0xe0) === 0xc0) sequenceLength = 2;
+      else if ((lead & 0xf0) === 0xe0) sequenceLength = 3;
+      else if ((lead & 0xf8) === 0xf0) sequenceLength = 4;
+      if (end - 1 + sequenceLength > cap) end--;
+   }
+   return data.subarray(0, end);
+}
+
+function isUtf8(data: Buffer): boolean {
+   try {
+      const decoded = data.toString("utf-8");
+      return Buffer.from(decoded, "utf-8").equals(data);
+   } catch {
+      return false;
+   }
+}
+
+function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; size: number } | null {
+   let fd: number | null = null;
+   try {
+      const size = statSync(filePath).size;
+      if (maxBytes <= 0 || size <= maxBytes) {
+         return { data: readFileSync(filePath), size };
+      }
+      fd = openSync(filePath, "r");
+      // Read a few extra bytes so a UTF-8 sequence crossing the cap can be
+      // validated before truncateUtf8 removes its incomplete suffix.
+      const data = Buffer.allocUnsafe(maxBytes + 4);
+      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      return { data: data.subarray(0, bytesRead), size };
+   } catch {
+      return null;
+   } finally {
+      if (fd !== null) closeSync(fd);
+   }
+}
+
+function omittedNotice(file: string, size: number | null, reason: string): string {
+   const sizeText = size === null ? "unknown bytes" : `${size} bytes`;
+   return `### ${file} [omitted]\n\n[Trellis: omitted (${reason}) — ${file} (${sizeText}); required_read: ${file}]`;
+}
+
+function budgetedBlock(
+   budget: ContextBudget,
+   file: string,
+   content: string,
+   status: "inline" | "truncated",
+   size: number,
+   reason: string,
+): string {
+   const block = `### ${file} [${status}]\n\n${content}`;
+   if (budget.hasRoom(Buffer.byteLength(block, "utf-8"))) {
+      budget.add(Buffer.byteLength(block, "utf-8"));
+      return block;
+   }
+   const notice = omittedNotice(file, size, `total context limit reached: ${reason}`);
+   budget.add(Buffer.byteLength(notice, "utf-8"));
+   return notice;
+}
+
+function materializeFile(
+   targetPath: string,
+   displayPath: string,
+   reason: string,
+   limits: ContextInjectionLimits,
+   budget: ContextBudget,
+): string {
+   const file = readFilePrefix(targetPath, limits.max_file_bytes);
+   if (!file) {
+      return omittedNotice(displayPath, null, "file is missing or unreadable");
+   }
+   const { data, size } = file;
+   const truncated = truncateUtf8(data, limits.max_file_bytes);
+   if (truncated.includes(0) || !isUtf8(truncated)) {
+      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`);
+      budget.add(Buffer.byteLength(notice, "utf-8"));
+      return notice;
+   }
+   let content = truncated.toString("utf-8");
+   let status: "inline" | "truncated" = "inline";
+   if (truncated.length < size) {
+      status = "truncated";
+      content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
+   }
+   return budgetedBlock(budget, displayPath, content, status, size, reason);
+}
+
+function materializeArtifact(
+   targetPath: string,
+   displayPath: string,
+   reason: string,
+   limits: ContextInjectionLimits,
+   budget: ContextBudget,
+): string {
+   const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
+   if (!file) {
+      return omittedNotice(displayPath, null, "artifact is missing or unreadable");
+   }
+   const { data, size } = file;
+   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
+   if (truncated.includes(0) || !isUtf8(truncated)) {
+      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`);
+      budget.add(Buffer.byteLength(notice, "utf-8"));
+      return notice;
+   }
+   let content = truncated.toString("utf-8");
+   let status: "inline" | "truncated" = "inline";
+   if (truncated.length < size) {
+      status = "truncated";
+      content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
+   }
+   return budgetedBlock(budget, displayPath, content, status, size, reason);
+}
+
+function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string[]; omitted: string | null } {
+   let size: number;
+   try {
+      size = statSync(jsonlPath).size;
+   } catch {
+      return { lines: [], omitted: null };
+   }
+   if (size > MAX_JSONL_BYTES) {
+      return {
+         lines: [],
+         omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
+      };
+   }
+   try {
+      return { lines: readFileSync(jsonlPath, "utf-8").split(/\r?\n/), omitted: null };
+   } catch {
+      return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is missing or unreadable") };
+   }
+}
+
 function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
    const parts: string[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
+   const limits = readContextInjectionLimits(projectRoot);
+   const budget = new ContextBudget(limits.max_total_bytes);
 
    // prd.md and info.md — always included
-   let prd = "";
-   try { prd = readFileSync(join(taskDir, "prd.md"), "utf-8"); } catch { }
-   if (prd.trim()) parts.push(`## PRD\n\n${prd.trim()}`);
-
-   let info = "";
-   try { info = readFileSync(join(taskDir, "info.md"), "utf-8"); } catch { }
-   if (info.trim()) parts.push(`## Info\n\n${info.trim()}`);
+   const prdPath = join(taskDir, "prd.md");
+   const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
+   if (existsSync(prdPath)) parts.push(materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits, budget));
+   const infoPath = join(taskDir, "info.md");
+   const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
+   if (existsSync(infoPath)) parts.push(materializeArtifact(infoPath, relativeInfoPath, "Task information", limits, budget));
 
    // Determine which jsonl files to read based on agent type
    const jsonlNames = taskContextJsonlNames(agentType);
@@ -351,15 +594,15 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
 
-      let lines: string[];
-      try {
-         lines = readFileSync(jsonlPath, "utf-8").split(/\r?\n/);
-      } catch {
+      const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
+      const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
+      if (manifest.omitted) {
+         parts.push(`## ${jsonlName}\n\n${manifest.omitted}`);
          continue;
       }
 
       const fileChunks: string[] = [];
-      for (const line of lines) {
+      for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
          try {
@@ -369,12 +612,8 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             const targetPath = resolveProjectFile(projectRoot, file, trustedRoots);
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
-            let content = "";
-            try { content = readFileSync(targetPath, "utf-8"); } catch { }
-            if (content.trim()) {
-               includedPaths.add(targetPath);
-               fileChunks.push(`### ${file}\n\n${content.trim()}`);
-            }
+            includedPaths.add(targetPath);
+            fileChunks.push(materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits, budget));
          } catch {
             // seed rows and malformed lines are non-fatal
          }
@@ -386,7 +625,7 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    }
 
    return parts.length > 0
-      ? `<task-context>\n${parts.join("\n\n")}\n</task-context>`
+      ? `<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n${parts.join("\n\n")}\n</task-context>`
       : "";
 }
 

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
-import { closeSync, existsSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, lstatSync, openSync, readFileSync, readdirSync, realpathSync, statSync, readSync } from "node:fs";
 import { join, dirname, basename, isAbsolute, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -413,56 +413,119 @@ function readContextInjectionLimits(projectRoot: string): ContextInjectionLimits
 }
 
 class ContextBudget {
-   used = 0;
-   constructor(private readonly maxTotalBytes: number) {}
+   used: number;
+   private terminalSummaryEmitted = false;
+   private stopped = false;
+   constructor(private readonly maxTotalBytes: number, initialUsed = 0) {
+      this.used = initialUsed;
+   }
 
    hasRoom(bytes: number): boolean {
-      return this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes;
+      return !this.stopped && (this.maxTotalBytes <= 0 || this.used + bytes <= this.maxTotalBytes);
    }
 
-   add(bytes: number): void {
+   emit(text: string): string {
+      const bytes = Buffer.byteLength(text, "utf-8");
+      if (!this.hasRoom(bytes)) return "";
       this.used += bytes;
+      return text;
    }
+
+   emitCandidate(primary: string, fallback: string | null): string {
+      const direct = this.emit(primary);
+      if (direct) return direct;
+      if (fallback !== null) {
+         const notice = this.emit(fallback);
+         if (notice) return notice;
+      }
+      return this.emitTerminalSummary();
+   }
+
+   private emitTerminalSummary(): string {
+      if (this.terminalSummaryEmitted) return "";
+      this.terminalSummaryEmitted = true;
+      this.stopped = true;
+      const summary = "[Trellis: context limit reached; omitted entries remain authoritative on disk and require_read paths above.]";
+      if (this.maxTotalBytes <= 0) {
+         this.used += Buffer.byteLength(summary, "utf-8");
+         return summary;
+      }
+      const remaining = this.maxTotalBytes - this.used;
+      if (remaining <= 0) return "";
+      const bounded = truncateUtf8(Buffer.from(summary, "utf-8"), remaining).toString("utf-8");
+      this.used += Buffer.byteLength(bounded, "utf-8");
+      return bounded;
+   }
+}
+
+type Utf8Status = "valid" | "incomplete" | "invalid";
+
+function utf8Status(data: Buffer): Utf8Status {
+   for (let index = 0; index < data.length; index++) {
+      const lead = data[index]!;
+      if (lead <= 0x7f) continue;
+
+      let length: number;
+      let secondMin = 0x80;
+      let secondMax = 0xbf;
+      if (lead >= 0xc2 && lead <= 0xdf) length = 2;
+      else if (lead >= 0xe0 && lead <= 0xef) {
+         length = 3;
+         if (lead === 0xe0) secondMin = 0xa0;
+         if (lead === 0xed) secondMax = 0x9f;
+      } else if (lead >= 0xf0 && lead <= 0xf4) {
+         length = 4;
+         if (lead === 0xf0) secondMin = 0x90;
+         if (lead === 0xf4) secondMax = 0x8f;
+      } else return "invalid";
+
+      if (index + length > data.length) {
+         for (let tail = index + 1; tail < data.length; tail++) {
+            if (data[tail]! < 0x80 || data[tail]! > 0xbf) return "invalid";
+         }
+         return "incomplete";
+      }
+      const second = data[index + 1]!;
+      if (second < secondMin || second > secondMax) return "invalid";
+      for (let continuation = index + 2; continuation < index + length; continuation++) {
+         const byte = data[continuation]!;
+         if (byte < 0x80 || byte > 0xbf) return "invalid";
+      }
+      index += length - 1;
+   }
+   return "valid";
 }
 
 function truncateUtf8(data: Buffer, cap: number): Buffer {
    if (cap <= 0 || data.length <= cap) return data;
-   let end = cap;
-   while (end > 0 && (data[end - 1]! & 0xc0) === 0x80) end--;
-   if (end === 0) return Buffer.alloc(0);
-   const lead = data[end - 1]!;
-   if (lead & 0x80) {
-      let sequenceLength = 1;
-      if ((lead & 0xe0) === 0xc0) sequenceLength = 2;
-      else if ((lead & 0xf0) === 0xe0) sequenceLength = 3;
-      else if ((lead & 0xf8) === 0xf0) sequenceLength = 4;
-      if (end - 1 + sequenceLength > cap) end--;
+   if (utf8Status(data.subarray(0, cap)) === "valid") return data.subarray(0, cap);
+   // A bounded read has already been validated as a complete UTF-8 stream.
+   // Only its final, incomplete code point may make the cap prefix invalid.
+   for (let end = cap - 1; end >= Math.max(0, cap - 4); end--) {
+      const candidate = data.subarray(0, end);
+      if (utf8Status(candidate) === "valid") return candidate;
    }
-   return data.subarray(0, end);
+   return Buffer.alloc(0);
 }
 
 function isUtf8(data: Buffer): boolean {
-   try {
-      const decoded = data.toString("utf-8");
-      return Buffer.from(decoded, "utf-8").equals(data);
-   } catch {
-      return false;
-   }
+   return utf8Status(data) === "valid";
 }
 
 function readFilePrefix(filePath: string, maxBytes: number): { data: Buffer; size: number } | null {
    let fd: number | null = null;
    try {
-      const size = statSync(filePath).size;
-      if (maxBytes <= 0 || size <= maxBytes) {
-         return { data: readFileSync(filePath), size };
-      }
       fd = openSync(filePath, "r");
+      if (maxBytes <= 0) {
+         const data = readFileSync(fd);
+         return { data, size: fstatSync(fd).size };
+      }
       // Read a few extra bytes so a UTF-8 sequence crossing the cap can be
-      // validated before truncateUtf8 removes its incomplete suffix.
+      // validated before truncateUtf8 removes its incomplete suffix. The
+      // descriptor keeps the read bounded if the path is replaced or grows.
       const data = Buffer.allocUnsafe(maxBytes + 4);
       const bytesRead = readSync(fd, data, 0, data.length, 0);
-      return { data: data.subarray(0, bytesRead), size };
+      return { data: data.subarray(0, bytesRead), size: fstatSync(fd).size };
    } catch {
       return null;
    } finally {
@@ -475,22 +538,9 @@ function omittedNotice(file: string, size: number | null, reason: string): strin
    return `### ${file} [omitted]\n\n[Trellis: omitted (${reason}) — ${file} (${sizeText}); required_read: ${file}]`;
 }
 
-function budgetedBlock(
-   budget: ContextBudget,
-   file: string,
-   content: string,
-   status: "inline" | "truncated",
-   size: number,
-   reason: string,
-): string {
-   const block = `### ${file} [${status}]\n\n${content}`;
-   if (budget.hasRoom(Buffer.byteLength(block, "utf-8"))) {
-      budget.add(Buffer.byteLength(block, "utf-8"));
-      return block;
-   }
-   const notice = omittedNotice(file, size, `total context limit reached: ${reason}`);
-   budget.add(Buffer.byteLength(notice, "utf-8"));
-   return notice;
+interface MaterializedFile {
+   block: string | null;
+   notice: string;
 }
 
 function materializeFile(
@@ -498,26 +548,27 @@ function materializeFile(
    displayPath: string,
    reason: string,
    limits: ContextInjectionLimits,
-   budget: ContextBudget,
-): string {
+): MaterializedFile {
    const file = readFilePrefix(targetPath, limits.max_file_bytes);
    if (!file) {
-      return omittedNotice(displayPath, null, "file is missing or unreadable");
+      return { block: null, notice: omittedNotice(displayPath, null, "file is missing or unreadable") };
    }
    const { data, size } = file;
-   const truncated = truncateUtf8(data, limits.max_file_bytes);
-   if (truncated.includes(0) || !isUtf8(truncated)) {
-      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`);
-      budget.add(Buffer.byteLength(notice, "utf-8"));
-      return notice;
+   const encodingStatus = utf8Status(data);
+   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 file: ${reason}`) };
    }
+   const truncated = truncateUtf8(data, limits.max_file_bytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
       content += `\n[Trellis: truncated at ${limits.max_file_bytes} bytes — read ${displayPath} for the full content]`;
    }
-   return budgetedBlock(budget, displayPath, content, status, size, reason);
+   return {
+      block: `### ${displayPath} [${status}]\n\n${content}`,
+      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
+   };
 }
 
 function materializeArtifact(
@@ -525,45 +576,51 @@ function materializeArtifact(
    displayPath: string,
    reason: string,
    limits: ContextInjectionLimits,
-   budget: ContextBudget,
-): string {
+): MaterializedFile {
    const file = readFilePrefix(targetPath, limits.max_artifact_bytes);
    if (!file) {
-      return omittedNotice(displayPath, null, "artifact is missing or unreadable");
+      return { block: null, notice: omittedNotice(displayPath, null, "artifact is missing or unreadable") };
    }
    const { data, size } = file;
-   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
-   if (truncated.includes(0) || !isUtf8(truncated)) {
-      const notice = omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`);
-      budget.add(Buffer.byteLength(notice, "utf-8"));
-      return notice;
+   const encodingStatus = utf8Status(data);
+   if (data.includes(0) || encodingStatus === "invalid" || (encodingStatus === "incomplete" && size <= data.length)) {
+      return { block: null, notice: omittedNotice(displayPath, size, `binary or non-UTF-8 artifact: ${reason}`) };
    }
+   const truncated = truncateUtf8(data, limits.max_artifact_bytes);
    let content = truncated.toString("utf-8");
    let status: "inline" | "truncated" = "inline";
    if (truncated.length < size) {
       status = "truncated";
       content += `\n[Trellis: truncated at ${limits.max_artifact_bytes} bytes — read ${displayPath} for the full content]`;
    }
-   return budgetedBlock(budget, displayPath, content, status, size, reason);
+   return {
+      block: `### ${displayPath} [${status}]\n\n${content}`,
+      notice: omittedNotice(displayPath, size, `total context limit reached: ${reason}`),
+   };
 }
 
 function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string[]; omitted: string | null } {
-   let size: number;
+   let fd: number | null = null;
    try {
-      size = statSync(jsonlPath).size;
+      fd = openSync(jsonlPath, "r");
+      const data = Buffer.allocUnsafe(MAX_JSONL_BYTES + 1);
+      const bytesRead = readSync(fd, data, 0, data.length, 0);
+      const size = fstatSync(fd).size;
+      if (bytesRead > MAX_JSONL_BYTES || size > MAX_JSONL_BYTES) {
+         return {
+            lines: [],
+            omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
+         };
+      }
+      const content = data.subarray(0, bytesRead);
+      if (!isUtf8(content)) {
+         return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is not valid UTF-8") };
+      }
+      return { lines: content.toString("utf-8").split(/\r?\n/), omitted: null };
    } catch {
-      return { lines: [], omitted: null };
-   }
-   if (size > MAX_JSONL_BYTES) {
-      return {
-         lines: [],
-         omitted: omittedNotice(displayPath, size, `manifest exceeds ${MAX_JSONL_BYTES} byte parse limit`),
-      };
-   }
-   try {
-      return { lines: readFileSync(jsonlPath, "utf-8").split(/\r?\n/), omitted: null };
-   } catch {
-      return { lines: [], omitted: omittedNotice(displayPath, size, "manifest is missing or unreadable") };
+      return { lines: [], omitted: omittedNotice(displayPath, null, "manifest is missing or unreadable") };
+   } finally {
+      if (fd !== null) closeSync(fd);
    }
 }
 
@@ -573,15 +630,34 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
    const limits = readContextInjectionLimits(projectRoot);
-   const budget = new ContextBudget(limits.max_total_bytes);
+   const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
+   const suffix = "\n</task-context>";
+   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+
+   const emit = (text: string, fallback: string | null = null): string => budget.emitCandidate(text, fallback);
+   const appendCandidate = (primary: string, fallback: string | null = null): void => {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const output = emit(
+         primary ? separator + primary : "",
+         fallback === null ? null : separator + fallback,
+      );
+      if (output) parts.push(output);
+   };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
    const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
-   if (existsSync(prdPath)) parts.push(materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits, budget));
+   if (existsSync(prdPath)) {
+      const artifact = materializeArtifact(prdPath, relativePrdPath, "Requirements document", limits);
+      appendCandidate(artifact.block ?? "", artifact.notice);
+   }
    const infoPath = join(taskDir, "info.md");
    const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
-   if (existsSync(infoPath)) parts.push(materializeArtifact(infoPath, relativeInfoPath, "Task information", limits, budget));
+   if (existsSync(infoPath)) {
+      const artifact = materializeArtifact(infoPath, relativeInfoPath, "Task information", limits);
+      appendCandidate(artifact.block ?? "", artifact.notice);
+   }
 
    // Determine which jsonl files to read based on agent type
    const jsonlNames = taskContextJsonlNames(agentType);
@@ -597,11 +673,12 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
       const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
       const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
       if (manifest.omitted) {
-         parts.push(`## ${jsonlName}\n\n${manifest.omitted}`);
+         appendCandidate(`## ${jsonlName}\n\n${manifest.omitted}`);
          continue;
       }
 
       const fileChunks: string[] = [];
+      let sectionHeaderEmitted = false;
       for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
@@ -613,20 +690,31 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            fileChunks.push(materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits, budget));
+            const materialized = materializeFile(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits);
+            const sectionPrefix = sectionHeaderEmitted
+               ? "\n\n---\n\n"
+               : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
+            const output = emit(
+               materialized.block ? `${sectionPrefix}${materialized.block}` : "",
+               `${sectionPrefix}${materialized.notice}`,
+            );
+            if (output) {
+               fileChunks.push(output);
+               sectionHeaderEmitted = true;
+            }
          } catch {
             // seed rows and malformed lines are non-fatal
          }
       }
 
-      if (fileChunks.length > 0) {
-         parts.push(`## ${jsonlName}\n\n${fileChunks.join("\n\n---\n\n")}`);
-      }
+      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
    }
 
-   return parts.length > 0
-      ? `<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n${parts.join("\n\n")}\n</task-context>`
-      : "";
+   if (parts.length === 0) return "";
+   const context = `${prefix}${parts.join("")}${suffix}`;
+   return limits.max_total_bytes > 0 && Buffer.byteLength(context, "utf-8") > limits.max_total_bytes
+      ? truncateUtf8(Buffer.from(context, "utf-8"), limits.max_total_bytes).toString("utf-8")
+      : context;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -443,6 +443,32 @@ describe("omp templates", () => {
     }
   });
 
+  it("omits invalid UTF-8 second-byte boundary pairs", async () => {
+    for (const [name, bytes] of [
+      ["invalid-e0.md", [0x61, 0xe0, 0x80, 0x62]],
+      ["invalid-ed.md", [0x61, 0xed, 0xa0, 0x80, 0x62]],
+    ] as const) {
+      const project = makeOmpProject();
+      try {
+        fs.writeFileSync(
+          path.join(project.root, ".trellis", "config.yaml"),
+          "context_injection:\n  max_file_bytes: 3\n  max_artifact_bytes: 64\n  max_total_bytes: 2000\n",
+        );
+        fs.writeFileSync(path.join(project.root, name), Buffer.from(bytes));
+        fs.writeFileSync(
+          path.join(project.taskDir, "implement.jsonl"),
+          JSON.stringify({ file: name, reason: "invalid second-byte boundary" }) + "\n",
+        );
+
+        const context = await runSessionStart(project.root, project.sessionId);
+        expect(context).toContain(`${name} [omitted]`);
+        expect(context).not.toContain(`${name} [truncated]`);
+      } finally {
+        fs.rmSync(project.root, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("truncates a valid multibyte character that crosses the file limit", async () => {
     const project = makeOmpProject();
     try {
@@ -458,7 +484,8 @@ describe("omp templates", () => {
 
       const context = await runSessionStart(project.root, project.sessionId);
       expect(context).toContain("unicode.md [truncated]");
-      expect(context).toContain("a");
+      expect(context).toContain("### unicode.md [truncated]\n\na\n[Trellis: truncated at 3 bytes");
+      expect(context).not.toContain("€");
       expect(context).not.toContain("unicode.md [omitted]");
     } finally {
       fs.rmSync(project.root, { recursive: true, force: true });
@@ -505,7 +532,11 @@ describe("omp templates", () => {
 
       const context = await runSessionStart(project.root, project.sessionId);
       expect(Buffer.byteLength(context, "utf-8")).toBeLessThanOrEqual(maxTotalBytes);
-      expect(context.match(/\[omitted\]/g)?.length ?? 0).toBeLessThan(20);
+      const omittedCount = context.match(/\[omitted\]/g)?.length ?? 0;
+      expect(omittedCount).toBeGreaterThan(0);
+      expect(omittedCount).toBeLessThan(20);
+      expect(context).toContain("context limit reached");
+      expect(context).toMatch(/<\/task-context>$/);
     } finally {
       fs.rmSync(project.root, { recursive: true, force: true });
     }

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -421,6 +421,96 @@ describe("omp templates", () => {
     }
   });
 
+  it("omits a file when an invalid UTF-8 byte is exactly at the file limit", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 3\n  max_artifact_bytes: 64\n  max_total_bytes: 2000\n",
+      );
+      fs.writeFileSync(path.join(project.root, "invalid.md"), Buffer.from([0x61, 0x62, 0x63, 0x80, 0x64]));
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "invalid.md", reason: "invalid boundary" }) + "\n",
+      );
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain("invalid.md [omitted]");
+      expect(context).toContain("binary or non-UTF-8 file");
+      expect(context).not.toContain("invalid.md [truncated]");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("truncates a valid multibyte character that crosses the file limit", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 3\n  max_artifact_bytes: 64\n  max_total_bytes: 2000\n",
+      );
+      fs.writeFileSync(path.join(project.root, "unicode.md"), "a€tail");
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "unicode.md", reason: "unicode boundary" }) + "\n",
+      );
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain("unicode.md [truncated]");
+      expect(context).toContain("a");
+      expect(context).not.toContain("unicode.md [omitted]");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a valid multibyte character when it ends at the file limit", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 4\n  max_artifact_bytes: 64\n  max_total_bytes: 2000\n",
+      );
+      fs.writeFileSync(path.join(project.root, "unicode-end.md"), "a€tail");
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "unicode-end.md", reason: "unicode end boundary" }) + "\n",
+      );
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain("unicode-end.md [truncated]");
+      expect(context).toContain("a€");
+      expect(context).not.toContain("unicode-end.md [omitted]");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("never exceeds the total context byte limit with repeated omitted entries", async () => {
+    const project = makeOmpProject();
+    const maxTotalBytes = 700;
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        `context_injection:\n  max_file_bytes: 0\n  max_artifact_bytes: 64\n  max_total_bytes: ${maxTotalBytes}\n`,
+      );
+      const rows: string[] = [];
+      for (let index = 0; index < 20; index++) {
+        const file = `oversized-${index}.md`;
+        fs.writeFileSync(path.join(project.root, file), "x".repeat(2000));
+        rows.push(JSON.stringify({ file, reason: "budget regression" }));
+      }
+      fs.writeFileSync(path.join(project.taskDir, "implement.jsonl"), `${rows.join("\n")}\n`);
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(Buffer.byteLength(context, "utf-8")).toBeLessThanOrEqual(maxTotalBytes);
+      expect(context.match(/\[omitted\]/g)?.length ?? 0).toBeLessThan(20);
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
   it("no settings.json or Python hooks exist in the template directory", () => {
     // OMP is extension-backed: native provider auto-discovers .omp/ subdirs,
     // so no settings.json is needed and no Python hooks should be present.

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import os from "node:os";
 import vm from "node:vm";
 import ts from "typescript";
 import {
@@ -58,6 +57,39 @@ function captureOmpHandlers(): Map<string, OmpEventHandler> {
   return handlers;
 }
 
+function makeOmpProject(): { root: string; taskDir: string; sessionId: string } {
+  const root = fs.mkdtempSync(path.join(process.env.TMPDIR ?? "/tmp", "trellis-omp-") );
+  const taskDir = path.join(root, ".trellis", "tasks", "08-13-context-limits");
+  const sessionId = "context_limits";
+  fs.mkdirSync(path.join(root, ".trellis", ".runtime", "sessions"), { recursive: true });
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, "task.json"), JSON.stringify({ status: "in_progress", title: "Context limits" }));
+  fs.writeFileSync(
+    path.join(root, ".trellis", ".runtime", "sessions", "omp_context_limits.json"),
+    JSON.stringify({ current_task: ".trellis/tasks/08-13-context-limits" }),
+  );
+  return { root, taskDir, sessionId };
+}
+
+async function runSessionStart(root: string, sessionId: string): Promise<string> {
+  const messages: { customType?: string; content?: string }[] = [];
+  const handlers = new Map<string, OmpEventHandler>();
+  loadOmpExtension()({
+    on: (event, handler) => handlers.set(event, handler),
+    sendMessage: async (message: { customType?: string; content?: string }) => {
+      messages.push(message);
+    },
+  } as never);
+  const handler = handlers.get("session_start");
+  if (!handler) throw new Error("OMP extension did not register session_start");
+  await handler({}, {
+    cwd: root,
+    sessionManager: { getSessionId: () => sessionId },
+    ui: { notify: () => undefined },
+  });
+  return messages.find((message) => message.customType === "trellis-task-context")?.content ?? "";
+}
+
 describe("omp templates", () => {
   it("provides the three Trellis sub-agent definitions", () => {
     const agents = getAllAgents();
@@ -96,7 +128,7 @@ describe("omp templates", () => {
     expect(extension).toContain('buildContextKey("omp", "session", sessionId)');
     expect(extension).toContain("realpathSync");
     expect(extension).toContain("resolveProjectFile(projectRoot, file, trustedRoots)");
-    expect(extension).toContain("readFileSync(targetPath");
+    expect(extension).toContain("readFilePrefix(targetPath");
     expect(extension).toContain("if (!key) return null;");
     expect(extension).toContain("return key;");
     expect(extension).toContain(`if (existsSync(candidate)) {
@@ -323,6 +355,69 @@ describe("omp templates", () => {
       expect(unchanged).toBeUndefined();
     } finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds referenced files and marks truncated content as recoverable", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(path.join(project.taskDir, "prd.md"), "requirements");
+      fs.writeFileSync(path.join(project.root, "large.md"), "x".repeat(40_000));
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        JSON.stringify({ file: "large.md", reason: "large reference" }) + "\n",
+      );
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain("large.md [truncated]");
+      expect(context).toContain("read large.md for the full content");
+      expect(context).toContain("Context is bounded by .trellis/config.yaml");
+      expect(Buffer.byteLength(context, "utf-8")).toBeLessThan(140_000);
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("continues with later files after an earlier file is omitted by the total budget", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 0\n  max_total_bytes: 500\n",
+      );
+      fs.writeFileSync(path.join(project.root, "large.md"), "x".repeat(800));
+      fs.writeFileSync(path.join(project.root, "small.md"), "small reference");
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        [
+          JSON.stringify({ file: "large.md", reason: "large first" }),
+          JSON.stringify({ file: "small.md", reason: "small later" }),
+        ].join("\n") + "\n",
+      );
+
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain("large.md [omitted]");
+      expect(context).toContain("required_read: large.md");
+      expect(context).toContain("small.md [inline]");
+      expect(context).toContain("small reference");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an oversized JSONL manifest instead of silently truncating it", async () => {
+    const project = makeOmpProject();
+    try {
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        " ".repeat(1024 * 1024 + 1),
+      );
+      const context = await runSessionStart(project.root, project.sessionId);
+      expect(context).toContain(".trellis/tasks/08-13-context-limits/implement.jsonl [omitted]");
+      expect(context).toContain("required_read: .trellis/tasks/08-13-context-limits/implement.jsonl");
+      expect(context).toContain("manifest exceeds 1048576 byte parse limit");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
     }
   });
 

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -358,6 +358,83 @@ describe("omp templates", () => {
     }
   });
 
+  it("re-evaluates later budgeted files when an earlier file shrinks mid-session", async () => {
+    const project = makeOmpProject();
+    const messages: { customType?: string; content?: string }[] = [];
+
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 0\n  max_artifact_bytes: 64\n  max_total_bytes: 900\n",
+      );
+      const earlierFile = path.join(project.root, "earlier.md");
+      fs.writeFileSync(earlierFile, "a".repeat(450));
+      fs.writeFileSync(path.join(project.root, "later.md"), "later content ".repeat(25));
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        [
+          JSON.stringify({ file: "earlier.md", reason: "earlier budget consumer" }),
+          JSON.stringify({ file: "later.md", reason: "later candidate" }),
+        ].join("\n") + "\n",
+      );
+
+      const handlers = new Map<string, OmpEventHandler>();
+      loadOmpExtension()({
+        on: (event, handler) => handlers.set(event, handler),
+        sendMessage: async (message) =>
+          messages.push(message as { customType?: string; content?: string }),
+      });
+      const sessionStart = handlers.get("session_start");
+      const context = handlers.get("context");
+      if (!sessionStart || !context)
+        throw new Error("OMP extension did not register required handlers");
+      const ctx = {
+        cwd: project.root,
+        sessionManager: { getSessionId: () => project.sessionId },
+        ui: { notify: () => undefined },
+      };
+
+      await sessionStart({}, ctx);
+      const initial = messages.find(
+        (message) => message.customType === "trellis-task-context",
+      );
+      expect(initial?.content).toContain("earlier.md [inline]");
+      expect(initial?.content).toContain("later.md [omitted]");
+
+      fs.writeFileSync(earlierFile, "short earlier content");
+      const result = (await context(
+        {
+          messages: [
+            {
+              role: "custom",
+              customType: "trellis-task-context",
+              content: initial?.content,
+            },
+            {
+              role: "custom",
+              customType: "trellis-workflow-state",
+              content: "workflow",
+            },
+          ],
+        },
+        ctx,
+      )) as
+        | { messages?: { customType?: string; content?: string }[] }
+        | undefined;
+
+      const refreshed = result?.messages?.filter(
+        (message) => message.customType === "trellis-task-context",
+      );
+      expect(refreshed).toHaveLength(1);
+      expect(refreshed?.[0]?.content).toContain("short earlier content");
+      expect(refreshed?.[0]?.content).toContain("later.md [inline]");
+      expect(refreshed?.[0]?.content).toContain("later content");
+      expect(refreshed?.[0]?.content).not.toContain("later.md [omitted]");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
   it("bounds referenced files and marks truncated content as recoverable", async () => {
     const project = makeOmpProject();
     try {


### PR DESCRIPTION
## Summary

Bound OMP Trellis task-context injection with per-file, artifact, and total context budgets, preventing large fixtures, logs, or archived JSON files from inflating the model context.

## Implementation

- Reuse the `.trellis/config.yaml` `context_injection` settings, with defaults of 32 KiB for referenced files, 64 KiB for task artifacts, and 128 KiB for the total injected context.
- Emit `[truncated]` for oversized files while preserving a direct path for reading the full content.
- Emit `[omitted]` when the total budget is insufficient, including the path, file size, reason, and `required_read`.
- Continue processing later manifest entries after omitting an oversized file instead of stopping early.
- Inspect JSONL manifests larger than 1 MiB via metadata and report them explicitly rather than silently loading or truncating them.
- Synchronize the OMP installation template with the repository's `.omp` dogfood extension.

## Testing

- OMP targeted tests: 16/16 passed.
- Full CLI test suite: 1,674/1,674 passed.
- Core tests: 344 passed, with 1 pre-existing skipped test.
- Lint, typecheck, build, and `git diff --check` passed.

## Related

Related to #535.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for individual files, artifacts, and total injected task context.
  * Added safe handling for oversized, unreadable, binary, or invalid text files, with clear omission and truncation notices.
  * Added project-relative file paths and included project configuration in task context.
  * Limited JSONL manifest processing to 1 MiB with clear processing notices.
  * Clarified that omitted or truncated files remain available on disk as the authoritative source.
* **Bug Fixes**
  * Files exceeding context budgets no longer prevent later referenced files from being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->