### PR TITLE
fix(opencode): drop unused @opencode-ai/plugin dependency from template package.json

### DIFF
--- a/packages/cli/src/configurators/opencode.ts
+++ b/packages/cli/src/configurators/opencode.ts
@@ -14,8 +14,7 @@ import {
 /**
  * Files under packages/cli/src/templates/opencode/ that are NOT user-facing
  * assets (build artifacts, runtime caches, etc.). The template dir has a
- * real package.json that declares the @opencode-ai/plugin dep — that one
- * IS user-facing and must be shipped.
+ * real package.json — that one IS user-facing and must be shipped.
  */
 const EXCLUDE_PATTERNS = [
   ".d.ts",

--- a/packages/cli/src/templates/opencode/package.json
+++ b/packages/cli/src/templates/opencode/package.json
@@ -1,5 +1,1 @@
-{
-  "dependencies": {
-    "@opencode-ai/plugin": "^1.14.39"
-  }
-}
+{}


### PR DESCRIPTION
## Problem

The generated `.opencode/package.json` declares `@opencode-ai/plugin: ^1.14.39`, but nothing in the generated `.opencode/` tree imports it:

- every `import` in `packages/cli/src/templates/opencode/lib/*.js` and `plugins/*.js` resolves to a node builtin or a sibling module;
- OpenCode supplies the plugin API to the factory functions at runtime, so the package is never required for the plugins to load.

The caret range still gets resolved and installed into each consumer checkout (`.opencode/node_modules/` is gitignored by the Trellis-generated `.gitignore`), so every consumer pays a floating-version install for a package no shipped code uses.

## Change

- Ship an empty `package.json` (`{}`) from `packages/cli/src/templates/opencode/`.
- Update the stale comment in `packages/cli/src/configurators/opencode.ts` that justified shipping the file by naming the dep.

Deliberately untouched:

- `scrubOpencodePackageJson` and `uninstall.ts` keep handling installs that still carry the dep — existing consumers still get scrubbed correctly on uninstall.
- The file itself still ships. Dropping the file entirely would touch update/hash-tracking and migration semantics; that can be a follow-up if you'd rather not ship an empty manifest.

If the dep is intentionally kept for editor type support, the alternative is an exact pin plus a shipped lockfile so consumers at least install a known version — happy to rework the PR that way instead.

## Validation

`pnpm test` in `packages/cli`: 75 files / 1706 tests pass with the change.

## Provenance

Found by a dependency-hygiene audit in a downstream consumer repository (finding A-032): unused-dependency check over the generated `.opencode` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y3oVg5eZmhF14F5FGmB36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the OpenCode package template by removing its bundled plugin dependency.
  * Clarified packaging guidance to ensure the template’s `package.json` is included as a user-facing asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->