### PR TITLE
feat(cli): let an installed pack declare preferred workflow entry points

### DIFF
--- a/.trellis/scripts/common/entry_points.py
+++ b/.trellis/scripts/common/entry_points.py
@@ -1,0 +1,59 @@
+"""Declared entry-point lookup for wrapper packs.
+
+An installed wrapper pack may declare preferred entry surfaces for the core
+workflows in `.trellis/entry-points.json` so routing text points agents at the
+pack's canonical commands instead of the Trellis literals:
+
+    {
+      "schemaVersion": 1,
+      "entryPoints": {
+        "start": "/sd:sd-start",
+        "continue": "/sd:sd-continue",
+        "finish-work": "/sd:sd-finish-work",
+        "update-spec": "sd-update-spec"
+      }
+    }
+
+Trellis never writes the file. Every key is optional, values are bounded
+surface names rendered verbatim, and any invalid shape, key, or value
+disables the whole declaration so callers fall back to the Trellis literal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from .paths import DIR_WORKFLOW, get_repo_root
+
+ENTRY_POINT_KEYS = {"start", "continue", "finish-work", "update-spec"}
+_ENTRY_POINT_VALUE_RE = re.compile(r"/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}\Z")
+_ENTRY_POINT_MAX_BYTES = 16 * 1024
+
+
+def declared_entry_point(
+    key: str, fallback: str, repo_root: Path | None = None
+) -> str:
+    """Return the declared entry point for `key`, or `fallback`."""
+    try:
+        root = repo_root if repo_root is not None else get_repo_root()
+        path = root / DIR_WORKFLOW / "entry-points.json"
+        if not path.is_file() or path.stat().st_size > _ENTRY_POINT_MAX_BYTES:
+            return fallback
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schemaVersion") != 1:
+            return fallback
+        if set(data) - {"schemaVersion", "entryPoints"}:
+            return fallback
+        points = data.get("entryPoints")
+        if not isinstance(points, dict) or set(points) - ENTRY_POINT_KEYS:
+            return fallback
+        value = points.get(key)
+        if not isinstance(value, str) or not _ENTRY_POINT_VALUE_RE.fullmatch(
+            value
+        ):
+            return fallback
+        return value
+    except (OSError, ValueError):
+        return fallback

--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -31,6 +31,7 @@ from .config import (
     resolve_package,
     validate_package,
 )
+from .entry_points import declared_entry_point
 from .git import branch_exists_locally, resolve_default_branch, run_git
 from .io import read_json, write_json
 from .log import Colors, colored
@@ -497,7 +498,8 @@ def cmd_create(args: argparse.Namespace) -> int:
             "  - Curate implement.jsonl / check.jsonl as spec/research manifests when sub-agents need context",
             file=sys.stderr,
         )
-    print("  - Use /trellis:continue or phase context to decide the next step", file=sys.stderr)
+    continue_entry = declared_entry_point("continue", "/trellis:continue")
+    print(f"  - Use {continue_entry} or phase context to decide the next step", file=sys.stderr)
     print("", file=sys.stderr)
 
     # Output relative path for script chaining

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,6 +17,11 @@ import {
   getPythonCommandForPlatform,
   setResolvedPythonCommand,
 } from "../configurators/shared.js";
+import {
+  applyDeclaredEntryPoints,
+  loadDeclaredEntryPoints,
+  setDeclaredEntryPoints,
+} from "../utils/entry-points.js";
 import { AI_TOOLS, type CliFlag } from "../types/ai-tools.js";
 import { DIR_NAMES, FILE_NAMES, PATHS } from "../constants/paths.js";
 import { VERSION } from "../constants/version.js";
@@ -1118,6 +1123,9 @@ export async function init(options: InitOptions): Promise<void> {
   }
 
   const cwd = process.cwd();
+  // A wrapper pack may already have declared preferred entry points (e.g. a
+  // re-init over an installed pack); consult them for every template write.
+  setDeclaredEntryPoints(loadDeclaredEntryPoints(cwd));
   const isFirstInit = !fs.existsSync(path.join(cwd, DIR_NAMES.WORKFLOW));
   // Captured here (before createWorkflowStructure + init_developer run) so
   // the three-branch dispatch at the bottom can tell "fresh clone joiner"
@@ -2072,7 +2080,10 @@ async function createRootFiles(cwd: string): Promise<void> {
   const agentsPath = path.join(cwd, FILE_NAMES.AGENTS);
 
   // Write AGENTS.md from template
-  const agentsWritten = await writeFile(agentsPath, agentsMdContent);
+  const agentsWritten = await writeFile(
+    agentsPath,
+    applyDeclaredEntryPoints(agentsMdContent),
+  );
   if (agentsWritten) {
     console.log(chalk.blue("📄 Created AGENTS.md"));
   }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -60,6 +60,11 @@ import {
   isManagedRootDir,
 } from "../configurators/index.js";
 import { replacePythonCommandLiterals } from "../configurators/shared.js";
+import {
+  applyDeclaredEntryPoints,
+  loadDeclaredEntryPoints,
+  setDeclaredEntryPoints,
+} from "../utils/entry-points.js";
 import { preserveCodexAgentModelKeys } from "../configurators/codex.js";
 import { printZcodeSetupHint } from "../configurators/zcode.js";
 import { ensureGitattributes } from "../configurators/workflow.js";
@@ -948,7 +953,10 @@ async function collectTemplateFiles(
 
   // Apply python3→python replacement for Windows consistency with init-time writes
   for (const [filePath, content] of files) {
-    files.set(filePath, replacePythonCommandLiterals(content));
+    files.set(
+      filePath,
+      applyDeclaredEntryPoints(replacePythonCommandLiterals(content)),
+    );
   }
 
   return files;
@@ -2086,6 +2094,9 @@ export function renameTracesToJournal(workspaceDir: string): {
  */
 export async function update(options: UpdateOptions): Promise<void> {
   const cwd = process.cwd();
+  // Consult a wrapper pack's declared entry points for every template write
+  // in this run; absent or invalid declarations fall back to Trellis literals.
+  setDeclaredEntryPoints(loadDeclaredEntryPoints(cwd));
 
   // Check if Trellis is initialized
   if (!fs.existsSync(path.join(cwd, DIR_NAMES.WORKFLOW))) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -27,6 +27,11 @@ import { DIR_NAMES, PATHS } from "../constants/paths.js";
 import { collectMissingAgents } from "../utils/agent-refs.js";
 import { replacePythonCommandLiterals } from "../configurators/shared.js";
 import {
+  applyDeclaredEntryPoints,
+  loadDeclaredEntryPoints,
+  setDeclaredEntryPoints,
+} from "../utils/entry-points.js";
+import {
   computeHash,
   loadHashes,
   removeHash,
@@ -167,7 +172,9 @@ async function writeWorkflow(
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true });
   }
-  const finalContent = replacePythonCommandLiterals(template.content);
+  const finalContent = applyDeclaredEntryPoints(
+    replacePythonCommandLiterals(template.content),
+  );
 
   // `--create-new` always writes the `.new` sibling, regardless of disk state.
   if (options.createNew) {
@@ -242,6 +249,7 @@ export async function runWorkflowCommand(
   options: WorkflowCommandOptions,
 ): Promise<void> {
   const cwd = process.cwd();
+  setDeclaredEntryPoints(loadDeclaredEntryPoints(cwd));
   if (!fs.existsSync(path.join(cwd, DIR_NAMES.WORKFLOW))) {
     throw new WorkflowCommandError(
       "No .trellis/ directory found. Run `trellis init` first.",

--- a/packages/cli/src/configurators/omp.ts
+++ b/packages/cli/src/configurators/omp.ts
@@ -2,6 +2,7 @@ import { AI_TOOLS } from "../types/ai-tools.js";
 import {
   collectSkillTemplates,
   replacePythonCommandLiterals,
+  applyDeclaredEntryPoints,
   resolveCommands,
   resolveBundledSkills,
   resolveSkills,
@@ -43,7 +44,9 @@ export function collectOmpTemplates(): Map<string, string> {
   // Extension
   files.set(
     ".omp/extensions/trellis/index.ts",
-    replacePythonCommandLiterals(getExtensionTemplate()),
+    applyDeclaredEntryPoints(
+      replacePythonCommandLiterals(getExtensionTemplate()),
+    ),
   );
 
   return files;

--- a/packages/cli/src/configurators/opencode.ts
+++ b/packages/cli/src/configurators/opencode.ts
@@ -6,6 +6,7 @@ import { toPosix } from "../utils/posix.js";
 import {
   collectSkillTemplates,
   replacePythonCommandLiterals,
+  applyDeclaredEntryPoints,
   resolveBundledSkills,
   resolveCommands,
   resolveSkills,
@@ -65,7 +66,7 @@ function walkOpenCodeTemplateDir(): Map<string, string> {
         // keys downstream. Always POSIX, regardless of host OS.
         files.set(
           toPosix(path.join(".opencode", relEntry)),
-          replacePythonCommandLiterals(content),
+          applyDeclaredEntryPoints(replacePythonCommandLiterals(content)),
         );
       }
     }

--- a/packages/cli/src/configurators/shared.ts
+++ b/packages/cli/src/configurators/shared.ts
@@ -6,6 +6,9 @@
  */
 
 import type { TemplateContext } from "../types/ai-tools.js";
+import { applyDeclaredEntryPoints } from "../utils/entry-points.js";
+
+export { applyDeclaredEntryPoints } from "../utils/entry-points.js";
 
 /**
  * Per-platform configure options threaded from `trellis init` flags.
@@ -131,8 +134,10 @@ export function resolvePlaceholders(
   content: string,
   context?: TemplateContext,
 ): string {
-  let result = replacePythonCommandLiterals(
-    content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform()),
+  let result = applyDeclaredEntryPoints(
+    replacePythonCommandLiterals(
+      content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform()),
+    ),
   );
 
   if (!context) return result;
@@ -195,8 +200,10 @@ export function resolvePlaceholdersNeutral(
   content: string,
   context?: TemplateContext,
 ): string {
-  let result = replacePythonCommandLiterals(
-    content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform()),
+  let result = applyDeclaredEntryPoints(
+    replacePythonCommandLiterals(
+      content.replace(RE_PYTHON_CMD, getPythonCommandForPlatform()),
+    ),
   );
 
   if (!context) return result;
@@ -540,7 +547,10 @@ export function renderTemplateMap(
 ): Map<string, string> {
   const rendered = new Map<string, string>();
   for (const [relPath, content] of files) {
-    rendered.set(relPath, replacePythonCommandLiterals(content));
+    rendered.set(
+      relPath,
+      applyDeclaredEntryPoints(replacePythonCommandLiterals(content)),
+    );
   }
   return rendered;
 }
@@ -620,7 +630,8 @@ export function buildPullBasedPrelude(agentType: SubAgentType): string {
   // context buckets keyed by role (not by platform-visible agent name).
   const jsonl = agentType === "check" ? "check.jsonl" : "implement.jsonl";
 
-  return replacePythonCommandLiterals(`## Required: Load Trellis Context First
+  return applyDeclaredEntryPoints(
+    replacePythonCommandLiterals(`## Required: Load Trellis Context First
 
 This platform does NOT auto-inject task context via hook. Before doing anything else, you MUST load context yourself.
 
@@ -645,7 +656,8 @@ If the resolved task path has no \`prd.md\`, ask the user what to work on; do NO
 
 ---
 
-`);
+`),
+  );
 }
 
 /** Insert prelude into a markdown agent definition (after YAML frontmatter). */

--- a/packages/cli/src/configurators/snow.ts
+++ b/packages/cli/src/configurators/snow.ts
@@ -31,6 +31,7 @@ import {
   resolveBundledSkills,
   resolveCommands,
   replacePythonCommandLiterals,
+  applyDeclaredEntryPoints,
 } from "./shared.js";
 
 function buildSnowCommandJson(name: string, content: string): string {
@@ -82,7 +83,9 @@ export function collectSnowTemplates(): Map<string, string> {
   }
 
   for (const cmd of resolveCommands(ctx)) {
-    const body = replacePythonCommandLiterals(cmd.content);
+    const body = applyDeclaredEntryPoints(
+      replacePythonCommandLiterals(cmd.content),
+    );
     files.set(
       `.snow/commands/trellis-${cmd.name}.json`,
       buildSnowCommandJson(cmd.name, body),

--- a/packages/cli/src/configurators/workflow.ts
+++ b/packages/cli/src/configurators/workflow.ts
@@ -39,6 +39,7 @@ import {
 
 import { writeFile, ensureDir } from "../utils/file-writer.js";
 import { replacePythonCommandLiterals } from "./shared.js";
+import { applyDeclaredEntryPoints } from "../utils/entry-points.js";
 import {
   sanitizePkgName,
   type ProjectType,
@@ -143,7 +144,7 @@ export async function createWorkflowStructure(
   // Copy workflow.md (native bundled template or selected marketplace variant)
   await writeFile(
     path.join(cwd, PATHS.WORKFLOW_GUIDE_FILE),
-    replacePythonCommandLiterals(workflowMd),
+    applyDeclaredEntryPoints(replacePythonCommandLiterals(workflowMd)),
   );
 
   // Copy .gitignore from templates
@@ -177,7 +178,9 @@ export async function createWorkflowStructure(
   ensureDir(path.join(cwd, PATHS.WORKSPACE));
   await writeFile(
     path.join(cwd, PATHS.WORKSPACE, "index.md"),
-    replacePythonCommandLiterals(agentProgressIndexContent),
+    applyDeclaredEntryPoints(
+      replacePythonCommandLiterals(agentProgressIndexContent),
+    ),
   );
 
   // Create tasks/ directory

--- a/packages/cli/src/templates/extract.ts
+++ b/packages/cli/src/templates/extract.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, writeFile } from "../utils/file-writer.js";
 import { replacePythonCommandLiterals } from "../configurators/shared.js";
+import { applyDeclaredEntryPoints } from "../utils/entry-points.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -134,9 +135,13 @@ async function copyDirRecursive(
       const content = fs.readFileSync(srcPath, "utf-8");
       const isExecutable =
         options?.executable && (entry.endsWith(".sh") || entry.endsWith(".py"));
-      await writeFile(destPath, replacePythonCommandLiterals(content), {
-        executable: isExecutable,
-      });
+      await writeFile(
+        destPath,
+        applyDeclaredEntryPoints(replacePythonCommandLiterals(content)),
+        {
+          executable: isExecutable,
+        },
+      );
     }
   }
 }

--- a/packages/cli/src/templates/opencode/lib/session-utils.js
+++ b/packages/cli/src/templates/opencode/lib/session-utils.js
@@ -7,6 +7,34 @@ import { debugLog } from "./trellis-context.js"
 
 const PYTHON_CMD = platform() === "win32" ? "python" : "python3"
 
+// Bounded keys and value grammar for `.trellis/entry-points.json`, the
+// declaration an installed wrapper pack uses to point routing text at its own
+// canonical entry surfaces. Trellis never writes the file; any invalid
+// shape, key, or value disables the whole declaration and routing falls back
+// to the Trellis literals.
+const ENTRY_POINT_KEYS = new Set(["start", "continue", "finish-work", "update-spec"])
+const ENTRY_POINT_VALUE_RE = /^\/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}$/
+const ENTRY_POINT_MAX_BYTES = 16 * 1024
+
+function declaredEntryPoint(directory, key, fallback) {
+  try {
+    const filePath = join(directory, ".trellis", "entry-points.json")
+    if (!existsSync(filePath) || statSync(filePath).size > ENTRY_POINT_MAX_BYTES) return fallback
+    const data = JSON.parse(readFileSync(filePath, "utf-8"))
+    if (data === null || typeof data !== "object" || Array.isArray(data)) return fallback
+    if (data.schemaVersion !== 1) return fallback
+    if (Object.keys(data).some(k => k !== "schemaVersion" && k !== "entryPoints")) return fallback
+    const points = data.entryPoints
+    if (points === null || typeof points !== "object" || Array.isArray(points)) return fallback
+    if (Object.keys(points).some(k => !ENTRY_POINT_KEYS.has(k))) return fallback
+    const value = points[key]
+    if (typeof value !== "string" || !ENTRY_POINT_VALUE_RE.test(value)) return fallback
+    return value
+  } catch {
+    return fallback
+  }
+}
+
 const FIRST_REPLY_NOTICE = `<first-reply-notice>
 On the first visible assistant reply in this session, briefly acknowledge that Trellis SessionStart context loaded.
 Choose the acknowledgment language in this order:
@@ -71,7 +99,8 @@ function getTaskStatus(ctx, platformInput = null) {
   const taskStatus = taskData.status || "unknown"
 
   if (taskStatus === "completed") {
-    return `Status: COMPLETED\nTask: ${taskTitle}\nNext-Action: Run /trellis:finish-work. If the working tree is dirty, return to Phase 3.4 first.`
+    const finishEntry = declaredEntryPoint(ctx.directory, "finish-work", "/trellis:finish-work")
+    return `Status: COMPLETED\nTask: ${taskTitle}\nNext-Action: Run ${finishEntry}. If the working tree is dirty, return to Phase 3.4 first.`
   }
 
   const hasPrd = existsSync(join(taskDir, "prd.md"))

--- a/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
+++ b/packages/cli/src/templates/shared-hooks/inject-workflow-state.py
@@ -76,9 +76,58 @@ If you have not already loaded Trellis context this session, read the `trellis-s
 </trellis-bootstrap>"""
 
 
