### PR TITLE
fix(templates): avoid generated whitespace errors

### DIFF
--- a/.trellis/scripts/common/developer.py
+++ b/.trellis/scripts/common/developer.py
@@ -83,7 +83,6 @@ def init_developer(name: str, repo_root: Path | None = None) -> bool:
 > Started: {today}
 
 ---
-
 """
         try:
             journal_file.write_text(journal_content, encoding="utf-8")

--- a/packages/cli/src/templates/common/bundled-skills/trellis-channel/references/command-reference.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-channel/references/command-reference.md
@@ -477,4 +477,3 @@ Forum channels are event-sourced; use the CLI reducers
   pipe); diagnostic notes go to stderr.
 - **Errors** go through `chalk.red("Error:")` to stderr and `exit 1`.
 - **`wait` timeout** specifically exits **124**.
-

--- a/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/workspace-memory.md
+++ b/packages/cli/src/templates/common/bundled-skills/trellis-meta/references/local-architecture/workspace-memory.md
@@ -53,8 +53,8 @@ Planning or review work without a commit can also be recorded by using `--no-com
 | `.trellis/workspace/` | Work records across tasks and sessions. |
 | `.trellis/spec/` | Engineering knowledge preserved as long-term conventions. |
 
-If information is only useful for the current task, put it in the task directory.  
-If information describes what happened in the current session, put it in the workspace journal.  
+If information is only useful for the current task, put it in the task directory.<br>
+If information describes what happened in the current session, put it in the workspace journal.<br>
 If information should be followed every time code is written in the future, put it in spec.
 
 ## Local Customization Points

--- a/packages/cli/src/templates/trellis/scripts/common/developer.py
+++ b/packages/cli/src/templates/trellis/scripts/common/developer.py
@@ -83,7 +83,6 @@ def init_developer(name: str, repo_root: Path | None = None) -> bool:
 > Started: {today}
 
 ---
-
 """
         try:
             journal_file.write_text(journal_content, encoding="utf-8")

--- a/packages/cli/test/templates/fixed-diff.test.ts
+++ b/packages/cli/test/templates/fixed-diff.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBundledSkillTemplates } from "../../src/templates/common/index.js";
+import { getAllScripts } from "../../src/templates/trellis/index.js";
+
+const pythonCmd = process.platform === "win32" ? "python" : "python3";
+
+describe("generated templates pass fixed-diff checks", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-fixed-diff-"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: tmpDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(relativePath: string, content: string): string {
+    const absolutePath = path.join(tmpDir, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, content, "utf-8");
+    return absolutePath;
+  }
+
+  function initializeDeveloper(): string {
+    const scriptsDir = path.join(tmpDir, ".trellis", "scripts");
+    for (const [relativePath, content] of getAllScripts()) {
+      writeFile(path.join(".trellis", "scripts", relativePath), content);
+    }
+
+    execFileSync(
+      pythonCmd,
+      [path.join(scriptsDir, "init_developer.py"), "test-dev"],
+      { cwd: tmpDir, stdio: "pipe" },
+    );
+    return fs.readFileSync(
+      path.join(tmpDir, ".trellis", "workspace", "test-dev", "journal-1.md"),
+      "utf-8",
+    );
+  }
+
+  function writeAffectedBundledSkillFiles(): string[] {
+    const affected = new Map([
+      ["trellis-channel", new Set(["references/command-reference.md"])],
+      [
+        "trellis-meta",
+        new Set(["references/local-architecture/workspace-memory.md"]),
+      ],
+    ]);
+    const written: string[] = [];
+
+    for (const skill of getBundledSkillTemplates()) {
+      const selected = affected.get(skill.name);
+      if (!selected) continue;
+      for (const file of skill.files) {
+        if (!selected.has(file.relativePath)) continue;
+        const relativePath = path.join(
+          ".agents",
+          "skills",
+          skill.name,
+          file.relativePath,
+        );
+        writeFile(relativePath, file.content);
+        written.push(relativePath);
+      }
+    }
+
+    expect(written).toHaveLength(2);
+    return written;
+  }
+
+  it("initial journal has exactly one final newline", () => {
+    const journal = initializeDeveloper();
+
+    expect(journal.endsWith("\n")).toBe(true);
+    expect(journal.endsWith("\n\n")).toBe(false);
+  });
+
+  it("fresh affected files are clean when staged", () => {
+    const bundledFiles = writeAffectedBundledSkillFiles();
+    initializeDeveloper();
+    const journalPath = path.join(
+      ".trellis",
+      "workspace",
+      "test-dev",
+      "journal-1.md",
+    );
+
+    execFileSync("git", ["add", "--", ...bundledFiles, journalPath], {
+      cwd: tmpDir,
+    });
+    const fixedDiff = spawnSync("git", ["diff", "--cached", "--check"], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(fixedDiff.status, `${fixedDiff.stdout}${fixedDiff.stderr}`).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- remove fixed-diff whitespace findings from two bundled skill documents
- make newly initialized developer journals end with exactly one newline
- keep the root developer script mirror byte-identical to the packaged template
- add regression coverage that stages actual generated files and runs `git diff --cached --check`

## Verification

- focused fixed-diff tests: 2/2 passed
- selected template mirror regression tests: 29/29 passed
- full CLI test suite: 77 files, 1710/1710 tests passed
- lint, typecheck, and build passed
- changed Markdown/TypeScript files pass Prettier; changed Python files compile
- developer script mirror comparison and `git diff --check` passed

## Existing baseline

The package-wide `format:check` still reports 16 unchanged files outside this pull request. Every changed file supported by Prettier passes its focused format check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting consistency in generated workspace journals and guidance documents.
  * Removed trailing whitespace issues from bundled templates.

* **Tests**
  * Added automated checks to verify generated files have correct newline formatting and no Git whitespace errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->