### PR TITLE
fix(channel): continue seq after a torn events.jsonl tail

### DIFF
--- a/.trellis/spec/cli/backend/commands-channel.md
+++ b/.trellis/spec/cli/backend/commands-channel.md
@@ -26,12 +26,19 @@ inbox policy, and public SDK contracts.
 
 `packages/cli/src/commands/channel/store/*` still exists and is current code,
 not dead code. Some files are thin re-export / compatibility modules over core
-(`schema.ts`, `filter.ts`, `thread-state.ts`); others remain CLI-local runtime
-primitives for supervisor / spawn / kill / wait paths during the supervisor
-migration (`events.ts`, `paths.ts`, `lock.ts`, `watch.ts`). Do not delete these
-wrappers until their callers have moved to core APIs. New reusable behavior
-belongs in core; CLI-local files should only handle terminal UX, process
-supervision, pid/cursor sidecars, and migration glue.
+(`schema.ts`, `filter.ts`, `thread-state.ts`, and `events.ts` `appendEvent` /
+`readLastSeq`). Others remain CLI-local runtime primitives for supervisor /
+spawn / kill / wait paths during the supervisor migration (`paths.ts`,
+`lock.ts`, `watch.ts`, plus the full-file `readChannelEvents` in `events.ts`).
+Do not delete these wrappers until their callers have moved to core APIs.
+
+Sequence allocation belongs to core. A torn JSONL tail (no trailing newline)
+is truncated to the last complete line before the next append; `seq` continues
+from the last parseable record rather than resetting to 1
+(`truncateIncompleteTail` + `reconcileSeq`). Complete but unparseable lines
+are left intact. New reusable behavior belongs in core; CLI-local files should
+only handle terminal UX, process supervision, pid/cursor sidecars, and
+migration glue.
 
 ---
 

--- a/packages/cli/src/commands/channel/store/events.ts
+++ b/packages/cli/src/commands/channel/store/events.ts
@@ -1,15 +1,13 @@
 /**
  * Channel events local module.
  *
- * Canonical types and reducers come from `@mindfoldhq/trellis-core`.
- * The legacy local `appendEvent` / `readLastSeq` primitives remain
- * here for CLI runtime callers (supervisor / spawn / kill) that still
- * write directly to the JSONL during the Phase 5 supervisor migration.
+ * Canonical types, reducers, and seq-allocating append come from
+ * `@mindfoldhq/trellis-core`. Supervisor / spawn / kill still import
+ * `appendEvent` from here so their call sites stay stable; the
+ * implementation is core's, including torn-tail seq recovery.
  *
- * Local `appendEvent` shares the channel-level lock with core, so
- * concurrent writes stay mutually exclusive. Core's seq sidecar
- * self-repairs on the next core append if a CLI-runtime write lands
- * without updating it.
+ * `readChannelEvents` stays a CLI-local full-file reader until those
+ * callers move to core's paginated API.
  */
 
 import fs from "node:fs";
@@ -21,8 +19,7 @@ import {
   type ChannelMetadata,
 } from "@mindfoldhq/trellis-core/channel";
 