+def _codex_bootstrap_notice(trellis_dir: Path) -> str:
+    """Render the bootstrap notice, honoring a declared start entry point.
+
+    The declared value may be a slash command or a skill name, so the
+    declared form uses a load-neutral phrasing; the undeclared form keeps
+    the exact historical wording.
+    """
+    entry = _declared_entry_point(trellis_dir, "start", "trellis-start")
+    if entry == "trellis-start":
+        return CODEX_NO_TASK_BOOTSTRAP_NOTICE
+    return (
+        "<trellis-bootstrap>\n"
+        f"If you have not already loaded Trellis context this session, load `{entry}` once.\n"
+        "</trellis-bootstrap>"
+    )
+
+
 # ---------------------------------------------------------------------------
 # CWD-robust Trellis root discovery (fixes hook-path-robustness for this hook)
 # ---------------------------------------------------------------------------
+
+# Bounded keys and value grammar for `.trellis/entry-points.json`, the
+# declaration an installed wrapper pack uses to point routing text at its own
+# canonical entry surfaces. Trellis never writes the file; any invalid shape,
+# key, or value disables the whole declaration and routing falls back to the
+# Trellis literals.
+_ENTRY_POINT_KEYS = {"start", "continue", "finish-work", "update-spec"}
+_ENTRY_POINT_VALUE_RE = re.compile(r"/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}\Z")
+_ENTRY_POINT_MAX_BYTES = 16 * 1024
+
+
+def _declared_entry_point(trellis_dir: Path, key: str, fallback: str) -> str:
+    """Return the wrapper pack's declared entry point for `key`, or `fallback`."""
+    try:
+        path = trellis_dir / "entry-points.json"
+        if not path.is_file() or path.stat().st_size > _ENTRY_POINT_MAX_BYTES:
+            return fallback
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schemaVersion") != 1:
+            return fallback
+        if set(data) - {"schemaVersion", "entryPoints"}:
+            return fallback
+        points = data.get("entryPoints")
+        if not isinstance(points, dict) or set(points) - _ENTRY_POINT_KEYS:
+            return fallback
+        value = points.get(key)
+        if not isinstance(value, str) or not _ENTRY_POINT_VALUE_RE.fullmatch(value):
+            return fallback
+        return value
+    except (OSError, ValueError):
+        return fallback
+
 
 def find_trellis_root(start: Path) -> Optional[Path]:
     """Walk up from start to find directory containing .trellis/.
@@ -454,7 +503,7 @@ def main() -> int:
     if platform == "codex":
         parts: list[str] = []
         if task is None:
-            parts.append(CODEX_NO_TASK_BOOTSTRAP_NOTICE)
+            parts.append(_codex_bootstrap_notice(root / ".trellis"))
         parts.append(_codex_mode_banner(config))
         parts.append(breadcrumb)
         breadcrumb = "\n\n".join(parts)

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -421,6 +421,38 @@ def _resolve_task_dir(trellis_dir: Path, task_ref: str) -> Path:
     return trellis_dir / "tasks" / path_obj
 
 
+# Bounded keys and value grammar for `.trellis/entry-points.json`, the
+# declaration an installed wrapper pack uses to point routing text at its own
+# canonical entry surfaces. Trellis never writes the file; any invalid shape,
+# key, or value disables the whole declaration and routing falls back to the
+# Trellis literals.
+_ENTRY_POINT_KEYS = {"start", "continue", "finish-work", "update-spec"}
+_ENTRY_POINT_VALUE_RE = re.compile(r"/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}\Z")
+_ENTRY_POINT_MAX_BYTES = 16 * 1024
+
+
+def _declared_entry_point(trellis_dir: Path, key: str, fallback: str) -> str:
+    """Return the wrapper pack's declared entry point for `key`, or `fallback`."""
+    try:
+        path = trellis_dir / "entry-points.json"
+        if not path.is_file() or path.stat().st_size > _ENTRY_POINT_MAX_BYTES:
+            return fallback
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schemaVersion") != 1:
+            return fallback
+        if set(data) - {"schemaVersion", "entryPoints"}:
+            return fallback
+        points = data.get("entryPoints")
+        if not isinstance(points, dict) or set(points) - _ENTRY_POINT_KEYS:
+            return fallback
+        value = points.get(key)
+        if not isinstance(value, str) or not _ENTRY_POINT_VALUE_RE.fullmatch(value):
+            return fallback
+        return value
+    except (OSError, ValueError):
+        return fallback
+
+
 def _get_task_status(trellis_dir: Path, input_data: dict) -> str:
     """Return compact active-task status, artifact presence, and next action."""
     active = _resolve_active_task(trellis_dir, input_data)
