### PR TITLE
feat(cli): warn when the resolved python command is slow to start

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -71,6 +71,14 @@ const MIN_PYTHON_MAJOR = 3;
 const MIN_PYTHON_MINOR = 9;
 const PYTHON_VERSION_RE = /Python (\d+)\.(\d+)/;
 
+// Above this, `<cmd> --version` is answering too slowly to be a bare
+// interpreter. Measured on Windows 11 + pyenv-win 3.11.9: the real interpreter
+// answers in 30-80ms, while the pyenv shim costs 654ms cold and still 330ms
+// warm. Since we compare against the warm figure (see warnIfSlowPythonCommand),
+// the number that matters is 330ms, and the threshold must stay well under it —
+// raising this past ~300ms silently stops detecting the case this exists for.
+const SLOW_PYTHON_PROBE_MS = 250;
+
 function collectSpecPaths(cwd: string): Set<string> {
   const specRoot = path.join(cwd, PATHS.SPEC);
   const paths = new Set<string>();
@@ -120,6 +128,68 @@ function detectPythonVersion(command: string): PythonProbe {
       return "sandbox-restricted";
     }
     return null;
+  }
+}
+
+/** `detectPythonVersion` plus how long the spawn took. */
+function timedPythonProbe(command: string): {
+  probe: PythonProbe;
+  elapsedMs: number;
+} {
+  const started = Date.now();
+  const probe = detectPythonVersion(command);
+  return { probe, elapsedMs: Date.now() - started };
+}
+
+/**
+ * Warn when the chosen Python command is slow to start.
+ *
+ * The command we resolve here is written into every generated hook, and those
+ * hooks run on every prompt, every file edit and every subagent dispatch. A
+ * command that costs ~0.5s per spawn — the usual signature of a version-manager
+ * shim (pyenv-win, asdf, mise) — therefore adds tens of seconds per session,
+ * spread across as many separate stalls. The version probe alone can't see this
+ * because a shim reports the same version as the interpreter behind it.
+ *
+ * We deliberately warn instead of substituting the absolute interpreter path.
+ * Whatever command we resolve is written literally into generated config such
+ * as `.claude/settings.json`, and those files are routinely committed and
+ * shared — see #503, where a plain `python3` vs `python` mismatch already
+ * breaks collaborators on another OS. An absolute machine path is a strictly
+ * worse offender, so we point at PATH first and mention TRELLIS_PYTHON_CMD only
+ * as the local-only alternative, rather than deciding the tradeoff for them.
+ *
+ * Never throws — a diagnostic must not be able to fail `init`.
+ */
+function warnIfSlowPythonCommand(command: string, elapsedMs: number): void {
+  if (elapsedMs <= SLOW_PYTHON_PROBE_MS) return;
+
+  try {
+    // Re-probe once and keep the better reading, so a cold filesystem cache or
+    // an antivirus first-touch can't trigger the warning on its own.
+    const { elapsedMs: second } = timedPythonProbe(command);
+    const best = Math.min(elapsedMs, second);
+    if (best <= SLOW_PYTHON_PROBE_MS) return;
+
+    console.warn(
+      chalk.yellow(
+        `⚠ "${command}" took ${best}ms to start (expected < ${SLOW_PYTHON_PROBE_MS}ms).\n` +
+          `  Trellis hooks spawn it on every prompt, every file edit and every\n` +
+          `  subagent dispatch, so this cost is paid tens of times per session.\n\n` +
+          `  A version manager shim (pyenv, asdf, mise) is the usual cause. See\n` +
+          `  which interpreter is behind it:\n\n` +
+          `      ${command} -c "import sys; print(sys.executable)"\n\n` +
+          `  Recommended: put that directory ahead of the shim directory on\n` +
+          `  PATH, then re-run init. The generated config keeps working for\n` +
+          `  everyone who shares this repo.\n\n` +
+          `  Local-only projects can instead set TRELLIS_PYTHON_CMD to that\n` +
+          `  path and re-run init. That writes an absolute machine path into\n` +
+          `  the generated hook config, so avoid it if you commit that config\n` +
+          `  or work across machines.`,
+      ),
+    );
+  } catch {
+    // Diagnostics are best-effort.
   }
 }
 
