### PR TITLE
docs(dsh): clarify bundled meta foreground fallback

### DIFF
--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/agents.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/platform-files/agents.md
@@ -35,7 +35,7 @@ Agent files should not become generic chat prompts. They should define input sou
 | Reasonix | `.reasonix/skills/trellis-*/SKILL.md` (subagent frontmatter) |
 | ZCode | `.zcode/agents/trellis-*.md` |
 | Kimi Code | `.kimi-code/skills/trellis-*/SKILL.md` (agent prompts as skills, dispatched to the built-in `coder`; research needs its file-editing tools to persist findings) |
-| DeepSeek Harness | `.dsh/skills/trellis-agent-*/SKILL.md` (role prompts as child-only skills; optional `trellis_wait` enables continuable background settlement, otherwise initial foreground dispatch) |
+| DeepSeek Harness | `.dsh/skills/trellis-agent-*/SKILL.md` (role prompts as child-only skills; optional `trellis_wait` enables continuable background settlement; without it, dispatch every child with `run_in_background: false` from the outset) |
 
 GitHub Copilot agent/prompt support is provided by a combination of directories such as `.github/agents/`, `.github/prompts/`, and `.github/skills/`; inspect the files actually generated in the user project.
 

--- a/packages/cli/test/templates/dsh.test.ts
+++ b/packages/cli/test/templates/dsh.test.ts
@@ -147,6 +147,17 @@ describe("dsh collectDshTemplates", () => {
     }
   });
 
+  it("keeps the bundled meta reference explicit about the DSH fallback", () => {
+    const metaAgents = collectDshTemplates().get(
+      ".agents/skills/trellis-meta/references/platform-files/agents.md",
+    );
+
+    expect(metaAgents).toContain(
+      "without it, dispatch every child with `run_in_background: false` from the outset",
+    );
+    expect(metaAgents).not.toContain("otherwise initial foreground dispatch");
+  });
+
   it("ships the operator guide and no hooks/settings files", () => {
     const files = collectDshTemplates();
     expect(files.get(".dsh/DSH.md")).toContain(


### PR DESCRIPTION
## Summary

- make the DeepSeek Harness row in the bundled `trellis-meta` platform reference explicit about the no-plugin fallback
- require every DSH child to start with `run_in_background: false` when `trellis_wait` is unavailable
- add a DSH template regression test so the bundled reference cannot drift back to the ambiguous wording

## Why

This is a narrow follow-up to #550 and addresses the unresolved review finding in https://github.com/mindfold-ai/Trellis/pull/550#discussion_r3782080030. The affected row originated in the DSH support merged through #548; no other platform guidance is changed.

## Impact

Generated `trellis-meta` guidance is now consistent with the DSH operator guide and workflow template. Runtime behavior and non-DSH platform documentation are unchanged.

## Validation

- `pnpm --filter @mindfoldhq/trellis test -- test/templates/dsh.test.ts` (10 passed)
- `pnpm --filter @mindfoldhq/trellis exec eslint test/templates/dsh.test.ts`
- `git diff --check`
- GitNexus change analysis: low risk, no affected execution flows