### PR TITLE
fix(opencode): inject context via messages.transform so TUI/history stay clean

### DIFF
--- a/.opencode/lib/context-visibility.js
+++ b/.opencode/lib/context-visibility.js
@@ -84,3 +84,65 @@ export function insertSyntheticTextPart(parts, text, kind) {
   else parts.splice(insertionIndex, 0, part)
   return part
 }
+
+/** OpenCode hook that mutates the in-memory model payload, not stored history. */
+export const MESSAGES_TRANSFORM_HOOK = "experimental.chat.messages.transform"
+
+/**
+ * Index of the last user message in an OpenCode `{info, parts}[]` transcript.
+ * Compaction and prompt both pass that shape to messages.transform.
+ */
+export function findLatestUserMessageIndex(messages) {
+  if (!Array.isArray(messages)) return -1
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.info?.role === "user") return i
+  }
+  return -1
+}
+
+export function platformInputFromMessages(messages) {
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return null
+  const info = messages[index].info
+  if (!info || typeof info !== "object") return null
+  return {
+    sessionID: info.sessionID,
+    agent: info.agent,
+  }
+}
+
+export function latestUserPromptText(messages) {
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return ""
+  const part = findUserTextPart(messages[index].parts)
+  return typeof part?.text === "string" ? part.text : ""
+}
+
+export function transcriptHasAssistantMessage(messages) {
+  if (!Array.isArray(messages)) return false
+  return messages.some(message => message?.info?.role === "assistant")
+}
+
+/**
+ * Clone the latest user message and prepend an ephemeral synthetic text
+ * part. The original message object and its `parts` array are left
+ * untouched so a transform cannot leak into OpenCode's stored history.
+ */
+export function prependEphemeralText(messages, text) {
+  if (!Array.isArray(messages)) return false
+  if (typeof text !== "string") return false
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return false
+  const original = messages[index]
+  const parts = Array.isArray(original.parts) ? original.parts.slice() : []
+  parts.unshift({
+    type: "text",
+    text,
+    synthetic: true,
+  })
+  messages[index] = {
+    ...original,
+    parts,
+  }
+  return true
+}

--- a/.opencode/plugins/inject-workflow-state.js
+++ b/.opencode/plugins/inject-workflow-state.js
@@ -4,18 +4,16 @@
  *
  * Per-turn UserPromptSubmit equivalent for OpenCode.
  *