@@ -462,7 +494,7 @@ def _get_task_status(trellis_dir: Path, input_data: dict) -> str:
         return (
             f"Status: COMPLETED\nTask: {task_title}\n"
             f"Present: {present_line}\n"
-            "Next-Action: Run `/trellis:finish-work`. If the working tree is dirty, return to Phase 3.4 first."
+            f"Next-Action: Run `{_declared_entry_point(trellis_dir, 'finish-work', '/trellis:finish-work')}`. If the working tree is dirty, return to Phase 3.4 first."
         )
 
     has_prd = (task_dir / "prd.md").is_file()

--- a/packages/cli/src/templates/trellis/index.ts
+++ b/packages/cli/src/templates/trellis/index.ts
@@ -49,6 +49,7 @@ export const commonGit = readTemplate("scripts/common/git.py");
 export const commonTypes = readTemplate("scripts/common/types.py");
 export const commonTasks = readTemplate("scripts/common/tasks.py");
 export const commonTaskContext = readTemplate("scripts/common/task_context.py");
+export const commonEntryPoints = readTemplate("scripts/common/entry_points.py");
 export const commonTaskStore = readTemplate("scripts/common/task_store.py");
 export const commonSessionContext = readTemplate(
   "scripts/common/session_context.py",
@@ -109,6 +110,7 @@ export function getAllScripts(): Map<string, string> {
   scripts.set("common/types.py", commonTypes);
   scripts.set("common/tasks.py", commonTasks);
   scripts.set("common/task_context.py", commonTaskContext);
+  scripts.set("common/entry_points.py", commonEntryPoints);
   scripts.set("common/task_store.py", commonTaskStore);
   scripts.set("common/session_context.py", commonSessionContext);
   scripts.set("common/packages_context.py", commonPackagesContext);

--- a/packages/cli/src/templates/trellis/scripts/common/entry_points.py
+++ b/packages/cli/src/templates/trellis/scripts/common/entry_points.py
@@ -1,0 +1,59 @@
+"""Declared entry-point lookup for wrapper packs.
+
+An installed wrapper pack may declare preferred entry surfaces for the core
+workflows in `.trellis/entry-points.json` so routing text points agents at the
+pack's canonical commands instead of the Trellis literals:
+
+    {
+      "schemaVersion": 1,
+      "entryPoints": {
+        "start": "/sd:sd-start",
+        "continue": "/sd:sd-continue",
+        "finish-work": "/sd:sd-finish-work",
+        "update-spec": "sd-update-spec"
+      }
+    }
+
+Trellis never writes the file. Every key is optional, values are bounded
+surface names rendered verbatim, and any invalid shape, key, or value
+disables the whole declaration so callers fall back to the Trellis literal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from .paths import DIR_WORKFLOW, get_repo_root
+
+ENTRY_POINT_KEYS = {"start", "continue", "finish-work", "update-spec"}
+_ENTRY_POINT_VALUE_RE = re.compile(r"/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}\Z")
+_ENTRY_POINT_MAX_BYTES = 16 * 1024
+
+
+def declared_entry_point(
+    key: str, fallback: str, repo_root: Path | None = None
+) -> str:
+    """Return the declared entry point for `key`, or `fallback`."""
+    try:
+        root = repo_root if repo_root is not None else get_repo_root()
+        path = root / DIR_WORKFLOW / "entry-points.json"
+        if not path.is_file() or path.stat().st_size > _ENTRY_POINT_MAX_BYTES:
+            return fallback
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schemaVersion") != 1:
+            return fallback
+        if set(data) - {"schemaVersion", "entryPoints"}:
+            return fallback
+        points = data.get("entryPoints")
+        if not isinstance(points, dict) or set(points) - ENTRY_POINT_KEYS:
+            return fallback
+        value = points.get(key)
+        if not isinstance(value, str) or not _ENTRY_POINT_VALUE_RE.fullmatch(
+            value
+        ):
+            return fallback
+        return value
+    except (OSError, ValueError):
+        return fallback

--- a/packages/cli/src/templates/trellis/scripts/common/task_store.py
+++ b/packages/cli/src/templates/trellis/scripts/common/task_store.py
@@ -31,6 +31,7 @@ from .config import (
     resolve_package,
     validate_package,
 )
+from .entry_points import declared_entry_point
 from .git import branch_exists_locally, resolve_default_branch, run_git
 from .io import read_json, write_json
 from .log import Colors, colored
@@ -497,7 +498,8 @@ def cmd_create(args: argparse.Namespace) -> int:
             "  - Curate implement.jsonl / check.jsonl as spec/research manifests when sub-agents need context",
             file=sys.stderr,
         )
-    print("  - Use /trellis:continue or phase context to decide the next step", file=sys.stderr)
+    continue_entry = declared_entry_point("continue", "/trellis:continue")
+    print(f"  - Use {continue_entry} or phase context to decide the next step", file=sys.stderr)
     print("", file=sys.stderr)
 
     # Output relative path for script chaining

--- a/packages/cli/src/utils/entry-points.ts
+++ b/packages/cli/src/utils/entry-points.ts
@@ -1,0 +1,158 @@
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Declared entry points let an installed wrapper pack (for example a company
+ * command pack that wraps `/trellis:finish-work` behind its own finish-work
+ * command) tell Trellis which surface agents should be routed to for a
+ * workflow. Trellis consults the declaration when it writes routing text and
+ * falls back to its own literals when nothing is declared, so behavior in a
+ * repository without a declaration is unchanged.
+ *
+ * The declaration lives at `.trellis/entry-points.json` in the target
+ * repository and is owned by whatever installed it — Trellis never writes it:
+ *
+ * ```json
+ * {
+ *   "schemaVersion": 1,
+ *   "entryPoints": {
+ *     "start": "/sd:sd-start",
+ *     "continue": "/sd:sd-continue",
+ *     "finish-work": "/sd:sd-finish-work",
+ *     "update-spec": "sd-update-spec"
+ *   }
+ * }
+ * ```
+ *
+ * Every key is optional. Values are surface names rendered verbatim into
+ * routing text (a slash command or a skill name), so they are bounded and
+ * validated strictly; any invalid file, shape, key, or value disables the
+ * whole declaration rather than applying it partially.
+ */
+export interface DeclaredEntryPoints {
+  start?: string;
+  continue?: string;
+  "finish-work"?: string;
+  "update-spec"?: string;
+}
+
+export const ENTRY_POINTS_FILE = "entry-points.json";
+
+const ENTRY_POINT_KEYS = new Set([
+  "start",
+  "continue",
+  "finish-work",
+  "update-spec",
+]);
+
+const ENTRY_POINT_VALUE_RE = /^\/?[A-Za-z0-9][A-Za-z0-9/:._-]{0,63}$/;
+
+const MAX_DECLARATION_BYTES = 16 * 1024;
+
+/**
+ * Routing literals each declared key replaces in written template content.
+ * Only exact command/skill routing tokens are mapped; bare skill-identity
+ * names such as `trellis-start` are deliberately not rewritten, because they
+ * also name the installed skill directories themselves.
+ */
+const ENTRY_POINT_LITERALS: readonly (readonly [
+  keyof DeclaredEntryPoints,
+  string,
+])[] = [
+  ["finish-work", "/trellis:finish-work"],
+  ["continue", "/trellis:continue"],
+  ["start", "/trellis:start"],
+  ["update-spec", "trellis-update-spec"],
+];
+
+let declaredEntryPoints: DeclaredEntryPoints | null = null;
+
+/**
+ * Read and validate `.trellis/entry-points.json` under `projectPath`.
+ * Returns `null` (fall back to Trellis literals) for a missing, oversized,
+ * unparsable, or in any way invalid declaration. Never throws.
+ */
+export function loadDeclaredEntryPoints(
+  projectPath: string,
+): DeclaredEntryPoints | null {
+  const filePath = path.join(projectPath, ".trellis", ENTRY_POINTS_FILE);
+  let raw: string;
+  try {
+    if (statSync(filePath).size > MAX_DECLARATION_BYTES) return null;
+    raw = readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const root = parsed as Record<string, unknown>;
+  if (root.schemaVersion !== 1) return null;
+  if (
+    Object.keys(root).some(
+      (key) => key !== "schemaVersion" && key !== "entryPoints",
+    )
+  ) {
+    return null;
+  }
+  const points = root.entryPoints;
+  if (points === null || typeof points !== "object" || Array.isArray(points)) {
+    return null;
+  }
+  const result: DeclaredEntryPoints = {};
+  for (const [key, value] of Object.entries(
+    points as Record<string, unknown>,
+  )) {
+    if (!ENTRY_POINT_KEYS.has(key)) return null;
+    if (typeof value !== "string" || !ENTRY_POINT_VALUE_RE.test(value)) {
+      return null;
+    }
+    // A declared value must not embed a routing literal this transform also
+    // replaces: such a value would make repeated substitution passes
+    // non-idempotent, and pointing an entry at a Trellis literal is already
+    // what the fallback does.
+    if (value.includes("/trellis:") || value.includes("trellis-update-spec")) {
+      return null;
+    }
+    result[key as keyof DeclaredEntryPoints] = value;
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Install the declaration consulted by `applyDeclaredEntryPoints`. Called
+ * once per init/update run after the project path is known; pass `null` to
+ * clear (used by tests and by runs without a declaration).
+ */
+export function setDeclaredEntryPoints(
+  value: DeclaredEntryPoints | null,
+): void {
+  declaredEntryPoints = value;
+}
+
+/**
+ * Replace Trellis routing literals in template content with the declared
+ * entry points. No-op when nothing is declared. Applied at the same
+ * init/update write chokepoints as `replacePythonCommandLiterals`, so the
+ * update-time template hash tracking hashes the same transformed content it
+ * writes. Idempotent: the loader rejects declared values that embed a
+ * replaced literal, so no substitution can introduce new match sites.
+ */
+export function applyDeclaredEntryPoints(content: string): string {
+  const declared = declaredEntryPoints;
+  if (declared === null) return content;
+  let result = content;
+  for (const [key, literal] of ENTRY_POINT_LITERALS) {
+    const value = declared[key];
+    if (value !== undefined && value !== literal) {
+      result = result.replaceAll(literal, value);
+    }
+  }
+  return result;
+}

--- a/packages/cli/test/utils/entry-points.test.ts
+++ b/packages/cli/test/utils/entry-points.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for declared entry points (`.trellis/entry-points.json`).
+ *
+ * Covers:
+ *  - loading: valid declaration, absent file, invalid shapes/keys/values
+ *  - transform: literal substitution, fallback passthrough, idempotency
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  applyDeclaredEntryPoints,
+  loadDeclaredEntryPoints,
+  setDeclaredEntryPoints,
+} from "../../src/utils/entry-points.js";
+
+const DECLARATION = {
+  schemaVersion: 1,
+  entryPoints: {
+    start: "/sd:sd-start",
+    continue: "/sd:sd-continue",
+    "finish-work": "/sd:sd-finish-work",
+    "update-spec": "sd-update-spec",
+  },
+};
+
+function projectWithDeclaration(value: unknown): string {
+  const root = mkdtempSync(path.join(tmpdir(), "trellis-entry-points-"));
+  mkdirSync(path.join(root, ".trellis"), { recursive: true });
+  writeFileSync(
+    path.join(root, ".trellis", "entry-points.json"),
+    typeof value === "string" ? value : JSON.stringify(value),
+    "utf-8",
+  );
+  return root;
+}
+
+afterEach(() => {
+  setDeclaredEntryPoints(null);
+});
+
+describe("loadDeclaredEntryPoints", () => {
+  it("loads a valid declaration", () => {
+    const root = projectWithDeclaration(DECLARATION);
+    try {
+      expect(loadDeclaredEntryPoints(root)).toEqual(DECLARATION.entryPoints);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when the file is absent", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trellis-entry-points-"));
+    try {
+      expect(loadDeclaredEntryPoints(root)).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["unparsable JSON", "{nope"],
+    ["wrong schema version", { schemaVersion: 2, entryPoints: {} }],
+    ["array root", [1]],
+    [
+      "unknown top-level key",
+      { schemaVersion: 1, entryPoints: {}, extra: true },
+    ],
+    [
+      "unknown entry key",
+      { schemaVersion: 1, entryPoints: { "finish-line": "/x:y" } },
+    ],
+    [
+      "non-string value",
+      { schemaVersion: 1, entryPoints: { start: 5 } },
+    ],
+    [
+      "value with whitespace",
+      { schemaVersion: 1, entryPoints: { start: "/sd:sd start" } },
+    ],
+    [
+      "value embedding a replaced literal",
+      { schemaVersion: 1, entryPoints: { start: "/trellis:continue" } },
+    ],
+    [
+      "value embedding the update-spec literal",
+      { schemaVersion: 1, entryPoints: { start: "trellis-update-spec2" } },
+    ],
+    ["empty entryPoints", { schemaVersion: 1, entryPoints: {} }],
+  ])("returns null for %s", (_label, value) => {
+    const root = projectWithDeclaration(value);
+    try {
+      expect(loadDeclaredEntryPoints(root)).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyDeclaredEntryPoints", () => {
+  const sample = [
+    "Flow: `trellis-implement` -> `trellis-update-spec` -> commit -> `/trellis:finish-work`.",
+    "Use /trellis:continue or phase context to decide the next step.",
+    "Run `/trellis:start` to begin.",
+  ].join("\n");
+
+  it("is a no-op when nothing is declared", () => {
+    setDeclaredEntryPoints(null);
+    expect(applyDeclaredEntryPoints(sample)).toBe(sample);
+  });
+
+  it("replaces every mapped literal with the declared value", () => {
+    setDeclaredEntryPoints(DECLARATION.entryPoints);
+    const result = applyDeclaredEntryPoints(sample);
+    expect(result).toContain("`sd-update-spec` -> commit -> `/sd:sd-finish-work`");
+    expect(result).toContain("Use /sd:sd-continue or phase context");
+    expect(result).toContain("Run `/sd:sd-start` to begin.");
+    expect(result).not.toContain("/trellis:");
+    expect(result).not.toContain("trellis-update-spec");
+  });
+
+  it("leaves unmapped literals and skill identities alone", () => {
+    setDeclaredEntryPoints({ "finish-work": "/sd:sd-finish-work" });
+    const result = applyDeclaredEntryPoints(sample);
+    expect(result).toContain("`trellis-implement`");
+    expect(result).toContain("/trellis:continue");
+    expect(result).toContain("/sd:sd-finish-work");
+  });
+
+  it("is idempotent", () => {
+    setDeclaredEntryPoints(DECLARATION.entryPoints);
+    const once = applyDeclaredEntryPoints(sample);
+    expect(applyDeclaredEntryPoints(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Problem

A wrapper pack that fronts the Trellis workflows with its own commands (e.g. a company command pack wrapping `/trellis:finish-work` behind a finish-work command of its own) has no way to stop Trellis from routing agents back to the wrapped surfaces. The routing literals live in files no consumer can edit — a refresh reverts any local change:

- `workflow.md` — `Flow: … -> /trellis:finish-work` and `trellis-update-spec` routing
- `AGENTS.md` — "prefer `/trellis:finish-work`, `/trellis:continue`"
- `shared-hooks/session-start.py` — `Next-Action: Run /trellis:finish-work`
- `shared-hooks/inject-workflow-state.py` — bootstrap notice pointing at the `trellis-start` skill
- `opencode/lib/session-utils.js` — the same Next-Action line
- `scripts/common/task_store.py` — "Use /trellis:continue …" after task creation

## Change

Add a **declared-entry-point seam**: an installed pack may write `.trellis/entry-points.json` declaring a preferred entry surface per workflow, and the emitters above consult it, falling back to today's literals when nothing is declared.

```json
{
  "schemaVersion": 1,
  "entryPoints": {
    "start": "/sd:sd-start",
    "continue": "/sd:sd-continue",
    "finish-work": "/sd:sd-finish-work",
    "update-spec": "sd-update-spec"
  }
}
```

Trellis never writes the file.

**Write time** — `init` / `update` / `workflow` load the declaration once, and `applyDeclaredEntryPoints()` rides the exact write chokepoints `replacePythonCommandLiterals()` already uses, so every written template carries the declared routing and template hash tracking hashes exactly what it writes (updates keep diffing cleanly, including when the declaration changes between updates).

**Runtime** — the two shared hooks, the OpenCode session lib, and `task_store.py` consult the declaration on each emit.

**Validation is strict and all-or-nothing**: bounded file size, `schemaVersion: 1`, fixed key set, bounded value grammar, and no declared value may embed a replaced literal (keeps substitution idempotent). Any invalid declaration disables the whole seam. Bare skill identities such as the `trellis-start` directory name are deliberately not rewritten — only the four routing tokens `/trellis:start`, `/trellis:continue`, `/trellis:finish-work`, and `trellis-update-spec`.

## Behavior without a declaration

Unchanged, byte for byte — the transform is a no-op and every emitter keeps its historical wording. The full existing test suite (which inits without declarations everywhere) passes untouched.

## Validation

- `pnpm test`: core 344 passed, cli **1723 passed** (includes 16 new entry-point tests: loader validation matrix, substitution, fallback, idempotency)
- `pnpm lint`: clean
- End-to-end: a real `trellis init` over a repo carrying the declaration produces generated markdown with **zero** remaining `/trellis:` literals, substituted `AGENTS.md`, and `task.py create` printing the declared continue entry; the same init without a declaration keeps all literals.

## Provenance

Filed from a downstream consumer where an audit (finding A-005) measured agents being routed to wrapped entry points by vendored files. The pack half of that finding is platypeeps/sd-ai-command-pack#486; this is the Trellis half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y3oVg5eZmhF14F5FGmB36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional entry-point declarations, allowing Trellis commands and generated instructions to use customized routes.
  * Applied configured routes consistently across initialization, updates, workflows, templates, and task guidance.
  * Added support for customized start, continue, finish-work, and update-spec actions.
* **Reliability**
  * Invalid, oversized, or unsupported declarations safely fall back to the standard Trellis routes without interrupting command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->