### PR TITLE
feat(zcode): add trellis bridge setup hint

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -61,6 +61,7 @@ import {
 } from "../configurators/index.js";
 import { replacePythonCommandLiterals } from "../configurators/shared.js";
 import { preserveCodexAgentModelKeys } from "../configurators/codex.js";
+import { printZcodeSetupHint } from "../configurators/zcode.js";
 import { ensureGitattributes } from "../configurators/workflow.js";
 import { pruneOrphanManifestKeys } from "../utils/manifest-prune.js";
 import {
@@ -2159,6 +2160,7 @@ export async function update(options: UpdateOptions): Promise<void> {
 
   // Load template hashes for modification detection
   let hashes = loadHashes(cwd);
+  const zcodeConfigured = getConfiguredPlatforms(cwd).has("zcode");
   const isFirstHashTracking = Object.keys(hashes).length === 0;
 
   // Handle unknown version - skip regular migrations but safe-file-delete still runs
@@ -2449,6 +2451,7 @@ export async function update(options: UpdateOptions): Promise<void> {
         );
       }
     }
+    if (zcodeConfigured) printZcodeSetupHint();
     return;
   }
 
@@ -2865,6 +2868,8 @@ export async function update(options: UpdateOptions): Promise<void> {
       }
     }
   }
+
+  if (zcodeConfigured) printZcodeSetupHint();
 
   // Display breaking change warnings at the very end (so they don't scroll off screen)
   if (cliVsProject > 0 && projectVersion !== "unknown") {

--- a/packages/cli/src/configurators/zcode.ts
+++ b/packages/cli/src/configurators/zcode.ts
@@ -69,21 +69,25 @@ export function collectZcodeTemplates(): Map<string, string> {
   return files;
 }
 
+/** Print the manual global-plugin fallback required by affected ZCode builds. */
+export function printZcodeSetupHint(): void {
+  if (process.env.VITEST || process.env.TRELLIS_QUIET) return;
+
+  const plugin = AI_TOOLS.zcode.globalHookPlugin;
+  if (!plugin) return;
+
+  process.stderr.write(
+    `ℹ️  ZCode: if project Hooks are disabled, install ${plugin.name}, then start a new session.\n` +
+      `   ZCode：若项目 Hooks 被禁用，请安装 ${plugin.name}，然后新建会话。\n` +
+      `   请手动在 ZCode 插件市场中添加 ${plugin.marketplaceUrl}，并手动安装 ZCode 补丁插件 ${plugin.name}\n`,
+  );
+}
+
 /**
  * Configure ZCode at init time: write the collected file set, then the one
  * thing a `Map<path, content>` cannot carry — a console notice.
  */
 export async function configureZcode(cwd: string): Promise<void> {
   await writeTemplateMap(cwd, collectZcodeTemplates());
-
-  // ZCode loads hook config at session start and does NOT hot-reload it, so
-  // users must open a new session for these hooks to fire. Mirrors the Codex
-  // one-shot hint pattern; silent under test/quiet environments.
-  if (!process.env.VITEST && !process.env.TRELLIS_QUIET) {
-    process.stderr.write(
-      "ℹ️  ZCode loads hooks at session start (no hot-reload). " +
-        "Open a NEW ZCode session for the Trellis SessionStart / " +
-        "UserPromptSubmit / PreToolUse hooks in .zcode/config.json to take effect.\n",
-    );
-  }
+  printZcodeSetupHint();
 }

--- a/packages/cli/src/types/ai-tools.ts
+++ b/packages/cli/src/types/ai-tools.ts
@@ -153,6 +153,16 @@ export interface AIToolConfig {
   defaultChecked: boolean;
   /** Whether this tool uses Python hooks (affects Windows encoding detection) */
   hasPythonHooks: boolean;
+  /**
+   * Optional user-global compatibility plugin for platform versions where
+   * project-level integration is unavailable. Trellis may surface a manual
+   * installation hint, but leaves installation and lifecycle management to
+   * the platform UI.
+   */
+  globalHookPlugin?: {
+    name: string;
+    marketplaceUrl: string;
+  };
   /** Template context for placeholder resolution in common templates */
   templateContext: TemplateContext;
 }
@@ -472,20 +482,26 @@ export const AI_TOOLS: Record<AITool, AIToolConfig> = {
       ".zcode/agents",
       ".zcode/commands",
       ".zcode/skills",
-      // Hooks assets written by configureZcode.
+      // Hook implementations written by configureZcode. On ZCode builds that
+      // disable project hook registration, trellis-bridge invokes them instead.
       ".zcode/hooks",
     ],
     cliFlag: "zcode",
     defaultChecked: false,
     hasPythonHooks: true,
+    globalHookPlugin: {
+      name: "trellis-bridge",
+      marketplaceUrl: "https://github.com/CNHLAIA/ZCode-Trellis-Plugin.git",
+    },
     templateContext: {
       cmdRefPrefix: "/trellis:",
       executorAI: "Bash scripts or Agent calls",
       userActionLabel: "Skills",
       agentCapable: true,
-      // ZCode (3.x) supports a workspace hook config at .zcode/config.json
-      // with SessionStart / UserPromptSubmit / PreToolUse events. PreToolUse
-      // can mutate sub-agent prompts, so ZCode is class-1 hook-inject.
+      // ZCode supports project hook registration through .zcode/config.json.
+      // On builds that disable it, the optional global trellis-bridge plugin
+      // registers the same events and delegates to the project hook scripts.
+      // PreToolUse can mutate sub-agent prompts, so either path is class-1.
       hasHooks: true,
       cliFlag: "zcode",
     },

--- a/packages/cli/test/commands/init.integration.test.ts
+++ b/packages/cli/test/commands/init.integration.test.ts
@@ -806,6 +806,35 @@ describe("init() integration", () => {
     ).toBe(true);
   });
 
