### PR TITLE
fix(readme): switch star history chart to a working provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Yes. Personal workspace journals stay separate per developer, while shared specs
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mindfold-ai/Trellis&type=Date)](https://star-history.com/#mindfold-ai/Trellis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mindfold-ai/Trellis&type=Date)](https://star-history.dera.page/#mindfold-ai/Trellis&Date)
 
 ## Community & Resources
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -133,7 +133,7 @@ Trellis 内部运行一个 4 阶段循环，skill 与子代理均由系统自动
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mindfold-ai/Trellis&type=Date)](https://star-history.com/#mindfold-ai/Trellis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mindfold-ai/Trellis&type=Date)](https://star-history.dera.page/#mindfold-ai/Trellis&Date)
 
 ## 社区与资源
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it at a working mirror that requires no API token, so the chart renders again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English and Chinese README files.
  * Links now use the current Star History website and image URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->