- * On every chat.message, if a Trellis task is active, inject a short
- * <workflow-state> breadcrumb reminding the main AI what task is
- * active and its expected flow. Breadcrumb text is pulled exclusively
+ * On every model request, inject a short <workflow-state> breadcrumb
+ * into the in-memory copy of the latest user message via
+ * `experimental.chat.messages.transform`. Stored history and the TUI
+ * are not modified (issue #553). Breadcrumb text is pulled exclusively
  * from the project's workflow.md [workflow-state:STATUS] tag blocks —
  * workflow.md is the single source of truth. There are no fallback
  * tables in this plugin: when workflow.md is missing or a tag is
  * absent, the breadcrumb degrades to a generic
  * "Refer to workflow.md for current step." line so users see (and fix)
  * the broken state instead of the plugin silently masking it.
- *
- * Unlike session-start, this plugin does NOT dedupe — the breadcrumb
- * should surface on every turn so long conversations don't drift.
  *
  * Silently skips when:
  *   - No .trellis/ directory
@@ -25,7 +23,12 @@
 
 import { existsSync, readFileSync } from "fs"
 import { join } from "path"
-import { findUserTextPart, insertSyntheticTextPart } from "../lib/context-visibility.js"
+import {
+  MESSAGES_TRANSFORM_HOOK,
+  latestUserPromptText,
+  platformInputFromMessages,
+  prependEphemeralText,
+} from "../lib/context-visibility.js"
 import { TrellisContext, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
 
 // Supports STATUS values with letters, digits, underscores, hyphens
@@ -181,15 +184,15 @@ export default async ({ directory }) => {
   debugLog("workflow-state", "Plugin loaded, directory:", directory)
 
   return {
-      // chat.message fires on every user message. Insert a complete synthetic
-      // breadcrumb part so it persists without changing the user prompt.
-      "chat.message": async (input, output) => {
+      [MESSAGES_TRANSFORM_HOOK]: async (_input, output) => {
         try {
+          const messages = output?.messages
+          const platformInput = platformInputFromMessages(messages)
           // Skip Trellis sub-agent turns — the per-turn breadcrumb is for the
           // main session only; sub-agent context comes from the parent's
           // tool.execute.before injection.
-          if (isTrellisSubagent(input)) {
-            debugLog("workflow-state", "Skipping trellis subagent turn:", input?.agent)
+          if (isTrellisSubagent(platformInput)) {
+            debugLog("workflow-state", "Skipping trellis subagent turn:", platformInput?.agent)
             return
           }
           if (process.env.TRELLIS_HOOKS === "0" || process.env.TRELLIS_DISABLE_HOOKS === "1") {
@@ -202,9 +205,7 @@ export default async ({ directory }) => {
             return
           }
 
-          const parts = output?.parts || []
-          const userTextPart = findUserTextPart(parts)
-          const originalText = userTextPart?.text || ""
+          const originalText = latestUserPromptText(messages)
 
           // Escape hatch (issue #427): user prompt contains the skip keyword
           // as a standalone word — emit nothing for this turn only.
@@ -214,12 +215,12 @@ export default async ({ directory }) => {
           }
 
           const templates = loadBreadcrumbs(directory)
-          const task = getActiveTask(ctx, input)
+          const task = getActiveTask(ctx, platformInput)
           const breadcrumb = task
             ? buildBreadcrumb(task.id, task.status, templates, task.source)
             : buildBreadcrumb(null, "no_task", templates)
 
-          insertSyntheticTextPart(parts, breadcrumb, "workflowState")
+          prependEphemeralText(messages, breadcrumb)
           debugLog(
             "workflow-state",
             "Injected breadcrumb for task",
@@ -230,7 +231,7 @@ export default async ({ directory }) => {
         } catch (error) {
           debugLog(
             "workflow-state",
-            "Error in chat.message:",
+            "Error in messages.transform:",
             error instanceof Error ? error.message : String(error),
           )
         }

--- a/.opencode/plugins/session-start.js
+++ b/.opencode/plugins/session-start.js
@@ -2,36 +2,41 @@
 /**
  * Trellis Session Start Plugin
  *
- * Injects context when user sends the first message in a session.
- * Uses OpenCode's chat.message hook directly so the context persists in history.
+ * Injects compact SessionStart context into the copy of the latest user
+ * message that OpenCode sends to the model. Uses
+ * `experimental.chat.messages.transform` so TUI / Web / SQLite history
+ * stay untouched (issue #553).
  */
 
-import { TrellisContext, contextCollector, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
-import { insertSyntheticTextPart } from "../lib/context-visibility.js"
+import { TrellisContext, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
 import {
-  buildSessionContext,
-  hasPersistedInjectedContext,
-  markContextInjected,
-} from "../lib/session-utils.js"
+  MESSAGES_TRANSFORM_HOOK,
+  platformInputFromMessages,
+  prependEphemeralText,
+  transcriptHasAssistantMessage,
+} from "../lib/context-visibility.js"
+import { buildSessionContext } from "../lib/session-utils.js"
+
+const FIRST_REPLY_NOTICE_RE = /<first-reply-notice>[\s\S]*?<\/first-reply-notice>\s*/g
+
+function stripFirstReplyNotice(context) {
+  return context.replace(FIRST_REPLY_NOTICE_RE, "")
+}
 
 // OpenCode 1.2.x expects plugins to be factory functions (see inject-subagent-context.js comment).
-export default async ({ directory, client }) => {
+export default async ({ directory }) => {
   const ctx = new TrellisContext(directory)
   debugLog("session", "Plugin loaded, directory:", directory)
 
   return {
-    // chat.message - triggered when user sends a message.
-    // Insert a complete synthetic part so the context persists without changing the user prompt.
-    "chat.message": async (input, output) => {
+    [MESSAGES_TRANSFORM_HOOK]: async (_input, output) => {
       try {
-        const sessionID = input.sessionID
-        const agent = input.agent || "unknown"
-        debugLog("session", "chat.message called, sessionID:", sessionID, "agent:", agent)
+        const messages = output?.messages
+        const platformInput = platformInputFromMessages(messages)
+        const agent = platformInput?.agent || "unknown"
+        debugLog("session", "messages.transform called, agent:", agent)
 
-        // Skip Trellis sub-agent turns — sub-agent context is injected by
-        // `inject-subagent-context.js` on the parent's tool.execute.before;
-        // re-injecting the main-session SessionStart here would drown that.
-        if (isTrellisSubagent(input)) {
+        if (isTrellisSubagent(platformInput)) {
           debugLog("session", "Skipping trellis subagent turn:", agent)
           return
         }
@@ -46,28 +51,14 @@ export default async ({ directory, client }) => {
           return
         }
 
-        if (contextCollector.isProcessed(sessionID)) {
-          debugLog("session", "Skipping - session already processed")
-          return
+        let context = buildSessionContext(ctx, platformInput)
+        if (transcriptHasAssistantMessage(messages)) {
+          context = stripFirstReplyNotice(context)
         }
-
-        if (await hasPersistedInjectedContext(client, ctx.directory, sessionID)) {
-          contextCollector.markProcessed(sessionID)
-          debugLog("session", "Skipping - session already contains persisted Trellis context")
-          return
-        }
-
-        const context = buildSessionContext(ctx, input)
         debugLog("session", "Built context, length:", context.length)
-
-        const parts = output?.parts || []
-        const injectedPart = insertSyntheticTextPart(parts, context, "sessionStart")
-        markContextInjected(injectedPart)
-        debugLog("session", "Inserted synthetic context part, length:", context.length)
-
-        contextCollector.markProcessed(sessionID)
+        prependEphemeralText(messages, context)
       } catch (error) {
-        debugLog("session", "Error in chat.message:", error.message, error.stack)
+        debugLog("session", "Error in messages.transform:", error.message, error.stack)
       }
     },
   }

--- a/.trellis/spec/cli/backend/workflow-state-contract.md
+++ b/.trellis/spec/cli/backend/workflow-state-contract.md
@@ -108,84 +108,84 @@ Both regexes MUST use the `\1` backreference variant — `[workflow-state:([A-Za
    When adding a new hook-capable platform whose per-turn event name is not
    `UserPromptSubmit`, extend `_detect_platform()` and the `hook_event_name`
    selector in `inject-workflow-state.py` (and the OpenCode `.js` plugin if
-   the new platform shares its `chat.message`-style envelope). Do NOT
-   hardcode `UserPromptSubmit` at any new emission site.
+   the new platform shares its transform envelope). Do NOT hardcode
+   `UserPromptSubmit` at any new emission site.
 
 ---
 
-## OpenCode persisted-part contract
+## OpenCode messages.transform contract
 
 ### 1. Scope / Trigger
 
-This contract applies when an OpenCode `chat.message` plugin adds Trellis
-context after OpenCode has resolved the user's input parts. Unlike the Python
-hook envelope above, these JavaScript-added parts must carry their own complete
-persisted identity.
+OpenCode SessionStart and per-turn workflow-state plugins inject Trellis
+context through `experimental.chat.messages.transform`. That hook runs on
+the in-memory transcript OpenCode is about to convert to model messages
+(`SessionPrompt.run` and compaction). It does not write SQLite / TUI /
+Web history. `chat.message` remains the persist path and must not be used
+for Trellis context (issue #553, replacing the persisted-synthetic-part
+contract from #524).
 
 ### 2. Signatures
 
-- `findUserTextPart(parts) -> ordinary text part | undefined`
-- `insertSyntheticTextPart(parts, text, kind) -> persisted synthetic text part`
-- Supported `kind` values: `sessionStart` and `workflowState`
-- Required persisted fields: `id`, `sessionID`, and `messageID`
+- `findLatestUserMessageIndex(messages) -> number`
+- `latestUserPromptText(messages) -> string`
+- `platformInputFromMessages(messages) -> { sessionID, agent } | null`
+- `prependEphemeralText(messages, text) -> boolean`
+- Hook name: `experimental.chat.messages.transform`
+- Hook input from OpenCode is `{}`; session identity is read from the
+  latest user message `info`.
 
 ### 3. Contracts
 
-- Existing user parts are ordinary when `synthetic !== true`; neither plugin
-  may mutate their text, metadata, identity, or relative order.
-- The identity source is the lexicographically earliest ordinary part with a
-  valid OpenCode `prt_...` ID plus string `sessionID` and `messageID`. This also
-  supports attachment-only turns where no ordinary text part exists.
-- Generated IDs are deterministic for the source message and kind. They sort
-  in the same order used in memory: SessionStart, workflow state, then the
-  ordinary input parts. ID-sorted database replay must therefore equal the
-  first model request order.
-- Both injected parts use `type: "text"` and `synthetic: true`. Synthetic marks
-  machine-authored UI ownership; it does not remove the text from model input.
-- Only the SessionStart part receives `metadata.trellis.sessionStart = true`.
-  History dedupe continues to detect that marker after restart or compaction.
-- The workflow-state plugin checks the skip keyword only against an ordinary
-  user text part, never against an earlier synthetic SessionStart part.
-- Plugin error handling leaves the original parts unchanged. SessionStart is
-  marked processed only after a successful insertion.
+- Only the latest `info.role === "user"` message is cloned. Earlier user
+  and assistant messages stay the original object references.
+- The clone prepends `{ type: "text", text, synthetic: true }` parts.
+  Ordinary parts on the clone keep their original objects; the original
+  message's `parts` array is not mutated.
+- Injection does not require a persisted `prt_...` identity. Attachment-only
+  latest user messages still receive the ephemeral text parts.
+- Workflow-state checks the skip keyword only against ordinary user text
+  (`findUserTextPart`), never against ephemeral or stored synthetic parts.
+- SessionStart injects rebuilt compact context onto the latest user message
+  every model call. `<first-reply-notice>` is included only when the
+  transcript has no assistant message.
+- Plugin error handling leaves `output.messages` unchanged (prepend is the
+  last step).
+- Trellis sub-agent turns (`info.agent` matching `trellis-implement` /
+  `trellis-check` / `trellis-research`) skip both plugins.
 
 ### 4. Validation & Error Matrix
 
 | Condition | Required behavior |
 |---|---|
-| `parts` is not an array or `text` is not a string | Throw before mutation |
-| `kind` is not `sessionStart` or `workflowState` | Throw before source lookup or mutation |
-| No ordinary part has a complete supported persisted identity | Throw; plugin logs and preserves the input parts |
-| Source ID ordinal cannot reserve both context slots | Throw instead of generating a clamped or colliding ID |
-| Generated ID already exists | Throw; never overwrite or silently reuse the existing part |
-| Plugin order is reversed | Final part order remains SessionStart, workflow state, ordinary parts |
+| `messages` is missing or has no user message | No-op |
+| Latest user message has no ordinary text part | Still prepend ephemeral text (attachment-only turns) |
+| Skip keyword present in ordinary latest-user text | Workflow-state no-op; SessionStart still injects |
+| `TRELLIS_HOOKS=0` / `TRELLIS_DISABLE_HOOKS=1` / `OPENCODE_NON_INTERACTIVE=1` | Both plugins no-op |
+| Plugin order is reversed | Both ephemeral parts still precede ordinary latest-user parts |
 
 ### 5. Good / Base / Bad Cases
 
-- Good: a normal text turn persists two complete synthetic parts before an
-  unchanged user text part, and ID-sorted replay is byte-for-byte equivalent to
-  the first-use order.
-- Base: an attachment-only turn uses the attachment identity, preserves the
-  file part, and still persists both machine-authored text parts.
-- Bad: `parts.unshift({ type: "text", text, synthetic: true })` looks hidden in
-  the UI but lacks the identity OpenCode needs to save and replay the part.
+- Good: a two-turn transcript's first user message is byte-identical after
+  transform; only the latest user message clone carries `<session-context>`
+  and `<workflow-state>`.
+- Base: an attachment-only latest user message gets ephemeral text parts
+  prepended; the file part object is unchanged.
+- Bad: mutating `chat.message` `output.parts` persists Trellis context into
+  history and makes revert restore it into the prompt box.
 
 ### 6. Tests Required
 
-- Helper tests assert deterministic unique IDs, complete identity fields,
-  supported kinds, duplicate refusal, low-ordinal refusal, missing identity,
-  attachment-only input, no partial mutation, and replay-order equality.
-- Real plugin tests run both plugin orders and deep-compare every ordinary part
-  before and after injection.
-- SessionStart tests cover in-memory and persisted-history dedupe; workflow
-  tests cover default/custom/disabled skip keywords. There is no compaction
-  reset: history dedupe reads the whole session, so clearing the in-memory
-  flag after compaction is undone by the very next check. Re-injecting context
-  after compaction is a known gap, not a design choice.
-- Existing hook-disable, non-interactive, and Trellis sub-agent exclusion tests
-  remain mandatory.
-- Template collection tests assert the helper ships through both fresh init and
-  `trellis update`; dogfood `.opencode/` copies must match template bytes.
+- Helper tests cover latest-user selection, clone-not-mutate, and prepend
+  onto attachment-only messages.
+- Real plugin tests run both plugin orders against a multi-turn transcript
+  and deep-compare every historical message.
+- SessionStart tests cover first-reply-notice presence vs absence after an
+  assistant turn. Workflow tests cover default/custom/disabled skip keywords.
+- Existing hook-disable, non-interactive, and Trellis sub-agent exclusion
+  tests remain mandatory, aimed at the transform hook.
+- Template collection tests assert the helper ships through both fresh init
+  and `trellis update`; dogfood `.opencode/` copies must match template bytes.
 
 ### 7. Wrong vs Correct
 
@@ -193,21 +193,21 @@ persisted identity.
 
 ```javascript
 parts[0].text = `${breadcrumb}\n\n${parts[0].text}`
+insertSyntheticTextPart(parts, breadcrumb, "workflowState")
 ```
 
-This changes user-authored history and makes machine context visible as part of
-the user's message.
+Both persist machine context into OpenCode history. The first also rewrites
+the user's visible message.
 
 #### Correct
 
 ```javascript
-const userPart = findUserTextPart(parts)
-if (promptHasSkipKeyword(userPart?.text ?? "", skipKeyword)) return
-insertSyntheticTextPart(parts, breadcrumb, "workflowState")
+if (promptHasSkipKeyword(latestUserPromptText(messages), skipKeyword)) return
+prependEphemeralText(messages, breadcrumb)
 ```
 
-This keeps user content unchanged while giving the machine-authored context a
-complete, replay-stable persisted identity.
+This changes only the in-memory model payload. Stored history and the TUI
+keep the original user message.
 
 ---
 

--- a/packages/cli/src/templates/opencode/lib/context-visibility.js
+++ b/packages/cli/src/templates/opencode/lib/context-visibility.js
@@ -84,3 +84,65 @@ export function insertSyntheticTextPart(parts, text, kind) {
   else parts.splice(insertionIndex, 0, part)
   return part
 }
+
+/** OpenCode hook that mutates the in-memory model payload, not stored history. */
+export const MESSAGES_TRANSFORM_HOOK = "experimental.chat.messages.transform"
+
+/**
+ * Index of the last user message in an OpenCode `{info, parts}[]` transcript.
+ * Compaction and prompt both pass that shape to messages.transform.
+ */
+export function findLatestUserMessageIndex(messages) {
+  if (!Array.isArray(messages)) return -1
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.info?.role === "user") return i
+  }
+  return -1
+}
+
+export function platformInputFromMessages(messages) {
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return null
+  const info = messages[index].info
+  if (!info || typeof info !== "object") return null
+  return {
+    sessionID: info.sessionID,
+    agent: info.agent,
+  }
+}
+
+export function latestUserPromptText(messages) {
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return ""
+  const part = findUserTextPart(messages[index].parts)
+  return typeof part?.text === "string" ? part.text : ""
+}
+
+export function transcriptHasAssistantMessage(messages) {
+  if (!Array.isArray(messages)) return false
+  return messages.some(message => message?.info?.role === "assistant")
+}
+
+/**
+ * Clone the latest user message and prepend an ephemeral synthetic text
+ * part. The original message object and its `parts` array are left
+ * untouched so a transform cannot leak into OpenCode's stored history.
+ */
+export function prependEphemeralText(messages, text) {
+  if (!Array.isArray(messages)) return false
+  if (typeof text !== "string") return false
+  const index = findLatestUserMessageIndex(messages)
+  if (index < 0) return false
+  const original = messages[index]
+  const parts = Array.isArray(original.parts) ? original.parts.slice() : []
+  parts.unshift({
+    type: "text",
+    text,
+    synthetic: true,
+  })
+  messages[index] = {
+    ...original,
+    parts,
+  }
+  return true
+}

--- a/packages/cli/src/templates/opencode/plugins/inject-workflow-state.js
+++ b/packages/cli/src/templates/opencode/plugins/inject-workflow-state.js
@@ -4,18 +4,16 @@
  *
  * Per-turn UserPromptSubmit equivalent for OpenCode.
  *
- * On every chat.message, if a Trellis task is active, inject a short
- * <workflow-state> breadcrumb reminding the main AI what task is
- * active and its expected flow. Breadcrumb text is pulled exclusively
+ * On every model request, inject a short <workflow-state> breadcrumb
+ * into the in-memory copy of the latest user message via
+ * `experimental.chat.messages.transform`. Stored history and the TUI
+ * are not modified (issue #553). Breadcrumb text is pulled exclusively
  * from the project's workflow.md [workflow-state:STATUS] tag blocks —
  * workflow.md is the single source of truth. There are no fallback
  * tables in this plugin: when workflow.md is missing or a tag is
  * absent, the breadcrumb degrades to a generic
  * "Refer to workflow.md for current step." line so users see (and fix)
  * the broken state instead of the plugin silently masking it.
- *
- * Unlike session-start, this plugin does NOT dedupe — the breadcrumb
- * should surface on every turn so long conversations don't drift.
  *
  * Silently skips when:
  *   - No .trellis/ directory
@@ -25,7 +23,12 @@
 
 import { existsSync, readFileSync } from "fs"
 import { join } from "path"
-import { findUserTextPart, insertSyntheticTextPart } from "../lib/context-visibility.js"
+import {
+  MESSAGES_TRANSFORM_HOOK,
+  latestUserPromptText,
+  platformInputFromMessages,
+  prependEphemeralText,
+} from "../lib/context-visibility.js"
 import { TrellisContext, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
 
 // Supports STATUS values with letters, digits, underscores, hyphens
@@ -181,15 +184,15 @@ export default async ({ directory }) => {
   debugLog("workflow-state", "Plugin loaded, directory:", directory)
 
   return {
-      // chat.message fires on every user message. Insert a complete synthetic
-      // breadcrumb part so it persists without changing the user prompt.
-      "chat.message": async (input, output) => {
+      [MESSAGES_TRANSFORM_HOOK]: async (_input, output) => {
         try {
+          const messages = output?.messages
+          const platformInput = platformInputFromMessages(messages)
           // Skip Trellis sub-agent turns — the per-turn breadcrumb is for the
           // main session only; sub-agent context comes from the parent's
           // tool.execute.before injection.
-          if (isTrellisSubagent(input)) {
-            debugLog("workflow-state", "Skipping trellis subagent turn:", input?.agent)
+          if (isTrellisSubagent(platformInput)) {
+            debugLog("workflow-state", "Skipping trellis subagent turn:", platformInput?.agent)
             return
           }
           if (process.env.TRELLIS_HOOKS === "0" || process.env.TRELLIS_DISABLE_HOOKS === "1") {
@@ -202,9 +205,7 @@ export default async ({ directory }) => {
             return
           }
 
-          const parts = output?.parts || []
-          const userTextPart = findUserTextPart(parts)
-          const originalText = userTextPart?.text || ""
+          const originalText = latestUserPromptText(messages)
 
           // Escape hatch (issue #427): user prompt contains the skip keyword
           // as a standalone word — emit nothing for this turn only.
@@ -214,12 +215,12 @@ export default async ({ directory }) => {
           }
 
           const templates = loadBreadcrumbs(directory)
-          const task = getActiveTask(ctx, input)
+          const task = getActiveTask(ctx, platformInput)
           const breadcrumb = task
             ? buildBreadcrumb(task.id, task.status, templates, task.source)
             : buildBreadcrumb(null, "no_task", templates)
 
-          insertSyntheticTextPart(parts, breadcrumb, "workflowState")
+          prependEphemeralText(messages, breadcrumb)
           debugLog(
             "workflow-state",
             "Injected breadcrumb for task",
@@ -230,7 +231,7 @@ export default async ({ directory }) => {
         } catch (error) {
           debugLog(
             "workflow-state",
-            "Error in chat.message:",
+            "Error in messages.transform:",
             error instanceof Error ? error.message : String(error),
           )
         }

--- a/packages/cli/src/templates/opencode/plugins/session-start.js
+++ b/packages/cli/src/templates/opencode/plugins/session-start.js
@@ -2,36 +2,41 @@
 /**
  * Trellis Session Start Plugin
  *
- * Injects context when user sends the first message in a session.
- * Uses OpenCode's chat.message hook directly so the context persists in history.
+ * Injects compact SessionStart context into the copy of the latest user
+ * message that OpenCode sends to the model. Uses
+ * `experimental.chat.messages.transform` so TUI / Web / SQLite history
+ * stay untouched (issue #553).
  */
 
-import { TrellisContext, contextCollector, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
-import { insertSyntheticTextPart } from "../lib/context-visibility.js"
+import { TrellisContext, debugLog, isTrellisSubagent } from "../lib/trellis-context.js"
 import {
-  buildSessionContext,
-  hasPersistedInjectedContext,
-  markContextInjected,
-} from "../lib/session-utils.js"
+  MESSAGES_TRANSFORM_HOOK,
+  platformInputFromMessages,
+  prependEphemeralText,
+  transcriptHasAssistantMessage,
+} from "../lib/context-visibility.js"
+import { buildSessionContext } from "../lib/session-utils.js"
+
+const FIRST_REPLY_NOTICE_RE = /<first-reply-notice>[\s\S]*?<\/first-reply-notice>\s*/g
+
+function stripFirstReplyNotice(context) {
+  return context.replace(FIRST_REPLY_NOTICE_RE, "")
+}
 
 // OpenCode 1.2.x expects plugins to be factory functions (see inject-subagent-context.js comment).
-export default async ({ directory, client }) => {
+export default async ({ directory }) => {
   const ctx = new TrellisContext(directory)
   debugLog("session", "Plugin loaded, directory:", directory)
 
   return {
-    // chat.message - triggered when user sends a message.
-    // Insert a complete synthetic part so the context persists without changing the user prompt.
-    "chat.message": async (input, output) => {
+    [MESSAGES_TRANSFORM_HOOK]: async (_input, output) => {
       try {
-        const sessionID = input.sessionID
-        const agent = input.agent || "unknown"
-        debugLog("session", "chat.message called, sessionID:", sessionID, "agent:", agent)
+        const messages = output?.messages
+        const platformInput = platformInputFromMessages(messages)
+        const agent = platformInput?.agent || "unknown"
+        debugLog("session", "messages.transform called, agent:", agent)
 
-        // Skip Trellis sub-agent turns — sub-agent context is injected by
-        // `inject-subagent-context.js` on the parent's tool.execute.before;
-        // re-injecting the main-session SessionStart here would drown that.
-        if (isTrellisSubagent(input)) {
+        if (isTrellisSubagent(platformInput)) {
           debugLog("session", "Skipping trellis subagent turn:", agent)
           return
         }
@@ -46,28 +51,14 @@ export default async ({ directory, client }) => {
           return
         }
 
-        if (contextCollector.isProcessed(sessionID)) {
-          debugLog("session", "Skipping - session already processed")
-          return
+        let context = buildSessionContext(ctx, platformInput)
+        if (transcriptHasAssistantMessage(messages)) {
+          context = stripFirstReplyNotice(context)
         }
-
-        if (await hasPersistedInjectedContext(client, ctx.directory, sessionID)) {
-          contextCollector.markProcessed(sessionID)
-          debugLog("session", "Skipping - session already contains persisted Trellis context")
-          return
-        }
-
-        const context = buildSessionContext(ctx, input)
         debugLog("session", "Built context, length:", context.length)
-
-        const parts = output?.parts || []
-        const injectedPart = insertSyntheticTextPart(parts, context, "sessionStart")
-        markContextInjected(injectedPart)
-        debugLog("session", "Inserted synthetic context part, length:", context.length)
-
-        contextCollector.markProcessed(sessionID)
+        prependEphemeralText(messages, context)
       } catch (error) {
-        debugLog("session", "Error in chat.message:", error.message, error.stack)
+        debugLog("session", "Error in messages.transform:", error.message, error.stack)
       }
     },
   }

--- a/packages/cli/test/templates/opencode.test.ts
+++ b/packages/cli/test/templates/opencode.test.ts
@@ -12,6 +12,8 @@ import {
 import {
   findUserTextPart,
   insertSyntheticTextPart,
+  MESSAGES_TRANSFORM_HOOK,
+  prependEphemeralText,
 } from "../../src/templates/opencode/lib/context-visibility.js";
 import {
   buildSessionContext,
@@ -44,6 +46,59 @@ async function createOpenCodeInjectHooks(
     platform,
     env,
   })) as OpenCodeInjectHooks;
+}
+
+interface ChatMessagePart {
+  id?: string;
+  sessionID?: string;
+  messageID?: string;
+  type: string;
+  text?: string;
+  synthetic?: boolean;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface TransformMessage {
+  info: { role: string; sessionID?: string; agent?: string };
+  parts: ChatMessagePart[];
+}
+
+interface TransformHooks {
+  "experimental.chat.messages.transform": (
+    input: object,
+    output: { messages: TransformMessage[] },
+  ) => Promise<void>;
+}
+
+function createUserTextPart(
+  text: string,
+  sessionID = "main-session",
+  messageID = "message-a",
+  ordinal = "000000000010",
+): ChatMessagePart {
+  return {
+    id: `prt_${ordinal}abcdefghijklmn`,
+    sessionID,
+    messageID,
+    type: "text",
+    text,
+  };
+}
+
+function userTurn(
+  text: string,
+  opts: { sessionID?: string; agent?: string; messageID?: string } = {},
+): TransformMessage {
+  const sessionID = opts.sessionID ?? "main-session";
+  return {
+    info: {
+      role: "user",
+      sessionID,
+      agent: opts.agent ?? "build",
+    },
+    parts: [createUserTextPart(text, sessionID, opts.messageID)],
+  };
 }
 
 describe("opencode session context dedupe", () => {
@@ -127,116 +182,46 @@ describe("opencode session-start history detection", () => {
     );
   });
 
-  it("persists startup context and suppresses reinjection from history", async () => {
-    interface ChatOutput {
-      parts: {
-        id: string;
-        sessionID: string;
-        messageID: string;
-        type: string;
-        text: string;
-        synthetic?: boolean;
-        metadata?: { trellis?: { sessionStart?: boolean } };
-      }[];
-    }
-
-    let historyReads = 0;
-    let persistedParts: ChatOutput["parts"] = [];
+  it("injects startup context onto the latest user message without mutating stored parts", async () => {
     const hooks = (await sessionStartPlugin({
       directory: "/tmp/trellis-opencode-test",
-      client: {
-        session: {
-          messages: async () => {
-            historyReads += 1;
-            return {
-              data:
-                persistedParts.length === 0
-                  ? []
-                  : [{ info: { role: "user" }, parts: persistedParts }],
-            };
-          },
-        },
-      },
-    })) as {
-      "chat.message": (
-        input: { sessionID: string; agent: string },
-        output: ChatOutput,
-      ) => Promise<void>;
-    };
+    })) as TransformHooks;
 
-    const firstOutput: ChatOutput = {
-      parts: [
-        {
-          id: "prt_000000000010abcdefghijklmn",
-          sessionID: "session-a",
-          messageID: "message-a",
-          type: "text",
-          text: "First request",
-        },
-      ],
-    };
-    await hooks["chat.message"](
-      { sessionID: "session-a", agent: "build" },
-      firstOutput,
-    );
+    const firstUser = userTurn("First request", { sessionID: "session-a" });
+    const originalFirstParts = firstUser.parts;
+    const firstMessages = [firstUser];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages: firstMessages });
 
-    expect(firstOutput.parts).toHaveLength(2);
-    expect(firstOutput.parts[0]).toMatchObject({
-      sessionID: "session-a",
-      messageID: "message-a",
+    expect(originalFirstParts).toHaveLength(1);
+    expect(originalFirstParts[0].text).toBe("First request");
+    expect(firstMessages[0]).not.toBe(firstUser);
+    expect(firstMessages[0].parts[0]).toMatchObject({
       type: "text",
       synthetic: true,
     });
-    expect(firstOutput.parts[0].text).toMatch(/^<session-context>/);
-    expect(firstOutput.parts[0].text).toContain("<first-reply-notice>");
-    expect(firstOutput.parts[0].text).toContain("Trellis SessionStart ✓");
-    expect(firstOutput.parts[0].metadata).toEqual({
-      trellis: { sessionStart: true },
-    });
-    expect(firstOutput.parts[1]).toEqual({
-      id: "prt_000000000010abcdefghijklmn",
+    expect(firstMessages[0].parts[0].text).toMatch(/^<session-context>/);
+    expect(firstMessages[0].parts[0].text).toContain("<first-reply-notice>");
+    expect(firstMessages[0].parts[0].text).toContain("Trellis SessionStart ✓");
+    expect(firstMessages[0].parts[1]).toEqual(originalFirstParts[0]);
+
+    const laterUser = userTurn("Second request", {
       sessionID: "session-a",
-      messageID: "message-a",
-      type: "text",
-      text: "First request",
+      messageID: "message-b",
     });
+    const originalLaterParts = laterUser.parts;
+    const laterMessages = [
+      firstUser,
+      { info: { role: "assistant", sessionID: "session-a" }, parts: [] },
+      laterUser,
+    ];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages: laterMessages });
 
-    persistedParts = firstOutput.parts;
-    // The plugin's `session.compacted` event handler was removed as dead
-    // code: clearing the in-memory processed flag there was always undone
-    // one line later by hasPersistedInjectedContext finding the
-    // pre-compaction marker still in history, so re-injecting fresh context
-    // after compaction is a known gap, not a design choice. Simulate a
-    // fresh process picking up this session instead, which exercises the
-    // real, still-live persisted-history dedupe path below.
-    contextCollector.clear("session-a");
-
-    const secondOutput: ChatOutput = {
-      parts: [
-        {
-          id: "prt_000000000020abcdefghijklmn",
-          sessionID: "session-a",
-          messageID: "message-b",
-          type: "text",
-          text: "Second request",
-        },
-      ],
-    };
-    await hooks["chat.message"](
-      { sessionID: "session-a", agent: "build" },
-      secondOutput,
-    );
-
-    expect(secondOutput.parts).toEqual([
-      {
-        id: "prt_000000000020abcdefghijklmn",
-        sessionID: "session-a",
-        messageID: "message-b",
-        type: "text",
-        text: "Second request",
-      },
-    ]);
-    expect(historyReads).toBe(2);
+    expect(laterMessages[0]).toBe(firstUser);
+    expect(laterMessages[0].parts).toBe(originalFirstParts);
+    expect(originalLaterParts).toHaveLength(1);
+    expect(laterMessages[2].parts[0].text).toMatch(/^<session-context>/);
+    expect(laterMessages[2].parts[0].text).not.toContain("<first-reply-notice>");
+    expect(laterMessages[2].parts[1]).toEqual(originalLaterParts[0]);
   });
 
   it("detects persisted Trellis context from metadata", () => {
@@ -510,7 +495,7 @@ describe("opencode bash session context", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Issue #264 — sub-agent context injection + chat.message skip
+// Issue #264 — sub-agent context injection + transform skip
 // ---------------------------------------------------------------------------
 
 interface TaskToolOutput {
@@ -525,39 +510,6 @@ interface TaskToolHooks {
     input: { tool: string; sessionID?: string; agent?: string },
     output: TaskToolOutput,
   ) => Promise<void>;
-}
-
-interface ChatMessagePart {
-  id?: string;
-  sessionID?: string;
-  messageID?: string;
-  type: string;
-  text?: string;
-  synthetic?: boolean;
-  metadata?: Record<string, unknown>;
-  [key: string]: unknown;
-}
-
-interface ChatMessageHooks {
-  "chat.message": (
-    input: { sessionID: string; agent?: string },
-    output: { parts: ChatMessagePart[] },
-  ) => Promise<void>;
-}
-
-function createUserTextPart(
-  text: string,
-  sessionID = "main-session",
-  messageID = "message-a",
-  ordinal = "000000000010",
-): ChatMessagePart {
-  return {
-    id: `prt_${ordinal}abcdefghijklmn`,
-    sessionID,
-    messageID,
-    type: "text",
-    text,
-  };
 }
 
 describe("opencode persisted synthetic context parts", () => {
@@ -1021,7 +973,7 @@ describe("opencode inject-subagent-context (issue #264)", () => {
   });
 });
 
-describe("opencode chat.message subagent skip (issue #264)", () => {
+describe("opencode messages.transform injection (issue #553)", () => {
   let dir: string;
 
   beforeEach(() => {
@@ -1030,161 +982,141 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
-    contextCollector.clear("subagent-session");
-    contextCollector.clear("main-session");
   });
 
-  it("persists separate context parts in replay order for both plugin execution orders", async () => {
-    for (const [index, order] of [
+  async function loadSessionHooks(): Promise<TransformHooks> {
+    return (await sessionStartPlugin({ directory: dir })) as TransformHooks;
+  }
+
+  async function loadWorkflowHooks(): Promise<TransformHooks> {
+    return (await injectWorkflowStatePlugin({
+      directory: dir,
+    })) as TransformHooks;
+  }
+
+  function ephemeralTexts(message: TransformMessage): string[] {
+    return message.parts
+      .filter(part => part.synthetic === true && typeof part.text === "string")
+      .map(part => part.text as string);
+  }
+
+  it("injects both plugins onto the latest user message without mutating history", async () => {
+    for (const order of [
       ["sessionStart", "workflowState"],
       ["workflowState", "sessionStart"],
-    ].entries()) {
-      const sessionID = `plugin-order-${index}`;
+    ]) {
+      const earlier = userTurn("old prompt", {
+        sessionID: "main-session",
+        messageID: "message-old",
+      });
       const ordinary = createUserTextPart(
         "ordinary user prompt",
-        sessionID,
-        `message-order-${index}`,
+        "main-session",
+        "message-new",
       );
       ordinary.metadata = { user: { preserved: true } };
-      const parts = [structuredClone(ordinary)];
-      const sessionHooks = (await sessionStartPlugin({
-        directory: dir,
-        client: {
-          session: { messages: async () => ({ data: [] }) },
-        },
-      })) as ChatMessageHooks;
-      const workflowHooks = (await injectWorkflowStatePlugin({
-        directory: dir,
-      })) as ChatMessageHooks;
+      const latest: TransformMessage = {
+        info: { role: "user", sessionID: "main-session", agent: "build" },
+        parts: [structuredClone(ordinary)],
+      };
+      const originalEarlierParts = earlier.parts;
+      const originalLatestParts = latest.parts;
+      const messages: TransformMessage[] = [
+        earlier,
+        { info: { role: "assistant", sessionID: "main-session" }, parts: [] },
+        latest,
+      ];
+      const sessionHooks = await loadSessionHooks();
+      const workflowHooks = await loadWorkflowHooks();
 
       for (const kind of order) {
         const hooks = kind === "sessionStart" ? sessionHooks : workflowHooks;
-        await hooks["chat.message"](
-          { sessionID, agent: "build" },
-          { parts },
-        );
+        await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
       }
 
-      expect(parts).toHaveLength(3);
-      expect(parts[0]).toMatchObject({
-        sessionID,
-        messageID: `message-order-${index}`,
-        type: "text",
-        synthetic: true,
-        metadata: { trellis: { sessionStart: true } },
-      });
-      expect(parts[0].text).toMatch(/^<session-context>/);
-      expect(parts[1]).toMatchObject({
-        sessionID,
-        messageID: `message-order-${index}`,
-        type: "text",
-        synthetic: true,
-      });
-      expect(parts[1].text).toMatch(/^<workflow-state>/);
-      expect(parts[1].metadata).toBeUndefined();
-      expect(parts[2]).toEqual(ordinary);
-      expect(parts.map(part => part.id)).toEqual(
-        [...parts]
-          .sort((left, right) => {
-            if (typeof left.id !== "string" || typeof right.id !== "string") {
-              throw new TypeError("expected persisted part identities");
-            }
-            return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
-          })
-          .map(part => part.id),
+      expect(messages[0]).toBe(earlier);
+      expect(messages[0].parts).toBe(originalEarlierParts);
+      expect(originalLatestParts).toEqual([ordinary]);
+      expect(messages[2]).not.toBe(latest);
+      const texts = ephemeralTexts(messages[2]);
+      expect(texts.some(text => text.startsWith("<session-context>"))).toBe(
+        true,
       );
-      contextCollector.clear(sessionID);
+      expect(texts.some(text => text.startsWith("<workflow-state>"))).toBe(
+        true,
+      );
+      expect(messages[2].parts.at(-1)).toEqual(ordinary);
     }
   });
 
-  it("uses attachment identity for both real plugins", async () => {
-    const sessionID = "attachment-only-session";
+  it("prepends ephemeral text onto attachment-only latest user messages", async () => {
     const attachment: ChatMessagePart = {
       id: "prt_000000000010abcdefghijklmn",
-      sessionID,
+      sessionID: "main-session",
       messageID: "attachment-only-message",
       type: "file",
       mime: "application/pdf",
       filename: "report.pdf",
     };
-    const parts = [structuredClone(attachment)];
-    const sessionHooks = (await sessionStartPlugin({
-      directory: dir,
-      client: { session: { messages: async () => ({ data: [] }) } },
-    })) as ChatMessageHooks;
-    const workflowHooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
+    const latest: TransformMessage = {
+      info: { role: "user", sessionID: "main-session", agent: "build" },
+      parts: [structuredClone(attachment)],
+    };
+    const originalParts = latest.parts;
+    const messages = [latest];
+    const sessionHooks = await loadSessionHooks();
+    const workflowHooks = await loadWorkflowHooks();
+    await workflowHooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    await sessionHooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
 
-    await workflowHooks["chat.message"](
-      { sessionID, agent: "build" },
-      { parts },
-    );
-    await sessionHooks["chat.message"](
-      { sessionID, agent: "build" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(3);
-    expect(parts[0].text).toMatch(/^<session-context>/);
-    expect(parts[1].text).toMatch(/^<workflow-state>/);
-    expect(parts[2]).toEqual(attachment);
-    contextCollector.clear(sessionID);
+    expect(originalParts).toEqual([attachment]);
+    const texts = ephemeralTexts(messages[0]);
+    expect(texts.some(text => text.startsWith("<session-context>"))).toBe(true);
+    expect(texts.some(text => text.startsWith("<workflow-state>"))).toBe(true);
+    expect(messages[0].parts.at(-1)).toEqual(attachment);
   });
 
-  it("preserves the user message when persisted identity is unavailable", async () => {
-    const sessionHooks = (await sessionStartPlugin({
-      directory: dir,
-      client: { session: { messages: async () => ({ data: [] }) } },
-    })) as ChatMessageHooks;
-    const workflowHooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-
-    for (const [sessionID, hooks] of [
-      ["missing-session-identity", sessionHooks],
-      ["missing-workflow-identity", workflowHooks],
-    ] as const) {
-      const parts: ChatMessagePart[] = [{ type: "text", text: "original" }];
-      await hooks["chat.message"](
-        { sessionID, agent: "build" },
-        { parts },
-      );
-      expect(parts).toEqual([{ type: "text", text: "original" }]);
-      contextCollector.clear(sessionID);
-    }
+  it("injects without a persisted part identity", async () => {
+    const sessionHooks = await loadSessionHooks();
+    const workflowHooks = await loadWorkflowHooks();
+    const latest: TransformMessage = {
+      info: { role: "user", sessionID: "main-session", agent: "build" },
+      parts: [{ type: "text", text: "original" }],
+    };
+    const originalParts = latest.parts;
+    const messages = [latest];
+    await sessionHooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    await workflowHooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(originalParts).toEqual([{ type: "text", text: "original" }]);
+    expect(ephemeralTexts(messages[0]).length).toBe(2);
+    expect(messages[0].parts.at(-1)).toEqual({ type: "text", text: "original" });
   });
 
   it("checks the skip keyword only in ordinary user text", async () => {
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
+    const hooks = await loadWorkflowHooks();
     const ordinary = createUserTextPart("ordinary prompt");
-    const parts = [structuredClone(ordinary)];
-    insertSyntheticTextPart(
-      parts,
-      "machine context containing no-trellis",
-      "sessionStart",
-    );
-
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(3);
-    expect(parts[1].text).toMatch(/^<workflow-state>/);
-    expect(parts[2]).toEqual(ordinary);
+    const latest: TransformMessage = {
+      info: { role: "user", sessionID: "main-session", agent: "build" },
+      parts: [
+        {
+          type: "text",
+          text: "machine context containing no-trellis",
+          synthetic: true,
+        },
+        structuredClone(ordinary),
+      ],
+    };
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(ephemeralTexts(messages[0]).some(text =>
+      text.startsWith("<workflow-state>"),
+    )).toBe(true);
+    expect(messages[0].parts.at(-1)).toEqual(ordinary);
   });
 
   it("keeps both plugins disabled by their existing environment gates", async () => {
-    const sessionHooks = (await sessionStartPlugin({
-      directory: dir,
-      client: { session: { messages: async () => ({ data: [] }) } },
-    })) as ChatMessageHooks;
-    const workflowHooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
+    const sessionHooks = await loadSessionHooks();
+    const workflowHooks = await loadWorkflowHooks();
     const cases = [
       ["TRELLIS_HOOKS", "0"],
       ["TRELLIS_DISABLE_HOOKS", "1"],
@@ -1195,19 +1127,13 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
       const previous = process.env[key];
       process.env[key] = value;
       try {
-        for (const [suffix, hooks] of [
-          ["session", sessionHooks],
-          ["workflow", workflowHooks],
-        ] as const) {
-          const sessionID = `${key}-${suffix}`;
-          const ordinary = createUserTextPart("original", sessionID);
-          const parts = [structuredClone(ordinary)];
-          await hooks["chat.message"](
-            { sessionID, agent: "build" },
-            { parts },
-          );
-          expect(parts).toEqual([ordinary]);
-          contextCollector.clear(sessionID);
+        for (const hooks of [sessionHooks, workflowHooks]) {
+          const latest = userTurn("original");
+          const original = latest.parts;
+          const messages = [latest];
+          await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+          expect(messages[0]).toBe(latest);
+          expect(messages[0].parts).toBe(original);
         }
       } finally {
         if (previous === undefined) Reflect.deleteProperty(process.env, key);
@@ -1216,103 +1142,63 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
     }
   });
 
-  it("session-start.js early-returns when input.agent is a trellis sub-agent", async () => {
-    const hooks = (await sessionStartPlugin({
-      directory: dir,
-      client: undefined,
-    })) as ChatMessageHooks;
-    const parts: ChatMessagePart[] = [createUserTextPart("original")];
-
-    await hooks["chat.message"](
-      { sessionID: "subagent-session", agent: "trellis-implement" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(1);
-    expect(parts[0].text).toBe("original");
-    expect(parts[0].metadata).toBeUndefined();
+  it("session-start.js early-returns when the latest user agent is a trellis sub-agent", async () => {
+    const hooks = await loadSessionHooks();
+    const latest = userTurn("original", { agent: "trellis-implement" });
+    const original = latest.parts;
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0]).toBe(latest);
+    expect(messages[0].parts).toBe(original);
   });
 
   it("session-start.js skips trellis-check and trellis-research", async () => {
-    const hooks = (await sessionStartPlugin({
-      directory: dir,
-      client: undefined,
-    })) as ChatMessageHooks;
-
+    const hooks = await loadSessionHooks();
     for (const agent of ["trellis-check", "trellis-research"]) {
-      const parts: ChatMessagePart[] = [createUserTextPart("untouched")];
-      await hooks["chat.message"](
-        { sessionID: "subagent-session", agent },
-        { parts },
-      );
-      expect(parts[0].text).toBe("untouched");
+      const latest = userTurn("untouched", { agent });
+      const messages = [latest];
+      await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+      expect(messages[0].parts[0].text).toBe("untouched");
     }
   });
 
-  it("inject-workflow-state.js early-returns when input.agent is a trellis sub-agent", async () => {
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-    const parts: ChatMessagePart[] = [createUserTextPart("original")];
-
-    await hooks["chat.message"](
-      { sessionID: "subagent-session", agent: "trellis-implement" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(1);
-    expect(parts[0].text).toBe("original");
+  it("inject-workflow-state.js early-returns when the latest user agent is a trellis sub-agent", async () => {
+    const hooks = await loadWorkflowHooks();
+    const latest = userTurn("original", { agent: "trellis-implement" });
+    const original = latest.parts;
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0]).toBe(latest);
+    expect(messages[0].parts).toBe(original);
   });
 
   it("inject-workflow-state.js still injects breadcrumb for main-session turns", async () => {
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-    const ordinary = createUserTextPart("user prompt");
-    const parts: ChatMessagePart[] = [structuredClone(ordinary)];
-
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(2);
-    expect(parts[0].text).toContain("<workflow-state>");
-    expect(parts[0].synthetic).toBe(true);
-    expect(parts[1]).toEqual(ordinary);
+    const hooks = await loadWorkflowHooks();
+    const latest = userTurn("user prompt");
+    const original = latest.parts[0];
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0].parts[0].text).toContain("<workflow-state>");
+    expect(messages[0].parts[0].synthetic).toBe(true);
+    expect(messages[0].parts[1]).toEqual(original);
   });
 
   it("inject-workflow-state.js skips injection when the prompt contains the default skip keyword", async () => {
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-    const parts: ChatMessagePart[] = [
-      createUserTextPart("no-trellis what does this regex do"),
-    ];
-
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts },
-    );
-
-    expect(parts).toHaveLength(1);
-    expect(parts[0].text).toBe("no-trellis what does this regex do");
+    const hooks = await loadWorkflowHooks();
+    const latest = userTurn("no-trellis what does this regex do");
+    const original = latest.parts;
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0]).toBe(latest);
+    expect(messages[0].parts).toBe(original);
   });
 
   it("inject-workflow-state.js does not skip on 'no-trellisfoo' (word-boundary negative)", async () => {
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-    const parts: ChatMessagePart[] = [
-      createUserTextPart("no-trellisfoo is a strange word"),
-    ];
-
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts },
-    );
-
-    expect(parts[0].text).toContain("<workflow-state>");
+    const hooks = await loadWorkflowHooks();
+    const latest = userTurn("no-trellisfoo is a strange word");
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0].parts[0].text).toContain("<workflow-state>");
   });
 
   it("inject-workflow-state.js honors a custom prompt_injection.skip_keyword", async () => {
@@ -1320,31 +1206,20 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
       join(dir, ".trellis", "config.yaml"),
       ["prompt_injection:", '  skip_keyword: "off-topic"'].join("\n"),
     );
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
+    const hooks = await loadWorkflowHooks();
 
-    const skipped: ChatMessagePart[] = [
-      createUserTextPart("off-topic question"),
-    ];
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts: skipped },
-    );
-    expect(skipped[0].text).toBe("off-topic question");
+    const skipped = userTurn("off-topic question");
+    const skippedMessages = [skipped];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages: skippedMessages });
+    expect(skippedMessages[0]).toBe(skipped);
 
-    const notSkipped: ChatMessagePart[] = [
-      createUserTextPart(
-        "no-trellis question",
-        "main-session-2",
-        "message-custom-keyword",
-      ),
-    ];
-    await hooks["chat.message"](
-      { sessionID: "main-session-2", agent: "build" },
-      { parts: notSkipped },
-    );
-    expect(notSkipped[0].text).toContain("<workflow-state>");
+    const notSkipped = userTurn("no-trellis question", {
+      sessionID: "main-session-2",
+      messageID: "message-custom-keyword",
+    });
+    const notSkippedMessages = [notSkipped];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages: notSkippedMessages });
+    expect(notSkippedMessages[0].parts[0].text).toContain("<workflow-state>");
   });
 
   it("inject-workflow-state.js disables the escape hatch with skip_keyword: \"\"", async () => {
@@ -1352,19 +1227,33 @@ describe("opencode chat.message subagent skip (issue #264)", () => {
       join(dir, ".trellis", "config.yaml"),
       ["prompt_injection:", '  skip_keyword: ""'].join("\n"),
     );
-    const hooks = (await injectWorkflowStatePlugin({
-      directory: dir,
-    })) as ChatMessageHooks;
-    const parts: ChatMessagePart[] = [
-      createUserTextPart("no-trellis question"),
+    const hooks = await loadWorkflowHooks();
+    const latest = userTurn("no-trellis question");
+    const messages = [latest];
+    await hooks[MESSAGES_TRANSFORM_HOOK]({}, { messages });
+    expect(messages[0].parts[0].text).toContain("<workflow-state>");
+  });
+});
+
+describe("opencode ephemeral transform helpers", () => {
+  it("clones only the latest user message when prepending text", () => {
+    const earlier = userTurn("old");
+    const latest = userTurn("new", { messageID: "message-b" });
+    const messages = [
+      earlier,
+      { info: { role: "assistant" }, parts: [] },
+      latest,
     ];
-
-    await hooks["chat.message"](
-      { sessionID: "main-session", agent: "build" },
-      { parts },
-    );
-
-    expect(parts[0].text).toContain("<workflow-state>");
+    expect(prependEphemeralText(messages, "ephemeral")).toBe(true);
+    expect(messages[0]).toBe(earlier);
+    expect(messages[2]).not.toBe(latest);
+    expect(latest.parts).toHaveLength(1);
+    expect(messages[2].parts[0]).toEqual({
+      type: "text",
+      text: "ephemeral",
+      synthetic: true,
+    });
+    expect(messages[2].parts[1]).toBe(latest.parts[0]);
   });
 });
 


### PR DESCRIPTION
## Summary

OpenCode SessionStart and per-turn workflow-state used `chat.message` to insert synthetic parts into the stored user message. That kept revert from rewriting the user's text (#524) but still persisted Trellis context into SQLite / TUI / Web history.

This moves both plugins to `experimental.chat.messages.transform`:

- clone only the latest user message in the in-memory model payload
- prepend ephemeral `{ type: "text", synthetic: true }` parts
- leave stored parts and earlier turns untouched
- inject `<first-reply-notice>` only before the first assistant turn
- keep skip keyword, hook-disable, and Trellis sub-agent exclusion

This is the OpenCode follow-up that was split out of the Pi `input transform` hotfix (#367): Pi already injects via a hidden `context` channel; OpenCode now uses the host transform that never writes history.

Closes #553

## Verification

- `pnpm --filter @mindfoldhq/trellis-core test` — 344 passed, 1 skipped
- `pnpm --filter @mindfoldhq/trellis test` — 1706 passed
- `pnpm --filter @mindfoldhq/trellis lint`
- `pnpm --filter @mindfoldhq/trellis typecheck`
- `git diff --check`
- template / dogfood `.opencode/` copies byte-identical

## Risk

No persist fallback: OpenCode builds without `experimental.chat.messages.transform` will not inject SessionStart or workflow-state. The hook is present in OpenCode 1.17.18 (verified in the shipped binary) and has been used by DCP since 2025-12. `inject-subagent-context.js` (bash session-id prefix) is unchanged.

Unsupported / missing latest user message is a no-op. Plugin errors log and leave `output.messages` unchanged because prepend is the last step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ephemeral workflow breadcrumbs and session-start context to model requests.
  - Context now appears in the model’s prompt without altering visible conversation history or stored transcripts.
  - Supports attachment-only messages and preserves existing message content.
  - Automatically excludes sub-agent interactions and disabled or non-interactive sessions.

- **Bug Fixes**
  - Improved context handling across repeated model calls.
  - First-reply notices are removed after an assistant response is present.
  - Added safeguards for invalid inputs and plugin errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->