-import { withLock } from "./lock.js";
-import { eventsPath, channelDir, lockPath } from "./paths.js";
+import { eventsPath } from "./paths.js";
 
 export {
   CHANNEL_EVENT_KINDS,
@@ -33,6 +30,8 @@ export {
   isContextEvent,
   isChannelMetadataEvent,
   reduceChannelMetadata,
+  appendEvent,
+  readLastSeq,
 } from "@mindfoldhq/trellis-core/channel";
 
 export type {
@@ -49,69 +48,8 @@ export type {
   ErrorChannelEvent,
   ProgressChannelEvent,
   SupervisorWarningChannelEvent,
+  AppendablePartial,
 } from "@mindfoldhq/trellis-core/channel";
-
-export async function ensureChannelDir(
-  name: string,
-  project?: string,
-): Promise<string> {
-  const dir = channelDir(name, project);
-  await fsp.mkdir(dir, { recursive: true, mode: 0o700 });
-  return dir;
-}
-
-export async function readLastSeq(
-  name: string,
-  project?: string,
-): Promise<number> {
-  const file = eventsPath(name, project);
-  if (!fs.existsSync(file)) return 0;
-  const content = await fsp.readFile(file, "utf-8");
-  const lines = content.split("\n").filter((l) => l.trim() !== "");
-  if (lines.length === 0) return 0;
-  const last = lines[lines.length - 1];
-  try {
-    const obj = JSON.parse(last) as { seq?: number };
-    return typeof obj.seq === "number" ? obj.seq : 0;
-  } catch {
-    return 0;
-  }
-}
-
-export interface AppendablePartial {
-  kind: ChannelEvent["kind"];
-  by: string;
-  ts?: string;
-  [extra: string]: unknown;
-}
-
-/**
- * Local channel append used by CLI runtime code (supervisor / spawn /
- * kill) until the Phase 5 supervisor migration moves those callers to
- * core's typed APIs. Shares the channel-level lock with core, so
- * concurrent writes stay mutually exclusive.
- */
-export async function appendEvent(
-  name: string,
-  partial: AppendablePartial,
-  project?: string,
-): Promise<ChannelEvent> {
-  await ensureChannelDir(name, project);
-  return withLock(lockPath(name, project), async () => {
-    const lastSeq = await readLastSeq(name, project);
-    const event = {
-      ...partial,
-      seq: lastSeq + 1,
-      ts: partial.ts ?? new Date().toISOString(),
-    } as ChannelEvent;
-    await fsp.appendFile(
-      eventsPath(name, project),
-      JSON.stringify(event) + "\n",
-      "utf-8",
-    );
-    return event;
-  });
-}
 
 export async function readChannelEvents(
   name: string,

--- a/packages/cli/test/commands/channel-events-seq.test.ts
+++ b/packages/cli/test/commands/channel-events-seq.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  appendEvent,
+  readChannelEvents,
+  readLastSeq,
+} from "../../src/commands/channel/store/events.js";
+import { eventsPath } from "../../src/commands/channel/store/paths.js";
+
+interface TmpEnv {
+  tmpDir: string;
+  projectDir: string;
+  oldRoot: string | undefined;
+  oldProject: string | undefined;
+}
+
+function setup(): TmpEnv {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "trellis-channel-seq-test-"),
+  );
+  const projectDir = path.join(tmpDir, "project");
+  fs.mkdirSync(projectDir);
+  const oldRoot = process.env.TRELLIS_CHANNEL_ROOT;
+  const oldProject = process.env.TRELLIS_CHANNEL_PROJECT;
+  process.env.TRELLIS_CHANNEL_ROOT = path.join(tmpDir, "channels");
+  delete process.env.TRELLIS_CHANNEL_PROJECT;
+  return { tmpDir, projectDir, oldRoot, oldProject };
+}
+
+function teardown(env: TmpEnv): void {
+  if (env.oldRoot === undefined) delete process.env.TRELLIS_CHANNEL_ROOT;
+  else process.env.TRELLIS_CHANNEL_ROOT = env.oldRoot;
+  if (env.oldProject === undefined) delete process.env.TRELLIS_CHANNEL_PROJECT;
+  else process.env.TRELLIS_CHANNEL_PROJECT = env.oldProject;
+  fs.rmSync(env.tmpDir, { recursive: true, force: true });
+}
+
+function seedEvents(channel: string, tail: string | Buffer): string {
+  const file = eventsPath(channel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const complete =
+    `${JSON.stringify({
+      seq: 1,
+      ts: "2026-08-06T00:00:00.000Z",
+      kind: "create",
+      by: "main",
+      name: channel,
+    })}\n` +
+    `${JSON.stringify({
+      seq: 2,
+      ts: "2026-08-06T00:00:01.000Z",
+      kind: "progress",
+      by: "worker",
+      text: "ok",
+    })}\n`;
+  fs.writeFileSync(file, complete);
+  fs.appendFileSync(file, tail);
+  return file;
+}
+
+describe("CLI appendEvent seq allocation (#527)", () => {
+  let env: TmpEnv;
+
+  beforeEach(() => {
+    env = setup();
+    vi.spyOn(process, "cwd").mockReturnValue(env.projectDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    teardown(env);
+  });
+
+  it("continues seq after a torn JSONL tail without a sidecar", async () => {
+    const file = seedEvents(
+      "torn",
+      '{"seq":99,"kind":"progress","by":"worker","text":"cut',
+    );
+    expect(await readLastSeq("torn")).toBe(2);
+
+    const appended = await appendEvent("torn", {
+      kind: "progress",
+      by: "supervisor:worker",
+      text: "after-tear",
+    });
+    expect(appended.seq).toBe(3);
+
+    const events = await readChannelEvents("torn");
+    expect(events.map((e) => e.seq)).toEqual([1, 2, 3]);
+    expect(fs.readFileSync(file, "utf-8")).not.toContain('"seq":99');
+  });
+
+  it("continues seq after a tail cut mid-multibyte character", async () => {
+    seedEvents("utf8-torn", Buffer.from([0xe4, 0xb8]));
+    const appended = await appendEvent("utf8-torn", {
+      kind: "error",
+      by: "cli:kill",
+      message: "supervisor lost",
+      worker: "worker",
+    });
+    expect(appended.seq).toBe(3);
+    expect((await readChannelEvents("utf8-torn")).map((e) => e.seq)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+});

--- a/packages/cli/test/commands/channel-wait-warning.test.ts
+++ b/packages/cli/test/commands/channel-wait-warning.test.ts
@@ -63,15 +63,32 @@ async function waitForWarning(
 
 describe("channelWait kind union (CLI)", () => {
   let env: TmpEnv;
+  let pendingAppends: Promise<unknown>[];
+
+  function appendSoon(
+    name: string,
+    partial: Parameters<typeof appendEvent>[1],
+    delayMs = 20,
+  ): void {
+    const p = new Promise<unknown>((resolve, reject) => {
+      setTimeout(() => {
+        void appendEvent(name, partial).then(resolve, reject);
+      }, delayMs);
+    });
+    pendingAppends.push(p);
+  }
 
   beforeEach(() => {
     env = setup();
+    pendingAppends = [];
     vi.spyOn(process, "cwd").mockReturnValue(env.projectDir);
     vi.spyOn(console, "log").mockImplementation(noop);
     vi.spyOn(console, "error").mockImplementation(noop);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.allSettled(pendingAppends);
+    pendingAppends = [];
     vi.restoreAllMocks();
     teardown(env);
   });
@@ -86,14 +103,12 @@ describe("channelWait kind union (CLI)", () => {
       timeoutMs: 5000,
     });
 
-    setTimeout(() => {
-      void appendEvent("wait-union", {
-        kind: "killed",
-        by: "worker",
-        reason: "explicit-kill",
-        signal: "SIGTERM",
-      });
-    }, 20);
+    appendSoon("wait-union", {
+      kind: "killed",
+      by: "worker",
+      reason: "explicit-kill",
+      signal: "SIGTERM",
+    });
 
     await waiter;
     expect(process.exitCode).not.toBe(124);
@@ -109,13 +124,11 @@ describe("channelWait kind union (CLI)", () => {
       timeoutMs: 5000,
     });
 
-    setTimeout(() => {
-      void appendEvent("wait-single", {
-        kind: "done",
-        by: "worker",
-        duration_ms: 5,
-      });
-    }, 20);
+    appendSoon("wait-single", {
+      kind: "done",
+      by: "worker",
+      duration_ms: 5,
+    });
 
     await waiter;
     expect(process.exitCode).not.toBe(124);
@@ -144,21 +157,21 @@ describe("channelWait kind union (CLI)", () => {
       timeoutMs: 5000,
     });
 
-    setTimeout(() => {
-      void appendEvent("wait-all-union", {
-        kind: "killed",
-        by: "worker-a",
-        reason: "explicit-kill",
-        signal: "SIGTERM",
-      });
-    }, 20);
-    setTimeout(() => {
-      void appendEvent("wait-all-union", {
+    appendSoon("wait-all-union", {
+      kind: "killed",
+      by: "worker-a",
+      reason: "explicit-kill",
+      signal: "SIGTERM",
+    });
+    appendSoon(
+      "wait-all-union",
+      {
         kind: "done",
         by: "worker-b",
         duration_ms: 5,
-      });
-    }, 40);
+      },
+      40,
+    );
 
     await waiter;
     expect(process.exitCode).not.toBe(124);
@@ -181,16 +194,14 @@ describe("channelWait kind union (CLI)", () => {
       timeoutMs: 150, // short — we expect timeout
     });
 
-    setTimeout(() => {
-      void appendEvent("wait-warn-default", {
-        kind: "supervisor_warning",
-        by: "supervisor:worker",
-        worker: "worker",
-        reason: "approaching_timeout",
-        timeout_ms: 60_000,
-        remaining_ms: 30_000,
-      });
-    }, 20);
+    appendSoon("wait-warn-default", {
+      kind: "supervisor_warning",
+      by: "supervisor:worker",
+      worker: "worker",
+      reason: "approaching_timeout",
+      timeout_ms: 60_000,
+      remaining_ms: 30_000,
+    });
 
     await waiter;
     expect(process.exitCode).toBe(124);
@@ -207,16 +218,14 @@ describe("channelWait kind union (CLI)", () => {
       timeoutMs: 5000,
     });
 
-    setTimeout(() => {
-      void appendEvent("wait-warn-explicit", {
-        kind: "supervisor_warning",
-        by: "supervisor:worker",
-        worker: "worker",
-        reason: "approaching_timeout",
-        timeout_ms: 60_000,
-        remaining_ms: 30_000,
-      });
-    }, 20);
+    appendSoon("wait-warn-explicit", {
+      kind: "supervisor_warning",
+      by: "supervisor:worker",
+      worker: "worker",
+      reason: "approaching_timeout",
+      timeout_ms: 60_000,
+      remaining_ms: 30_000,
+    });
 
     await waiter;
     expect(process.exitCode).not.toBe(124);

--- a/packages/core/src/channel/index.ts
+++ b/packages/core/src/channel/index.ts
@@ -58,6 +58,7 @@ export type {
   InterruptOutcome,
   UndeliverableReason,
   ReadChannelEventsPagination,
+  AppendablePartial,
 } from "./internal/store/events.js";
 
 export {
@@ -69,6 +70,8 @@ export {
   isThreadEvent,
   isContextEvent,
   isChannelMetadataEvent,
+  appendEvent,
+  readLastSeq,
 } from "./internal/store/events.js";
 
 export type {

--- a/packages/core/src/channel/internal/store/events.ts
+++ b/packages/core/src/channel/internal/store/events.ts
@@ -8,7 +8,7 @@ import {
   lockPath,
   seqSidecarPath,
 } from "./paths.js";
-import { reconcileSeq, writeSidecar } from "./seq.js";
+import { reconcileSeq, truncateIncompleteTail, writeSidecar } from "./seq.js";
 import type {
   ChannelType,
   ContextEntry,
@@ -399,9 +399,11 @@ export interface AppendablePartial {
 /**
  * Append a channel event atomically under the channel lock.
  *
- * Internally reconciles the `.seq` sidecar with the JSONL tail to avoid
- * the legacy full-scan path. Sidecar repair happens automatically on
- * corruption, missing file, or sidecar drift in either direction.
+ * Internally truncates a torn JSONL tail (missing final newline), then
+ * reconciles the `.seq` sidecar with the JSONL tail. Sidecar repair
+ * happens automatically on corruption, missing file, or sidecar drift
+ * in either direction. A torn tail must never reset `seq` to 1 or glue
+ * the next record onto the incomplete line.
  *
  * @internal Trellis CLI-internal write primitive — downstream consumers
  *   must go through the typed mutation APIs (`createChannel`,
@@ -417,6 +419,7 @@ export async function appendEvent(
   const jsonl = eventsPath(name, project);
   const sidecar = seqSidecarPath(name, project);
   return withLock(lockPath(name, project), async () => {
+    await truncateIncompleteTail(jsonl);
     const existing = findIdempotentEvent(jsonl, partial);
     if (existing !== undefined) return existing;
 

--- a/packages/core/src/channel/internal/store/seq.ts
+++ b/packages/core/src/channel/internal/store/seq.ts
@@ -3,6 +3,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 
 const READ_TAIL_BYTES = 4096;
+const TAIL_SCAN_CHUNK = 64 * 1024;
 
 /** Parse the sidecar file content. Returns null on missing / non-integer. */
 function parseSidecar(text: string): number | null {
@@ -91,6 +92,45 @@ async function readLastJsonlSeq(jsonlPath: string): Promise<number> {
     throw new Error(`Unable to recover channel seq from ${jsonlPath}`);
   }
   return 0;
+}
+
+/**
+ * If `events.jsonl` ends mid-record (no trailing newline — ENOSPC or
+ * SIGKILL during append), truncate to the last complete line. A complete
+ * JSONL record is written as stringify(event) plus a trailing newline, so
+ * a missing final newline is the torn-tail signal. Complete but
+ * unparseable lines are left intact — that is mid-file damage, not a
+ * torn tail.
+ *
+ * Caller must hold the channel lock.
+ */
+export async function truncateIncompleteTail(jsonlPath: string): Promise<void> {
+  if (!fs.existsSync(jsonlPath)) return;
+  const fh = await fsp.open(jsonlPath, "r+");
+  try {
+    const stat = await fh.stat();
+    if (stat.size === 0) return;
+    const lastByte = Buffer.alloc(1);
+    await fh.read(lastByte, 0, 1, stat.size - 1);
+    if (lastByte[0] === 0x0a) return;
+
+    let offset = stat.size;
+    while (offset > 0) {
+      const start = Math.max(0, offset - TAIL_SCAN_CHUNK);
+      const length = offset - start;
+      const buf = Buffer.alloc(length);
+      await fh.read(buf, 0, length, start);
+      const newline = buf.lastIndexOf(0x0a);
+      if (newline >= 0) {
+        await fh.truncate(start + newline + 1);
+        return;
+      }
+      offset = start;
+    }
+    await fh.truncate(0);
+  } finally {
+    await fh.close();
+  }
 }
 
 /**

--- a/packages/core/test/channel/seq.test.ts
+++ b/packages/core/test/channel/seq.test.ts
@@ -111,6 +111,41 @@ describe("appendEvent + .seq sidecar", () => {
     expect(fs.readFileSync(sidecar, "utf-8").trim()).toBe("3");
   });
 
+  it("continues seq after a torn JSONL tail", async () => {
+    await createChannel({ channel: "torn", by: "main" });
+    await sendMessage({ channel: "torn", by: "main", text: "one" });
+    const file = eventsPath(
+      "torn",
+      process.env.TRELLIS_CHANNEL_PROJECT ?? "",
+    );
+    const prefix = fs.readFileSync(file);
+    fs.appendFileSync(file, '{"seq":99,"kind":"progress","by":"w","text":"cut');
+    await sendMessage({ channel: "torn", by: "main", text: "two" });
+    const events = await readChannelEvents({ channel: "torn" });
+    expect(events.map((e) => e.seq)).toEqual([1, 2, 3]);
+    expect(events.at(-1)).toMatchObject({ kind: "message", text: "two" });
+    const after = fs.readFileSync(file);
+    expect(after.subarray(0, prefix.length).equals(prefix)).toBe(true);
+    expect(after.includes(Buffer.from('"seq":99'))).toBe(false);
+  });
+
+  it("continues seq after a tail cut mid-multibyte character", async () => {
+    await createChannel({ channel: "utf8-torn", by: "main" });
+    await sendMessage({ channel: "utf8-torn", by: "main", text: "one" });
+    const file = eventsPath(
+      "utf8-torn",
+      process.env.TRELLIS_CHANNEL_PROJECT ?? "",
+    );
+    const prefix = fs.readFileSync(file);
+    // Incomplete UTF-8 for U+4E2D (中): first two bytes only.
+    fs.appendFileSync(file, Buffer.from([0xe4, 0xb8]));
+    await sendMessage({ channel: "utf8-torn", by: "main", text: "two" });
+    const events = await readChannelEvents({ channel: "utf8-torn" });
+    expect(events.map((e) => e.seq)).toEqual([1, 2, 3]);
+    const after = fs.readFileSync(file);
+    expect(after.subarray(0, prefix.length).equals(prefix)).toBe(true);
+  });
+
   it("fails seq recovery when JSONL has no recoverable seq", async () => {
     await createChannel({ channel: "bad-jsonl", by: "main" });
     const file = eventsPath("bad-jsonl");


### PR DESCRIPTION
## Summary

If `events.jsonl` ends mid-record (ENOSPC / SIGKILL, including a cut mid-UTF-8), the CLI supervisor / spawn / kill append path allocated `seq = 1` instead of continuing the sequence. Two bugs stacked:

1. CLI `readLastSeq` returned `0` when the last line failed to parse.
2. `appendFile` glued the next JSON record onto the torn last line, so even a correct seq would still produce a corrupt file.

This routes `appendEvent` / `readLastSeq` through core. Before allocating the next seq, core truncates a missing-newline tail to the last complete line (`truncateIncompleteTail`), then `reconcileSeq` continues from the last parseable record. Complete but unparseable mid-file lines are left intact.

The optional `trellis channel repair` command from the issue is **not** in this PR.

Closes #527

## Verification

- `pnpm --filter @mindfoldhq/trellis-core test` — 346 passed, 1 skipped
- `pnpm --filter @mindfoldhq/trellis test` — 1708 passed
- `pnpm --filter @mindfoldhq/trellis-core lint` + `typecheck`
- `pnpm --filter @mindfoldhq/trellis lint` + `typecheck`
- `git diff --check`

## Risk

`appendEvent` has many callers (typed channel APIs plus supervisor / spawn / kill). Signature is unchanged. New behavior only fires when the JSONL does not end with a newline — the durable-write contract for a complete record. A complete record written without a trailing newline would be treated as torn and dropped; production writers always append `JSON.stringify(event) + "\n"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from incomplete or interrupted channel event records.
  * New events now continue with the correct sequence after a damaged JSONL tail.
  * Preserved valid event history while removing only incomplete trailing data.
  * Added handling for tails ending during a multi-byte character.
  * Improved consistency between CLI and core channel event handling.

* **Documentation**
  * Clarified channel sequence recovery and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->