+  it("[issue-zcode-plugin-hint] zcode init prints a concise bilingual plugin hint", async () => {
+    const originalVitest = process.env.VITEST;
+    const originalQuiet = process.env.TRELLIS_QUIET;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = ((chunk: string) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    delete process.env.VITEST;
+    delete process.env.TRELLIS_QUIET;
+
+    try {
+      await init({ yes: true, zcode: true });
+    } finally {
+      process.stderr.write = originalWrite;
+      if (originalVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = originalVitest;
+      if (originalQuiet === undefined) delete process.env.TRELLIS_QUIET;
+      else process.env.TRELLIS_QUIET = originalQuiet;
+    }
+
+    expect(stderr.join("")).toBe(
+      "ℹ️  ZCode: if project Hooks are disabled, install trellis-bridge, then start a new session.\n" +
+        "   ZCode：若项目 Hooks 被禁用，请安装 trellis-bridge，然后新建会话。\n" +
+        "   请手动在 ZCode 插件市场中添加 https://github.com/CNHLAIA/ZCode-Trellis-Plugin.git，并手动安装 ZCode 补丁插件 trellis-bridge\n",
+    );
+  });
+
   it("#3n opencode platform emits start slash command", async () => {
     await init({ yes: true, opencode: true });
 

--- a/packages/cli/test/commands/update.integration.test.ts
+++ b/packages/cli/test/commands/update.integration.test.ts
@@ -309,6 +309,69 @@ describe("update() integration", () => {
     expect(fs.existsSync(projectFile(".agents/skills"))).toBe(false);
   });
 
+  it("[issue-zcode-plugin-hint] zcode update prints the bilingual plugin hint when already up to date", async () => {
+    await init({ yes: true, force: true, zcode: true });
+
+    const originalVitest = process.env.VITEST;
+    const originalQuiet = process.env.TRELLIS_QUIET;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = ((chunk: string) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    delete process.env.VITEST;
+    delete process.env.TRELLIS_QUIET;
+
+    try {
+      await update({});
+    } finally {
+      process.stderr.write = originalWrite;
+      if (originalVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = originalVitest;
+      if (originalQuiet === undefined) delete process.env.TRELLIS_QUIET;
+      else process.env.TRELLIS_QUIET = originalQuiet;
+    }
+
+    expect(stderr.join("")).toBe(
+      "ℹ️  ZCode: if project Hooks are disabled, install trellis-bridge, then start a new session.\n" +
+        "   ZCode：若项目 Hooks 被禁用，请安装 trellis-bridge，然后新建会话。\n" +
+        "   请手动在 ZCode 插件市场中添加 https://github.com/CNHLAIA/ZCode-Trellis-Plugin.git，并手动安装 ZCode 补丁插件 trellis-bridge\n",
+    );
+  });
+
+  it("[issue-zcode-plugin-hint] zcode update prints the bilingual plugin hint after applying changes", async () => {
+    await init({ yes: true, force: true, zcode: true });
+    writeProjectFile(MANAGED_FILE, "user modified content");
+
+    const originalVitest = process.env.VITEST;
+    const originalQuiet = process.env.TRELLIS_QUIET;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = ((chunk: string) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    delete process.env.VITEST;
+    delete process.env.TRELLIS_QUIET;
+
+    try {
+      await update({ force: true });
+    } finally {
+      process.stderr.write = originalWrite;
+      if (originalVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = originalVitest;
+      if (originalQuiet === undefined) delete process.env.TRELLIS_QUIET;
+      else process.env.TRELLIS_QUIET = originalQuiet;
+    }
+
+    expect(stderr.join("")).toBe(
+      "ℹ️  ZCode: if project Hooks are disabled, install trellis-bridge, then start a new session.\n" +
+        "   ZCode：若项目 Hooks 被禁用，请安装 trellis-bridge，然后新建会话。\n" +
+        "   请手动在 ZCode 插件市场中添加 https://github.com/CNHLAIA/ZCode-Trellis-Plugin.git，并手动安装 ZCode 补丁插件 trellis-bridge\n",
+    );
+  });
+
   it("[issue-447] 0.6.8 rename-dir migration moves legacy .pi/skills/ into shared .agents/skills/ even when Codex already installed the shared root", async () => {
     // Simulate a pre-0.6.8 project: Pi + Codex both installed. Pre-fix Pi
     // wrote its own Pi-flavored copy under `.pi/skills/` (via resolveSkills,


### PR DESCRIPTION
Closes #556 

# Title

`feat(zcode): surface the global hook bridge plugin`

## Summary

- Add optional `globalHookPlugin` metadata to `AIToolConfig`.
- Point the ZCode entry to the `trellis-bridge` plugin and its marketplace repository.
- Print a concise English and Chinese installation hint after ZCode init and after
  successful updates, including the already-up-to-date path.
- Clarify that Trellis continues to generate project hook implementations and that the
  global plugin only provides a fallback registration path.

## Context

Some ZCode 3.6.x–3.7.x builds disable project-level hook registration. Trellis still
generates the correct `.zcode/hooks/*.py` implementations, but ZCode does not invoke
them, so session, prompt, and subagent context injection stop working.

The external [`trellis-bridge`](https://github.com/CNHLAIA/ZCode-Trellis-Plugin)
plugin registers the corresponding hooks globally and delegates each event to the
Trellis-owned scripts in the active project.

## User-facing hint

```text
ℹ️  ZCode: if project Hooks are disabled, install trellis-bridge, then start a new session.
   ZCode：若项目 Hooks 被禁用，请安装 trellis-bridge，然后新建会话。
   请手动在 ZCode 插件市场中添加 https://github.com/CNHLAIA/ZCode-Trellis-Plugin.git，并手动安装 ZCode 补丁插件 trellis-bridge
```

## Scope and behavior

The new field is informational metadata. This PR does not:

- install or update the plugin;
- write to the user's ZCode global configuration;
- remove project-level hooks or `.zcode/config.json`;
- duplicate Trellis hook logic in the plugin.

Users continue to install the plugin manually through ZCode. Existing platforms are
unaffected because the metadata is optional and the notice is ZCode-specific.

## Validation

- `pnpm --filter @mindfoldhq/trellis typecheck`
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis exec vitest run test/commands/init.integration.test.ts test/commands/update.integration.test.ts`

Typecheck and lint pass. The two integration files pass 101/101 tests, covering init,
no-op update, and update with applied file changes. A focused Prettier check passes for
all three changed source files. The package-wide format check still reports pre-existing
line-ending/style drift in 218 unrelated files on this Windows checkout.

The external bridge also passes its eight automated tests. Manual ZCode acceptance
confirmed SessionStart context, per-prompt `<workflow-state>` injection, and Trellis
research-agent context delivery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bilingual setup guidance for installing the ZCode integration plugin during initialization and updates.
  * Setup hints appear when no update is needed and after updates complete.
  * Added support for configuring a global integration plugin with a project-level fallback.

* **Tests**
  * Added coverage for setup guidance during initialization and both update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->