@@ -217,7 +287,7 @@ export function resolveSupportedPython(): {
 
   const probeFailures: string[] = [];
   for (const candidate of candidates) {
-    const probe = detectPythonVersion(candidate);
+    const { probe, elapsedMs } = timedPythonProbe(candidate);
     if (probe === "sandbox-restricted") {
       console.warn(
         chalk.yellow(
@@ -241,6 +311,7 @@ export function resolveSupportedPython(): {
       probeFailures.push(`${candidate}: ${probe} (< 3.9)`);
       continue;
     }
+    warnIfSlowPythonCommand(candidate, elapsedMs);
     setResolvedPythonCommand(candidate);
     return { command: candidate, version: probe };
   }

--- a/packages/cli/test/commands/init-internals.test.ts
+++ b/packages/cli/test/commands/init-internals.test.ts
@@ -205,3 +205,136 @@ describe("resolveSupportedPython", () => {
     expect(result.version).toMatch(/sandbox-restricted/);
   });
 });
+
+// =============================================================================
+// resolveSupportedPython — slow interpreter warning
+//
+// A version-manager shim (pyenv-win, asdf, mise) reports the same version as
+// the interpreter behind it, so the version probe can't tell them apart. What
+// separates them is startup cost: ~40ms for a real interpreter vs ~550ms
+// through a shim. Since the resolved command runs on every prompt, every edit
+// and every subagent dispatch, that gap is worth surfacing at init time.
+//
+// Probe latency is driven by advancing fake timers inside the execSync mock,
+// which moves the Date.now() readings the implementation takes. No sleeping.
+// =============================================================================
+
+describe("resolveSupportedPython — slow interpreter warning", () => {
+  /** Makes each probe report `durations[n]` ms, reusing the last value. */
+  const probeTaking = (...durations: number[]): void => {
+    let call = 0;
+    vi.mocked(execSync).mockImplementation((() => {
+      const ms = durations[Math.min(call, durations.length - 1)] ?? 0;
+      call += 1;
+      vi.advanceTimersByTime(ms);
+      return "Python 3.11.12";
+    }) as typeof execSync);
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(execSync).mockReset();
+    resetResolvedPythonCommand();
+    delete process.env.TRELLIS_PYTHON_CMD;
+    delete process.env.TRELLIS_SKIP_PYTHON_CHECK;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetResolvedPythonCommand();
+    delete process.env.TRELLIS_PYTHON_CMD;
+    delete process.env.TRELLIS_SKIP_PYTHON_CHECK;
+    vi.restoreAllMocks();
+  });
+
+  it("warns but still resolves when the interpreter is slow to start", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    probeTaking(600);
+
+    const result = resolveSupportedPython();
+
+    // Selection is unchanged — this is a diagnostic, not a fallback.
+    expect(result.version).toBe("Python 3.11.12");
+    expect(getPythonCommandForPlatform()).toBe(result.command);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/took 600ms to start/);
+  });
+
+  it("stays quiet when the interpreter starts fast", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    probeTaking(40);
+
+    expect(resolveSupportedPython().version).toBe("Python 3.11.12");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-probes before warning, so one cold spawn is not enough", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    // First spawn pays a cold filesystem / antivirus first-touch cost; the
+    // second shows what the command actually costs.
+    probeTaking(600, 40);
+
+    expect(resolveSupportedPython().version).toBe("Python 3.11.12");
+    expect(execSync).toHaveBeenCalledTimes(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("tells the user how to find the real interpreter and apply it", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    probeTaking(600);
+
+    resolveSupportedPython();
+
+    const message = warnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toMatch(/print\(sys\.executable\)/);
+    // PATH is the portable remedy and must be the recommended one: whatever
+    // command init resolves is written literally into generated config that
+    // gets committed and shared (#503). TRELLIS_PYTHON_CMD pins an absolute
+    // machine path, so it may only appear as the local-only alternative,
+    // carrying that caveat.
+    expect(message).toMatch(
+      /Recommended: put that directory ahead of the shim/,
+    );
+    expect(message.indexOf("Recommended:")).toBeLessThan(
+      message.indexOf("TRELLIS_PYTHON_CMD"),
+    );
+    expect(message).toMatch(/absolute machine path/);
+    // The audience for this warning is overwhelmingly Windows (pyenv-win), so
+    // the copy must not hand out `VAR=value cmd`, which only works in POSIX
+    // shells. Match the existing TRELLIS_SKIP_PYTHON_CHECK wording instead.
+    expect(message).not.toMatch(/TRELLIS_PYTHON_CMD=/);
+  });
+
+  it("stays quiet when TRELLIS_PYTHON_CMD pins the command", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    process.env.TRELLIS_PYTHON_CMD = "py -3.12";
+    probeTaking(600);
+
+    expect(resolveSupportedPython().command).toBe("py -3.12");
+    expect(execSync).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when TRELLIS_SKIP_PYTHON_CHECK=1 opts out of probing", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    process.env.TRELLIS_SKIP_PYTHON_CHECK = "1";
+    probeTaking(600);
+
+    resolveSupportedPython();
+    expect(execSync).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

`trellis init` selects a Python command by **version only**. It never checks how
long that command takes to start.

A version-manager shim (pyenv-win, asdf, mise) answers `--version` identically
to the interpreter behind it, so nothing in the current probe can tell them
apart — but it costs roughly **13x** more per spawn. The winning candidate then
gets baked into every generated hook command, and every session afterwards pays
that cost silently.

### Measured, not hypothetical

Windows 11, pyenv-win 3.11.9, `python` resolving to
`~/.pyenv/pyenv-win/shims/python`:

| Probe | via pyenv shim | via real interpreter |
| --- | --- | --- |
| `python -c "pass"` | 517–680 ms | 40–56 ms |
| `inject-workflow-state.py` (every user prompt) | 629 ms | 100 ms |
| `guard-spec-size.py` (every Write/Edit) | 614 ms | 56 ms |
| `inject-subagent-context.py` (every dispatch) | ~610 ms | 71 ms |
| `session-start.py` | 1353 ms | 376 ms |

The hook scripts' own work is 20–30 ms. Essentially all of the cost is
interpreter startup, which is why this is invisible when profiling the hooks
themselves.

Compounding: a session touching 40 files over 20 turns with 5 subagent
dispatches pays `(40 + 20 + 10 + 1) × ~0.54s` ≈ **38 seconds** of pure overhead,
delivered as ~70 separate stalls. It reads as "Trellis got slow", not as "one
thing is misconfigured".

Why this hasn't shown up upstream: on macOS/Linux `python3` starts in ~30 ms, so
the version-only probe is perfectly adequate there. The failure mode needs
Windows + a shim-based version manager. CI is `ubuntu-latest`, so it cannot see
this.

## Change

Time the probe that already happens, and warn. Interpreter selection is
**unchanged** — this is a diagnostic, not a fallback.

- `timedPythonProbe()` wraps the existing `detectPythonVersion()` call, so the
  healthy path spawns **no extra process** (C2). The `--version` handler itself
  is trivial, so elapsed time is dominated by interpreter/shim startup — exactly
  the quantity that matters.
- `warnIfSlowPythonCommand()` fires only on the **accept path** of the candidate
  loop. Rejected candidates, the `sandbox-restricted` branch, `TRELLIS_PYTHON_CMD`
  and `TRELLIS_SKIP_PYTHON_CHECK=1` all stay silent (the latter two return before
  the loop, so this is free).
- A slow first reading is **re-probed once** and the better figure kept, so a
  cold FS cache or an antivirus first-touch cannot trigger the warning on its
  own. The re-probe only ever runs on the already-slow path.
- Wrapped so any throw is swallowed — a diagnostic must never be able to fail
  `init`.

### Why timing rather than matching shim paths

Matching `**/shims/**` or `.bat` would be a proxy for the real symptom and would
need extending for every version manager. Timing measures the thing users
actually feel, needs no allowlist, and also catches unrelated causes with the
same effect — antivirus interception, a network-mounted interpreter, a wrapper
script.

### Why warn instead of auto-substituting `sys.executable`

This is the part I'd most like a maintainer's read on.

Substituting the absolute interpreter path would fix the reporter's machine and
**break their teammates**. Whatever command `init` resolves is written literally
into generated config such as `.claude/settings.json`, which is routinely
committed and shared — that is precisely #503, where a plain `python3` vs
`python` mismatch already breaks collaborators on another OS. An absolute
machine path (`C:\Users\<name>\...`) is a strictly worse offender.

So the warning leads with the **PATH** remedy (portable, keeps generated config
working for everyone sharing the repo) and demotes `TRELLIS_PYTHON_CMD` to a
local-only alternative carrying that caveat. The test locks that ordering as a
contract rather than leaving it to prose.

If you'd rather this became a real fix for #503 (placeholder / local
`platform.json`), I'm happy to rework it in that direction — this PR is
deliberately the smallest thing that stops the problem being invisible.

## Threshold

`SLOW_PYTHON_PROBE_MS = 250`. Real interpreters measure 30–80 ms; shim
indirection measures 330 ms warm / 654 ms cold on the reporter's box. 250 ms
sits in the empty band between the two populations. The constant carries a
comment noting that raising it past ~300 ms silently stops detecting the case it
exists for.

## Output

```
⚠ "python" took 438ms to start (expected < 250ms).
  Trellis hooks spawn it on every prompt, every file edit and every
  subagent dispatch, so this cost is paid tens of times per session.

  A version manager shim (pyenv, asdf, mise) is the usual cause. See
  which interpreter is behind it:

      python -c "import sys; print(sys.executable)"

  Recommended: put that directory ahead of the shim directory on
  PATH, then re-run init. The generated config keeps working for
  everyone who shares this repo.

  Local-only projects can instead set TRELLIS_PYTHON_CMD to that
  path and re-run init. That writes an absolute machine path into
  the generated hook config, so avoid it if you commit that config
  or work across machines.
```

The copy deliberately avoids `VAR=value cmd` syntax — the audience for this
warning is overwhelmingly Windows, where that only works in a POSIX shell. It
matches the existing `TRELLIS_SKIP_PYTHON_CHECK=1` phrasing instead, and there's
a regression assertion for it.

## Testing

6 new tests in `init-internals.test.ts`, driving probe latency with vitest fake
timers inside the existing `execSync` mock — deterministic, no sleeping:

- slow probe → still resolves, warning names the measured duration
- fast probe → silent
- slow-then-fast → re-probed, `execSync` called twice, **no** warning
- warning copy → contains `sys.executable`, recommends PATH **before**
  `TRELLIS_PYTHON_CMD`, states the absolute-path caveat, uses no POSIX-only
  syntax
- `TRELLIS_PYTHON_CMD` set → no probe, no warning
- `TRELLIS_SKIP_PYTHON_CHECK=1` → no probe, no warning

Existing tests are unaffected: their mocked `execSync` returns instantly, so
elapsed is 0 and the warning never fires.

Verified locally:
- `pnpm lint` → 0
- `pnpm typecheck` → 0
- `pnpm test:core` → 346 passed
- `packages/cli` full suite → identical failure set before and after the change
  (19 pre-existing failures on this Windows box: submodule mirror, atomic-write
  chmod semantics, python-rewrite parity), plus the 6 new passing tests
- End-to-end with the real pyenv shim first on PATH → warning fires at 438 ms,
  `resolveSupportedPython()` still returns `{"command":"python","version":"Python 3.11.9"}`.
  With the shim removed from PATH → silent, same resolution.

## Scope

Single file, additive, no signature changes, no new exports, no new dependency.
`resolveSupportedPython` has exactly one production caller (`init.ts`).
`git revert` of the one commit is sufficient rollback.

Related: #503 (same root cause class — resolved command leaking into shared
config), #236 (candidate fallback chain this builds on).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics for unusually slow Python startup during setup.
  * Automatically rechecks initially slow Python commands to distinguish cold starts from consistently slow launches.
  * Provides guidance when version-manager shims may be affecting startup time, including alternative configuration options.

* **Bug Fixes**
  * Slow or failed Python probes remain non-blocking and no longer interrupt setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->