### PR TITLE
feat(mem): restore the OpenCode session reader without a native dependency

### DIFF
--- a/packages/cli/src/commands/mem.ts
+++ b/packages/cli/src/commands/mem.ts
@@ -2,8 +2,8 @@
  * mem.ts — CLI wrapper over `@mindfoldhq/trellis-core/mem`.
  *
  * The reusable retrieval / context-extraction logic lives in core; this file
- * owns only CLI concerns: argument parsing, terminal rendering, the OpenCode
- * "reader unavailable" notice, and process exit behavior.
+ * owns only CLI concerns: argument parsing, terminal rendering, warning
+ * presentation, and process exit behavior.
  *
  * Commands:
  *   list                          list sessions (default if no command)
@@ -121,29 +121,6 @@ function die(msg: string): never {
   process.exit(2);
 }
 
-// ---------- OpenCode reader notice ----------
-//
-// OpenCode 1.2+ moved to a SQLite store; the native dependency was reverted in
-// 0.6.0-beta.4 due to install failures. Core's OpenCode adapter is a silent
-// no-op — surfacing the degraded state is a CLI presentation concern, emitted
-// once per process whenever the OpenCode source is in scope.
-
-let opencodeWarned = false;
-function warnOpencodeUnavailable(): void {
-  if (opencodeWarned) return;
-  opencodeWarned = true;
-  process.stderr.write(
-    "⚠️  tl mem: OpenCode platform reader is temporarily unavailable in this build.\n" +
-      "    OpenCode 1.2+ moved to SQLite; the native dependency was reverted in\n" +
-      "    0.6.0-beta.4 due to install failures. Re-enabled in a future release.\n",
-  );
-}
-
-function maybeWarnOpencode(f: MemFilter): void {
-  if (f.platform === "all" || f.platform === "opencode")
-    warnOpencodeUnavailable();
-}
-
 // ---------- formatting ----------
 
 const HOME = os.homedir();
@@ -188,7 +165,6 @@ function printWarnings(
 
 function cmdList(argv: Argv): void {
   const f = buildFilter(argv.flags);
-  maybeWarnOpencode(f);
   const warnings: { message: string }[] = [];
   const rows = listMemSessions({
     filter: f,
@@ -212,7 +188,6 @@ function cmdSearch(argv: Argv): void {
   const kw = argv.positional[0];
   if (!kw) die("usage: search <keyword>");
   const f = buildFilter(argv.flags);
-  maybeWarnOpencode(f);
   const includeChildren = argv.flags["include-children"] === true;
   const result = searchMemSessions({
     keyword: kw,
@@ -276,7 +251,6 @@ function cmdProjects(argv: Argv): void {
   // session counts. AI calls this first to learn which project paths have
   // recent activity, then picks one for `--cwd` in a follow-up `search`.
   const f = buildFilter({ ...argv.flags, global: true });
-  maybeWarnOpencode(f);
   const warnings: { message: string }[] = [];
   const rows = listMemProjects({
     filter: f,
@@ -321,7 +295,6 @@ function cmdContext(argv: Argv): void {
   if (!id)
     die("usage: context <session-id> [--grep KW] [--turns N] [--around M]");
   const f = buildFilter(argv.flags);
-  maybeWarnOpencode(f);
 
   const grepRaw = argv.flags.grep;
   const grep = typeof grepRaw === "string" ? grepRaw : undefined;
@@ -422,7 +395,6 @@ function cmdExtract(argv: Argv): void {
   const id = argv.positional[0];
   if (!id) die("usage: extract <session-id>");
   const f = buildFilter(argv.flags);
-  maybeWarnOpencode(f);
 
   const phase = parsePhaseFlag(argv.flags.phase);
   const grepRaw = argv.flags.grep;

--- a/packages/core/src/mem/adapters/opencode.ts
+++ b/packages/core/src/mem/adapters/opencode.ts
@@ -1,34 +1,592 @@
 /**
- * OpenCode session reader — currently a degraded no-op.
+ * OpenCode 1.2+ persisted-session reader.
  *
- * OpenCode 1.2+ moved to a SQLite store at
- * `~/.local/share/opencode/opencode.db`. The previous SQLite reader required a
- * native dependency (`better-sqlite3`) whose prebuilt-tarball + node-gyp
- * fallback chain broke `npm install` on Windows + restricted networks, so it
- * was reverted. These adapter functions are kept (dispatch / phase slicing
- * rely on them) but degraded to silent no-ops.
+ * OpenCode stores sessions in a WAL-mode SQLite database under its XDG data
+ * dir (see `internal/paths.ts:opencodeDbPath`). The three tables this adapter
+ * reads, confirmed against a live 1.18 store:
  *
- * The "OpenCode reader unavailable" warning is a presentation concern owned by
- * the CLI — core never prints. Re-enabled in a future release once a
- * non-native backend ships.
+ *   - `session`  — id / parent_id (sub-agent chain) / title / directory
+ *                  (workspace cwd) / time_created / time_updated
+ *   - `message`  — id / session_id / time_created / data (JSON: {role, ...})
+ *   - `part`     — message_id / session_id / time_created /
+ *                  data (JSON: {type: "text"|"tool"|"reasoning"|..., ...})
+ *
+ * SQLite access is via the zero-dependency parser in
+ * `internal/sqlite-readonly.ts`. A `better-sqlite3`-backed reader shipped in
+ * 0.6.0-beta.3 and was reverted one release later because its prebuild
+ * download + node-gyp fallback broke `npm install` on Windows and restricted
+ * networks; no native module, WASM blob, system `sqlite3`, or install-time
+ * build step may come back with this adapter.
+ *
+ * Everything here is read-only: the database is snapshotted and parsed, never
+ * opened for write, locked, checkpointed, or copied over.
  */
 
+import * as fs from "node:fs";
+
+import {
+  compactionBoundaryTurn,
+  stripInjectionTags,
+  isBootstrapTurn,
+} from "../dialogue.js";
+import { inRangeOverlap, sameProject } from "../filter.js";
+import {
+  openSqliteReadOnly,
+  SqliteParseError,
+  SqliteSnapshotUnstableError,
+  type SqliteRow,
+  type SqliteTableInfo,
+} from "../internal/sqlite-readonly.js";
+import { opencodeDbPath } from "../internal/paths.js";
 import { searchInDialogue } from "../search.js";
 import type {
+  DialogueRole,
   DialogueTurn,
   MemFilter,
   MemSessionInfo,
+  MemWarning,
   SearchHit,
 } from "../types.js";
 
-export function opencodeListSessions(_f: MemFilter): MemSessionInfo[] {
-  return [];
+// ---------- loose external shapes ----------
+
+interface OpencodeMessageData {
+  role?: string;
 }
 
-export function opencodeExtractDialogue(_s: MemSessionInfo): DialogueTurn[] {
-  return [];
+interface OpencodePartData {
+  type?: string;
+  text?: string;
+  summaryMessageId?: unknown;
+  tail_start_id?: unknown;
+  compactBoundary?: unknown;
+  replace?: unknown;
 }
 
-export function opencodeSearch(kw: string): SearchHit {
-  return searchInDialogue([], kw);
+function parseDialogueRole(v: unknown): DialogueRole | undefined {
+  return v === "user" || v === "assistant" ? v : undefined;
+}
+
+/** Safely parse the JSON stored in a `data` column. Returns null on failure —
+ * a row carrying hostile or truncated JSON is dropped, never thrown on. */
+function parseDataJson(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const v: unknown = JSON.parse(raw);
+    return v && typeof v === "object" && !Array.isArray(v)
+      ? (v as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------- schema contract ----------
+
+const SESSION_TABLE = "session";
+const MESSAGE_TABLE = "message";
+const PART_TABLE = "part";
+
+/** Accepted spellings for the session's workspace directory, in preference
+ * order. Current OpenCode uses `directory`; `cwd` is accepted so an older or
+ * renamed store still lists rather than failing closed. */
+const SESSION_CWD_COLUMNS = ["directory", "cwd"] as const;
+
+/**
+ * Thrown when the store is a readable SQLite file whose tables/columns do not
+ * match anything this adapter knows how to interpret. Kept distinct from a
+ * corrupt file so the CLI can tell "OpenCode changed its schema" apart from
+ * "this database is damaged" — both degrade to an empty result.
+ */
+class OpencodeSchemaError extends SqliteParseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpencodeSchemaError";
+  }
+}
+
+const DB_UNREADABLE_WARNING_CODE = "opencode-db-unreadable";
+const DB_SNAPSHOT_UNSTABLE_WARNING_CODE = "opencode-db-snapshot-unstable";
+const DB_SCHEMA_WARNING_CODE = "opencode-db-schema-unsupported";
+
+/** Record one degradation per condition per command — repeated failures while
+ * scanning many sessions must not produce repeated terminal noise. */
+function pushDbWarning(
+  warnings: MemWarning[],
+  dbPath: string,
+  error: SqliteParseError,
+): void {
+  const code =
+    error instanceof SqliteSnapshotUnstableError
+      ? DB_SNAPSHOT_UNSTABLE_WARNING_CODE
+      : error instanceof OpencodeSchemaError
+        ? DB_SCHEMA_WARNING_CODE
+        : DB_UNREADABLE_WARNING_CODE;
+  if (warnings.some((warning) => warning.code === code)) return;
+
+  const message =
+    code === DB_SNAPSHOT_UNSTABLE_WARNING_CODE
+      ? `OpenCode is writing to its session database; retry in a moment (${dbPath})`
+      : code === DB_SCHEMA_WARNING_CODE
+        ? `unsupported OpenCode session schema (${dbPath}): ${error.message}`
+        : `cannot read OpenCode session database (${dbPath}): ${error.message}`;
+  warnings.push({ code, message });
+}
+
+type ReadOnlyDb = ReturnType<typeof openSqliteReadOnly>;
+
+function findTable(db: ReadOnlyDb, name: string): SqliteTableInfo {
+  const table = db.listTables().find((item) => item.name === name);
+  if (!table) {
+    throw new OpencodeSchemaError(`missing table: ${name}`);
+  }
+  return table;
+}
+
+/** True when `CREATE TABLE` sql declares a column of this exact name. Column
+ * semantics are matched by name only — never by position, so a reordered or
+ * extended schema cannot silently shift values into the wrong field. */
+function declaresColumn(table: SqliteTableInfo, name: string): boolean {
+  const pattern = new RegExp(
+    `(?:\\(|,)\\s*["\`\\[]?${name}(?:["\`\\]]|\\b)`,
+    "i",
+  );
+  return pattern.test(table.sql);
+}
+
+function requireColumns(
+  table: SqliteTableInfo,
+  names: readonly string[],
+): void {
+  const missing = names.filter((name) => !declaresColumn(table, name));
+  if (missing.length > 0) {
+    throw new OpencodeSchemaError(
+      `table ${table.name} is missing column(s): ${missing.join(", ")}`,
+    );
+  }
+}
+
+/** Pick the first accepted spelling a table actually declares. */
+function requireOneOfColumns(
+  table: SqliteTableInfo,
+  candidates: readonly string[],
+): string {
+  const found = candidates.find((name) => declaresColumn(table, name));
+  if (!found) {
+    throw new OpencodeSchemaError(
+      `table ${table.name} has none of the expected column(s): ${candidates.join(" / ")}`,
+    );
+  }
+  return found;
+}
+
+/** The declared schema and the decoded rows can disagree when the sql failed to
+ * parse; re-check against a real row before trusting any of it. */
+function requireRowColumns(
+  rows: readonly SqliteRow[],
+  tableName: string,
+  names: readonly string[],
+): void {
+  const first = rows[0];
+  if (!first) return;
+  const missing = names.filter((name) => !(name in first));
+  if (missing.length > 0) {
+    throw new OpencodeSchemaError(
+      `table ${tableName} is missing column(s): ${missing.join(", ")}`,
+    );
+  }
+}
+
+// ---------- message / part store ----------
+
+interface OpencodeMessageRow {
+  id: string;
+  time_created: number;
+  /** Scan position, used to break ties so equal timestamps still order
+   * deterministically instead of depending on sort stability. */
+  seq: number;
+  role: DialogueRole;
+}
+
+interface OpencodePartRow {
+  time_created: number;
+  seq: number;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Messages + parts grouped by session. Only the search path builds this for a
+ * whole database; extract / context populate it with one session's rows.
+ */
+interface OpencodeSessionStore {
+  messagesBySession: Map<string, OpencodeMessageRow[]>;
+  partsByMsg: Map<string, OpencodePartRow[]>;
+}
+
+function emptySessionStore(): OpencodeSessionStore {
+  return { messagesBySession: new Map(), partsByMsg: new Map() };
+}
+
+/** Scan position breaks ties so rows written in the same millisecond still
+ * order the same way on every run. */
+function byTimeThenScan(
+  a: { time_created: number; seq: number },
+  b: { time_created: number; seq: number },
+): number {
+  return a.time_created !== b.time_created
+    ? a.time_created - b.time_created
+    : a.seq - b.seq;
+}
+
+function buildSessionStore(
+  allMessages: readonly SqliteRow[],
+  allParts: readonly SqliteRow[],
+): OpencodeSessionStore {
+  const messagesBySession = new Map<string, OpencodeMessageRow[]>();
+  for (let i = 0; i < allMessages.length; i++) {
+    const row = allMessages[i];
+    if (!row) continue;
+    const sessionId = typeof row.session_id === "string" ? row.session_id : "";
+    const id = typeof row.id === "string" ? row.id : "";
+    if (!sessionId || !id) continue;
+    const data = parseDataJson(row.data) as OpencodeMessageData | null;
+    const role = parseDialogueRole(data?.role);
+    if (!role) continue;
+    const list = messagesBySession.get(sessionId) ?? [];
+    list.push({
+      id,
+      time_created: typeof row.time_created === "number" ? row.time_created : 0,
+      seq: i,
+      role,
+    });
+    messagesBySession.set(sessionId, list);
+  }
+
+  const partsByMsg = new Map<string, OpencodePartRow[]>();
+  for (let i = 0; i < allParts.length; i++) {
+    const row = allParts[i];
+    if (!row) continue;
+    const msgId = typeof row.message_id === "string" ? row.message_id : "";
+    if (!msgId) continue;
+    const data = parseDataJson(row.data);
+    if (!data) continue;
+    const list = partsByMsg.get(msgId) ?? [];
+    list.push({
+      time_created: typeof row.time_created === "number" ? row.time_created : 0,
+      seq: i,
+      data,
+    });
+    partsByMsg.set(msgId, list);
+  }
+
+  for (const list of messagesBySession.values()) list.sort(byTimeThenScan);
+  for (const list of partsByMsg.values()) list.sort(byTimeThenScan);
+
+  return { messagesBySession, partsByMsg };
+}
+
+/** Validate `message` / `part` and return the rows selected by `sessionId`, or
+ * every row when `sessionId` is undefined (the search store). */
+function scanMessagesAndParts(
+  db: ReadOnlyDb,
+  sessionId: string | undefined,
+): OpencodeSessionStore {
+  const messageTable = findTable(db, MESSAGE_TABLE);
+  requireColumns(messageTable, ["id", "session_id", "data"]);
+  const partTable = findTable(db, PART_TABLE);
+  requireColumns(partTable, ["message_id", "data"]);
+
+  const messages =
+    sessionId === undefined
+      ? db.scanTable(MESSAGE_TABLE)
+      : db.scanTable(MESSAGE_TABLE, (row) => row.session_id === sessionId);
+  requireRowColumns(messages, MESSAGE_TABLE, ["id", "session_id", "data"]);
+
+  let parts: SqliteRow[];
+  if (sessionId === undefined) {
+    parts = db.scanTable(PART_TABLE);
+  } else if (declaresColumn(partTable, "session_id")) {
+    // Current OpenCode denormalizes `session_id` onto `part`, so one session's
+    // parts can be selected without first materializing its message ids.
+    parts = db.scanTable(PART_TABLE, (row) => row.session_id === sessionId);
+  } else {
+    const messageIds = new Set(
+      messages
+        .map((row) => row.id)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    parts = db.scanTable(
+      PART_TABLE,
+      (row) =>
+        typeof row.message_id === "string" && messageIds.has(row.message_id),
+    );
+  }
+  requireRowColumns(parts, PART_TABLE, ["message_id", "data"]);
+
+  return buildSessionStore(messages, parts);
+}
+
+/** Search-scoped whole-db store, prepared and released by the orchestrator.
+ * One-session extract / context calls never populate it. */
+let preparedStore: { dbPath: string; store: OpencodeSessionStore } | null =
+  null;
+
+export function prepareOpencodeSessionStore(
+  dbPath: string,
+  warnings: MemWarning[] = [],
+): void {
+  let store = emptySessionStore();
+  if (fs.existsSync(dbPath)) {
+    try {
+      const db = openSqliteReadOnly(dbPath);
+      try {
+        store = scanMessagesAndParts(db, undefined);
+      } finally {
+        db.close();
+      }
+    } catch (error) {
+      if (!(error instanceof SqliteParseError)) throw error;
+      pushDbWarning(warnings, dbPath, error);
+      store = emptySessionStore();
+    }
+  }
+  preparedStore = { dbPath, store };
+}
+
+export function releaseOpencodeSessionStore(): void {
+  preparedStore = null;
+}
+
+/** Read one session's messages + parts, reusing the search-scoped store when
+ * the orchestrator prepared one for this same database. */
+function readSessionMessages(
+  dbPath: string,
+  sessionId: string,
+  warnings: MemWarning[],
+): {
+  messages: OpencodeMessageRow[];
+  partsByMsg: Map<string, OpencodePartRow[]>;
+} {
+  if (preparedStore?.dbPath === dbPath) {
+    return {
+      messages: preparedStore.store.messagesBySession.get(sessionId) ?? [],
+      partsByMsg: preparedStore.store.partsByMsg,
+    };
+  }
+  if (!fs.existsSync(dbPath)) return { messages: [], partsByMsg: new Map() };
+
+  let store: OpencodeSessionStore;
+  try {
+    const db = openSqliteReadOnly(dbPath);
+    try {
+      store = scanMessagesAndParts(db, sessionId);
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    if (!(error instanceof SqliteParseError)) throw error;
+    pushDbWarning(warnings, dbPath, error);
+    return { messages: [], partsByMsg: new Map() };
+  }
+  return {
+    messages: store.messagesBySession.get(sessionId) ?? [],
+    partsByMsg: store.partsByMsg,
+  };
+}
+
+// ---------- compaction ----------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCompactionSummaryPart(data: Record<string, unknown>): boolean {
+  return (
+    data.type === "compaction" &&
+    (typeof data.tail_start_id === "string" || isRecord(data.compactBoundary))
+  );
+}
+
+function compactionMarkerSummaryId(
+  data: Record<string, unknown>,
+): string | undefined {
+  return data.type === "compaction" &&
+    data.replace === true &&
+    typeof data.summaryMessageId === "string"
+    ? data.summaryMessageId
+    : undefined;
+}
+
+/**
+ * Identify the messages that carry a compaction summary. The compacted turns
+ * remain as rows in the same database, so they stay in the dialogue and the
+ * summary message is rendered as a boundary marker in place.
+ *
+ * The marker shape (`{type:"compaction", replace, summaryMessageId}` plus a
+ * summary part with `tail_start_id` / `compactBoundary`) is the one ZCode
+ * inherited from its OpenCode fork. If OpenCode never writes it, no message is
+ * classified as a summary and every turn reads as ordinary dialogue.
+ */
+function compactSummaryMessageIds(
+  messages: readonly OpencodeMessageRow[],
+  partsByMsg: Map<string, OpencodePartRow[]>,
+): Set<string> {
+  const summaryIds = new Set<string>();
+  const markerSummaryIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (markerSummaryIds.has(msg.id)) summaryIds.add(msg.id);
+    for (const part of partsByMsg.get(msg.id) ?? []) {
+      const markerSummaryId = compactionMarkerSummaryId(part.data);
+      if (markerSummaryId) markerSummaryIds.add(markerSummaryId);
+      if (isCompactionSummaryPart(part.data)) {
+        summaryIds.add(msg.id);
+        break;
+      }
+    }
+  }
+  return summaryIds;
+}
+
+/**
+ * One message becomes one turn: its `text` parts concatenated, then cleaned.
+ * `reasoning`, `tool`, `step-start` and `step-finish` parts are not dialogue
+ * and are skipped. Messages left with no text are dropped.
+ */
+function buildTextTurn(
+  msg: OpencodeMessageRow,
+  parts: readonly OpencodePartRow[],
+  compactSummaryIds: ReadonlySet<string>,
+): DialogueTurn | null {
+  const collected: string[] = [];
+  let totalRaw = 0;
+  for (const part of parts) {
+    const pd = part.data as OpencodePartData;
+    if (pd.type !== "text") continue;
+    const txt = typeof pd.text === "string" ? pd.text : "";
+    if (!txt) continue;
+    totalRaw += txt.length;
+    collected.push(stripInjectionTags(txt));
+  }
+  if (!collected.length) return null;
+
+  const merged = collected.join("\n\n");
+  if (compactSummaryIds.has(msg.id)) {
+    return compactionBoundaryTurn(
+      "context compacted here; the turns above are still in the OpenCode database",
+      merged,
+    );
+  }
+  if (isBootstrapTurn(merged, totalRaw)) return null;
+  return merged.trim() ? { role: msg.role, text: merged } : null;
+}
+
+// ---------- list ----------
+
+/** Largest absolute time value an ECMAScript Date can represent. */
+const MAX_TIME_VALUE = 8.64e15;
+
+function toIso(epochMs: unknown): string | undefined {
+  // A corrupt or hostile timestamp must degrade to "no timestamp", not throw
+  // RangeError out of the row loop and fail the whole command.
+  if (typeof epochMs !== "number" || !Number.isFinite(epochMs)) return undefined;
+  if (epochMs <= 0 || epochMs > MAX_TIME_VALUE) return undefined;
+  return new Date(epochMs).toISOString();
+}
+
+/**
+ * List OpenCode sessions from the `session` table only — listing never touches
+ * `message` or `part`. A machine with no OpenCode store lists nothing and
+ * warns about nothing.
+ */
+export function opencodeListSessions(
+  f: MemFilter,
+  warnings: MemWarning[] = [],
+): MemSessionInfo[] {
+  const dbPath = opencodeDbPath();
+  if (dbPath === undefined || !fs.existsSync(dbPath)) return [];
+
+  let rows: SqliteRow[];
+  let cwdColumn: string;
+  try {
+    const db = openSqliteReadOnly(dbPath);
+    try {
+      const table = findTable(db, SESSION_TABLE);
+      requireColumns(table, ["id", "time_created", "time_updated"]);
+      cwdColumn = requireOneOfColumns(table, SESSION_CWD_COLUMNS);
+      rows = db.scanTable(SESSION_TABLE);
+      requireRowColumns(rows, SESSION_TABLE, [
+        "id",
+        cwdColumn,
+        "time_created",
+        "time_updated",
+      ]);
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    if (!(error instanceof SqliteParseError)) throw error;
+    pushDbWarning(warnings, dbPath, error);
+    return [];
+  }
+
+  const out: MemSessionInfo[] = [];
+  for (const row of rows) {
+    const id = typeof row.id === "string" ? row.id : "";
+    if (!id) continue;
+
+    const directory =
+      typeof row[cwdColumn] === "string"
+        ? (row[cwdColumn] as string)
+        : undefined;
+    if (f.cwd && !sameProject(directory, f.cwd)) continue;
+
+    const created = toIso(row.time_created);
+    const updated = toIso(row.time_updated) ?? created;
+    if (!inRangeOverlap(created, updated, f)) continue;
+
+    out.push({
+      platform: "opencode",
+      id,
+      title: typeof row.title === "string" ? row.title : undefined,
+      cwd: directory,
+      created,
+      updated,
+      filePath: dbPath,
+      // Sub-agent sessions point at their dispatcher; `--include-children`
+      // merges them into the parent.
+      ...(typeof row.parent_id === "string" && row.parent_id
+        ? { parent_id: row.parent_id }
+        : {}),
+    });
+  }
+  return out;
+}
+
+// ---------- extract / search ----------
+
+export function opencodeExtractDialogue(
+  s: MemSessionInfo,
+  warnings: MemWarning[] = [],
+): DialogueTurn[] {
+  const { messages, partsByMsg } = readSessionMessages(
+    s.filePath,
+    s.id,
+    warnings,
+  );
+  const summaryIds = compactSummaryMessageIds(messages, partsByMsg);
+  const turns: DialogueTurn[] = [];
+  for (const msg of messages) {
+    const turn = buildTextTurn(msg, partsByMsg.get(msg.id) ?? [], summaryIds);
+    if (turn) turns.push(turn);
+  }
+  return turns;
+}
+
+export function opencodeSearch(
+  s: MemSessionInfo,
+  kw: string,
+  warnings: MemWarning[] = [],
+): SearchHit {
+  return searchInDialogue(opencodeExtractDialogue(s, warnings), kw);
 }

--- a/packages/core/src/mem/internal/paths.ts
+++ b/packages/core/src/mem/internal/paths.ts
@@ -21,6 +21,71 @@ export const ZCODE_DB = path.join(HOME, ".zcode", "cli", "db", "db.sqlite");
  * this adapter needs no database and adds no dependency. */
 export const GROK_SESSIONS = path.join(HOME, ".grok", "sessions");
 
+/**
+ * OpenCode's data root: `$XDG_DATA_HOME/opencode`, falling back to
+ * `~/.local/share/opencode`.
+ *
+ * OpenCode applies this XDG rule on every platform — it has no Windows
+ * `%LOCALAPPDATA%` or macOS `Application Support` branch — so a Windows install
+ * stores its database under `%USERPROFILE%\.local\share\opencode` unless
+ * `XDG_DATA_HOME` is set. Verified against the shipped 1.18 bundle:
+ * `XDG_DATA_HOME || join(homedir, ".local", "share")` then `join(that,
+ * "opencode")`.
+ *
+ * Read per call rather than at module load so a caller (or test) that sets
+ * `XDG_DATA_HOME` sees its own value.
+ */
+export function opencodeDataDir(): string {
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  if (xdg) return path.join(xdg, "opencode");
+  return path.join(HOME, ".local", "share", "opencode");
+}
+
+/**
+ * Resolve the OpenCode session database, or `undefined` when this machine has
+ * none (a normal empty result, not an error).
+ *
+ * Mirrors OpenCode's own resolution order:
+ *   1. `OPENCODE_DB` — absolute path used as-is, relative name joined to the
+ *      data dir, and `:memory:` meaning there is no file to read at all.
+ *   2. `<data>/opencode.db` — the release channels (`latest` / `beta` /
+ *      `prod`) and anyone setting `OPENCODE_DISABLE_CHANNEL_DB`.
+ *   3. `<data>/opencode-<channel>.db` — other channels write a suffixed file.
+ *      The channel is baked into the user's binary and is not discoverable
+ *      from here, so the most recently written one wins.
+ */
+export function opencodeDbPath(): string | undefined {
+  const dir = opencodeDataDir();
+  const override = process.env.OPENCODE_DB?.trim();
+  if (override) {
+    if (override === ":memory:") return undefined;
+    const expanded = expandHome(override);
+    return path.isAbsolute(expanded) ? expanded : path.join(dir, expanded);
+  }
+
+  const primary = path.join(dir, "opencode.db");
+  if (fs.existsSync(primary)) return primary;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  let newest: { file: string; mtimeMs: number } | undefined;
+  for (const entry of entries) {
+    if (!entry.isFile() || !/^opencode-.+\.db$/.test(entry.name)) continue;
+    const file = path.join(dir, entry.name);
+    try {
+      const { mtimeMs } = fs.statSync(file);
+      if (!newest || mtimeMs > newest.mtimeMs) newest = { file, mtimeMs };
+    } catch {
+      /* raced away between readdir and stat — skip it */
+    }
+  }
+  return newest?.file;
+}
+
 function expandHome(p: string): string {
   if (p === "~") return HOME;
   if (p.startsWith(`~${path.sep}`)) return path.join(HOME, p.slice(2));

--- a/packages/core/src/mem/sessions.ts
+++ b/packages/core/src/mem/sessions.ts
@@ -26,6 +26,8 @@ import {
   opencodeExtractDialogue,
   opencodeListSessions,
   opencodeSearch,
+  prepareOpencodeSessionStore,
+  releaseOpencodeSessionStore,
 } from "./adapters/opencode.js";
 import {
   collectPiTurnsAndEvents,
@@ -101,7 +103,7 @@ export function listAll(
   if (f.platform === "all" || f.platform === "grok")
     all.push(...grokListSessions(f));
   if (f.platform === "all" || f.platform === "opencode")
-    all.push(...opencodeListSessions(f));
+    all.push(...opencodeListSessions(f, warnings));
   if (f.platform === "all" || f.platform === "pi")
     all.push(...piListSessions(f));
   if (f.platform === "all" || f.platform === "zcode")
@@ -124,7 +126,7 @@ function extractDialogue(
     case "grok":
       return grokExtractDialogue(s, warnings);
     case "opencode":
-      return opencodeExtractDialogue(s);
+      return opencodeExtractDialogue(s, warnings);
     case "pi":
       return piExtractDialogue(s);
     case "zcode":
@@ -145,7 +147,7 @@ function searchSession(
     case "grok":
       return grokSearch(s, kw);
     case "opencode":
-      return opencodeSearch(kw);
+      return opencodeSearch(s, kw, warnings);
     case "pi":
       return piSearch(s, kw);
     case "zcode":
@@ -168,7 +170,7 @@ function collectTurnsAndEvents(
     case "grok":
       return collectGrokTurnsAndEvents(s, warnings);
     case "opencode":
-      return { turns: opencodeExtractDialogue(s), events: [] };
+      return { turns: opencodeExtractDialogue(s, warnings), events: [] };
     case "pi":
       return collectPiTurnsAndEvents(s);
     case "zcode":
@@ -354,6 +356,12 @@ export function searchMemSessions(
     prepareZcodeSessionStore(zcodeCandidate.filePath, warnings);
   }
   try {
+    const opencodeCandidate = candidates.find(
+      (s) => s.platform === "opencode",
+    );
+    if (opencodeCandidate) {
+      prepareOpencodeSessionStore(opencodeCandidate.filePath, warnings);
+    }
     for (const s of candidates) {
       if (isAbsorbedChild(s)) continue;
       const hit = includeChildren
@@ -369,6 +377,7 @@ export function searchMemSessions(
     }
   } finally {
     releaseZcodeSessionStore();
+    releaseOpencodeSessionStore();
   }
   matches.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;

--- a/packages/core/test/mem/adapters.test.ts
+++ b/packages/core/test/mem/adapters.test.ts
@@ -74,8 +74,15 @@ const {
   grokSearch,
   collectGrokTurnsAndEvents,
 } = await import("../../src/mem/adapters/grok.js");
-const { opencodeListSessions, opencodeExtractDialogue, opencodeSearch } =
-  await import("../../src/mem/adapters/opencode.js");
+const {
+  opencodeListSessions,
+  opencodeExtractDialogue,
+  opencodeSearch,
+  prepareOpencodeSessionStore,
+  releaseOpencodeSessionStore,
+} = await import("../../src/mem/adapters/opencode.js");
+const { opencodeDataDir, opencodeDbPath, HOME } =
+  await import("../../src/mem/internal/paths.js");
 const { piListSessions, piExtractDialogue, piSearch } =
   await import("../../src/mem/adapters/pi.js");
 const {
@@ -86,7 +93,7 @@ const {
 } = await import("../../src/mem/adapters/zcode.js");
 const { ZCODE_DB } = await import("../../src/mem/internal/paths.js");
 
-import type { MemFilter } from "../../src/mem/types.js";
+import type { MemFilter, MemSessionInfo } from "../../src/mem/types.js";
 
 /** Minimal global-scope filter; overrides merge in. */
 function mkFilter(overrides: Partial<MemFilter> = {}): MemFilter {
@@ -1359,41 +1366,15 @@ describe("piListSessions / piExtractDialogue", () => {
 });
 
 // =============================================================================
-// OpenCode adapter (degraded — silent no-op; the "unavailable" notice is a CLI
-// presentation concern, see packages/cli/src/commands/mem.ts).
-// =============================================================================
-
-describe("opencode adapter (degraded no-op)", () => {
-  it("opencodeListSessions returns []", () => {
-    expect(opencodeListSessions(mkFilter())).toEqual([]);
-  });
-
-  it("opencodeExtractDialogue returns [] for any session", () => {
-    expect(
-      opencodeExtractDialogue({
-        platform: "opencode",
-        id: "ses_x",
-        filePath: "/tmp/opencode.db",
-      }),
-    ).toEqual([]);
-  });
-
-  it("opencodeSearch returns an empty hit", () => {
-    const hit = opencodeSearch("anything");
-    expect(hit.count).toBe(0);
-    expect(hit.totalTurns).toBe(0);
-  });
-});
-
-// =============================================================================
-// ZCode adapter — reads from `~/.zcode/cli/db/db.sqlite` via the zero-dependency
-// SQLite parser. Fixtures are built with the system python sqlite3 module; the
-// whole block is skipped when no python interpreter is available so CI without
-// python does not regress.
+// OpenCode adapter — reads `$XDG_DATA_HOME/opencode/opencode.db` (default
+// `~/.local/share/opencode/`) through the zero-dependency SQLite parser.
+// Fixtures are built with the system python's sqlite3 stdlib module; the block
+// is skipped when no interpreter is available. No `sqlite3` binary and no
+// native addon may be required, here or at runtime.
 // =============================================================================
 
 /** Detect a python launcher with the sqlite3 stdlib module. */
-function findPythonForZcode(): string[] | null {
+function findPythonForSqlite(): string[] | null {
   const { execFileSync } =
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require("node:child_process") as typeof import("node:child_process");
@@ -1410,7 +1391,670 @@ function findPythonForZcode(): string[] | null {
   return null;
 }
 
-const ZCODE_PY = findPythonForZcode();
+const SQLITE_PY = findPythonForSqlite();
+
+/** Run a python program from a temp file (avoids `-c` quoting limits). */
+function runPython(script: string): void {
+  const pyCmd = SQLITE_PY?.[0];
+  if (!pyCmd) throw new Error("python unavailable");
+  const { execFileSync } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("node:child_process") as typeof import("node:child_process");
+  const pyDir = nodeFs.mkdtempSync(nodePath.join(fakeHome, "py-oc-"));
+  const pyFile = nodePath.join(pyDir, "fixture.py");
+  nodeFs.writeFileSync(pyFile, script);
+  try {
+    execFileSync(pyCmd, [pyFile], {
+      stdio: "ignore",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } finally {
+    nodeFs.rmSync(pyDir, { recursive: true, force: true });
+  }
+}
+
+const OPENCODE_DB = nodePath.join(
+  fakeHome,
+  ".local",
+  "share",
+  "opencode",
+  "opencode.db",
+);
+
+interface OpencodeFixture {
+  sessions?: {
+    id: string;
+    parent_id?: string | null;
+    title?: string;
+    directory?: string;
+    time_created?: number;
+    time_updated?: number;
+  }[];
+  messages?: {
+    id: string;
+    session_id: string;
+    time_created: number;
+    role: string;
+  }[];
+  parts?: {
+    message_id: string;
+    session_id?: string;
+    time_created: number;
+    data: Record<string, unknown>;
+    /** Raw text written verbatim into `part.data`, bypassing JSON encoding. */
+    rawData?: string;
+  }[];
+  /** Column name used for the session's workspace directory. */
+  cwdColumn?: string;
+  /** Omit `part.session_id` to exercise the older/narrower schema. */
+  omitPartSessionId?: boolean;
+  /** Commit these rows to the WAL only, leaving the main file behind. */
+  walSessions?: { id: string; title?: string; directory?: string }[];
+  dbPath?: string;
+}
+
+/** Build an OpenCode-shaped SQLite db. Columns mirror the live 1.18 store,
+ * narrowed to what the adapter reads. */
+function buildOpencodeDb(spec: OpencodeFixture): void {
+  const dbPath = spec.dbPath ?? OPENCODE_DB;
+  const cwdColumn = spec.cwdColumn ?? "directory";
+  nodeFs.mkdirSync(nodePath.dirname(dbPath), { recursive: true });
+  const partColumns = spec.omitPartSessionId
+    ? "id TEXT PRIMARY KEY, message_id TEXT, time_created INTEGER, data TEXT"
+    : "id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT";
+  const useWal = (spec.walSessions?.length ?? 0) > 0;
+  runPython(`
+import sqlite3, json, os
+db_path = ${JSON.stringify(dbPath)}
+for suffix in ("", "-wal", "-shm"):
+    if os.path.exists(db_path + suffix):
+        os.remove(db_path + suffix)
+db = sqlite3.connect(db_path)
+${useWal ? 'db.execute("PRAGMA journal_mode=WAL")\ndb.execute("PRAGMA wal_autocheckpoint=0")' : ""}
+db.execute("CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, ${cwdColumn} TEXT, time_created INTEGER, time_updated INTEGER)")
+db.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)")
+db.execute("CREATE TABLE part (${partColumns})")
+spec = json.loads(${JSON.stringify(JSON.stringify(spec))})
+message_sessions = {m["id"]: m["session_id"] for m in spec.get("messages", [])}
+for s in spec.get("sessions", []):
+    db.execute(
+        "INSERT INTO session (id,parent_id,title,${cwdColumn},time_created,time_updated) VALUES (?,?,?,?,?,?)",
+        (s["id"], s.get("parent_id"), s.get("title"), s.get("directory"),
+         s.get("time_created", 1000), s.get("time_updated", 2000)))
+for m in spec.get("messages", []):
+    db.execute(
+        "INSERT INTO message (id,session_id,time_created,time_updated,data) VALUES (?,?,?,?,?)",
+        (m["id"], m["session_id"], m["time_created"], m["time_created"],
+         json.dumps({"role": m["role"]})))
+for i, p in enumerate(spec.get("parts", [])):
+    data = p["rawData"] if "rawData" in p else json.dumps(p["data"])
+    if ${spec.omitPartSessionId ? "True" : "False"}:
+        db.execute("INSERT INTO part (id,message_id,time_created,data) VALUES (?,?,?,?)",
+                   (f"prt_{i}", p["message_id"], p["time_created"], data))
+    else:
+        session_id = p.get("session_id") or message_sessions.get(p["message_id"], "")
+        db.execute("INSERT INTO part (id,message_id,session_id,time_created,data) VALUES (?,?,?,?,?)",
+                   (f"prt_{i}", p["message_id"], session_id, p["time_created"], data))
+db.commit()
+for s in spec.get("walSessions", []):
+    db.execute(
+        "INSERT INTO session (id,parent_id,title,${cwdColumn},time_created,time_updated) VALUES (?,?,?,?,?,?)",
+        (s["id"], None, s.get("title"), s.get("directory"), 5000, 6000))
+db.commit()
+${
+  useWal
+    ? "# Skip db.close(): python checkpoints the WAL on close, which would fold\n# these rows into the main file and defeat the WAL-visibility assertion.\nos._exit(0)"
+    : "db.close()"
+}
+`);
+}
+
+function rimrafOpencodeDb(): void {
+  nodeFs.rmSync(nodePath.join(fakeHome, ".local"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+function ocSession(
+  id: string,
+  overrides: Partial<MemSessionInfo> = {},
+): MemSessionInfo {
+  return {
+    platform: "opencode",
+    id,
+    filePath: OPENCODE_DB,
+    ...overrides,
+  };
+}
+
+describe.skipIf(!SQLITE_PY)("opencode adapter", () => {
+  const savedEnv = {
+    XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+    OPENCODE_DB: process.env.OPENCODE_DB,
+  };
+
+  beforeEach(() => {
+    // The default data root must be `<home>/.local/share/opencode`; a stray
+    // XDG_DATA_HOME in the developer's shell would otherwise redirect it.
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.OPENCODE_DB;
+    rimrafOpencodeDb();
+  });
+
+  afterEach(() => {
+    releaseOpencodeSessionStore();
+    rimrafOpencodeDb();
+    if (savedEnv.XDG_DATA_HOME === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = savedEnv.XDG_DATA_HOME;
+    if (savedEnv.OPENCODE_DB === undefined) delete process.env.OPENCODE_DB;
+    else process.env.OPENCODE_DB = savedEnv.OPENCODE_DB;
+  });
+
+  // ---------- path resolution ----------
+
+  it("defaults the data dir to <home>/.local/share/opencode on every platform", () => {
+    expect(opencodeDataDir()).toBe(
+      nodePath.join(fakeHome, ".local", "share", "opencode"),
+    );
+  });
+
+  it("honours XDG_DATA_HOME", () => {
+    process.env.XDG_DATA_HOME = nodePath.join(fakeHome, "xdg-data");
+    expect(opencodeDataDir()).toBe(
+      nodePath.join(fakeHome, "xdg-data", "opencode"),
+    );
+  });
+
+  it("resolves nothing when this machine has no OpenCode store", () => {
+    expect(opencodeDbPath()).toBeUndefined();
+    const warnings: { code: string; message: string }[] = [];
+    expect(opencodeListSessions(mkFilter(), warnings)).toEqual([]);
+    // Missing storage is a normal empty result, not a degradation.
+    expect(warnings).toEqual([]);
+  });
+
+  it("resolves OPENCODE_DB as an absolute path, a relative name, or :memory:", () => {
+    const absolute = nodePath.join(fakeHome, "elsewhere", "custom.db");
+    process.env.OPENCODE_DB = absolute;
+    expect(opencodeDbPath()).toBe(absolute);
+
+    process.env.OPENCODE_DB = "custom.db";
+    expect(opencodeDbPath()).toBe(
+      nodePath.join(opencodeDataDir(), "custom.db"),
+    );
+
+    // `:memory:` is a real OpenCode setting; there is no file to read.
+    process.env.OPENCODE_DB = ":memory:";
+    expect(opencodeDbPath()).toBeUndefined();
+    expect(opencodeListSessions(mkFilter())).toEqual([]);
+
+    // `~/...` must expand like the other overrides in this file (Pi does),
+    // not be joined under the data dir as a literal relative name.
+    process.env.OPENCODE_DB = "~/elsewhere/custom.db";
+    expect(opencodeDbPath()).toBe(
+      nodePath.join(HOME, "elsewhere", "custom.db"),
+    );
+  });
+
+  it("falls back to the newest opencode-<channel>.db when opencode.db is absent", () => {
+    const dir = opencodeDataDir();
+    const channelDb = nodePath.join(dir, "opencode-dev.db");
+    buildOpencodeDb({
+      dbPath: channelDb,
+      sessions: [{ id: "ses_dev", directory: "/proj/dev" }],
+    });
+    expect(opencodeDbPath()).toBe(channelDb);
+    const rows = opencodeListSessions(mkFilter({ cwd: undefined }));
+    expect(rows.map((r) => r.id)).toEqual(["ses_dev"]);
+    expect(rows[0]?.filePath).toBe(channelDb);
+  });
+
+  // ---------- list ----------
+
+  it("lists sessions with id/title/cwd/timestamps/db path/parent link", () => {
+    buildOpencodeDb({
+      sessions: [
+        {
+          id: "ses_parent",
+          title: "parent chat",
+          directory: "/proj/a",
+          time_created: 1000,
+          time_updated: 2000,
+        },
+        {
+          id: "ses_child",
+          parent_id: "ses_parent",
+          title: "sub-agent run",
+          directory: "/proj/a",
+          time_created: 1500,
+          time_updated: 1800,
+        },
+      ],
+    });
+    const rows = opencodeListSessions(mkFilter({ cwd: undefined }));
+    expect(rows).toHaveLength(2);
+    const parent = rows.find((r) => r.id === "ses_parent");
+    expect(parent).toEqual({
+      platform: "opencode",
+      id: "ses_parent",
+      title: "parent chat",
+      cwd: "/proj/a",
+      created: new Date(1000).toISOString(),
+      updated: new Date(2000).toISOString(),
+      filePath: OPENCODE_DB,
+    });
+    // parent_id survives so `--include-children` can merge sub-agent chains.
+    expect(rows.find((r) => r.id === "ses_child")?.parent_id).toBe(
+      "ses_parent",
+    );
+  });
+
+  it("filters by --cwd and accepts `cwd` as a `directory` alternative", () => {
+    buildOpencodeDb({
+      cwdColumn: "cwd",
+      sessions: [
+        { id: "s1", directory: "/proj/a" },
+        { id: "s2", directory: "/proj/b" },
+      ],
+    });
+    expect(
+      opencodeListSessions(mkFilter({ cwd: "/proj/a" })).map((r) => r.id),
+    ).toEqual(["s1"]);
+  });
+
+  it("sees sessions committed only to the WAL", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "in_main", directory: "/proj/a" }],
+      walSessions: [{ id: "in_wal", directory: "/proj/a" }],
+    });
+    expect(nodeFs.existsSync(OPENCODE_DB + "-wal")).toBe(true);
+    const ids = opencodeListSessions(mkFilter({ cwd: undefined }))
+      .map((r) => r.id)
+      .sort();
+    expect(ids).toEqual(["in_main", "in_wal"]);
+  });
+
+  it("never writes to the database it reads", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/proj/a" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+      ],
+      parts: [
+        { message_id: "m1", time_created: 10, data: { type: "text", text: "hi" } },
+      ],
+    });
+    const before = nodeFs.readFileSync(OPENCODE_DB);
+    opencodeListSessions(mkFilter({ cwd: undefined }));
+    opencodeExtractDialogue(ocSession("s1"));
+    opencodeSearch(ocSession("s1"), "hi");
+    expect(nodeFs.readFileSync(OPENCODE_DB).equals(before)).toBe(true);
+  });
+
+  // ---------- extract ----------
+
+  it("extracts text parts only, dropping reasoning/tool/step markers", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m2", session_id: "s1", time_created: 20, role: "assistant" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "why is the hook failing" },
+        },
+        { message_id: "m2", time_created: 20, data: { type: "step-start" } },
+        {
+          message_id: "m2",
+          time_created: 21,
+          data: { type: "reasoning", text: "internal deliberation" },
+        },
+        {
+          message_id: "m2",
+          time_created: 22,
+          data: {
+            type: "tool",
+            tool: "bash",
+            state: { input: { command: "ls -F" }, output: "a\nb\n" },
+          },
+        },
+        {
+          message_id: "m2",
+          time_created: 23,
+          data: { type: "text", text: "the hook times out" },
+        },
+      ],
+    });
+    const turns = opencodeExtractDialogue(ocSession("s1"));
+    expect(turns).toEqual([
+      { role: "user", text: "why is the hook failing" },
+      { role: "assistant", text: "the hook times out" },
+    ]);
+  });
+
+  it("returns only the requested session's turns", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }, { id: "s2", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m2", session_id: "s2", time_created: 20, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "belongs to one" },
+        },
+        {
+          message_id: "m2",
+          time_created: 20,
+          data: { type: "text", text: "belongs to two" },
+        },
+      ],
+    });
+    expect(opencodeExtractDialogue(ocSession("s1")).map((t) => t.text)).toEqual(
+      ["belongs to one"],
+    );
+    expect(opencodeExtractDialogue(ocSession("s2")).map((t) => t.text)).toEqual(
+      ["belongs to two"],
+    );
+  });
+
+  it("selects one session's parts when `part.session_id` is absent", () => {
+    buildOpencodeDb({
+      omitPartSessionId: true,
+      sessions: [{ id: "s1", directory: "/p" }, { id: "s2", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m2", session_id: "s2", time_created: 20, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "narrow schema one" },
+        },
+        {
+          message_id: "m2",
+          time_created: 20,
+          data: { type: "text", text: "narrow schema two" },
+        },
+      ],
+    });
+    expect(opencodeExtractDialogue(ocSession("s1")).map((t) => t.text)).toEqual(
+      ["narrow schema one"],
+    );
+  });
+
+  it("orders turns by time and strips injection tags", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m_late", session_id: "s1", time_created: 30, role: "user" },
+        { id: "m_early", session_id: "s1", time_created: 10, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m_late",
+          time_created: 30,
+          data: { type: "text", text: "second" },
+        },
+        {
+          message_id: "m_early",
+          time_created: 10,
+          data: {
+            type: "text",
+            text: "first <system-reminder>hidden noise</system-reminder>",
+          },
+        },
+      ],
+    });
+    const turns = opencodeExtractDialogue(ocSession("s1"));
+    expect(turns.map((t) => t.text)).toEqual(["first", "second"]);
+  });
+
+  it("renders a compaction summary as a boundary marker and keeps the summarized turns", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m_old", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m_marker", session_id: "s1", time_created: 20, role: "assistant" },
+        { id: "m_summary", session_id: "s1", time_created: 30, role: "assistant" },
+        { id: "m_after", session_id: "s1", time_created: 40, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m_old",
+          time_created: 10,
+          data: { type: "text", text: "old-secret should survive" },
+        },
+        {
+          message_id: "m_marker",
+          time_created: 20,
+          data: {
+            type: "compaction",
+            replace: true,
+            summaryMessageId: "m_summary",
+          },
+        },
+        {
+          message_id: "m_summary",
+          time_created: 30,
+          data: { type: "text", text: "summary of earlier work" },
+        },
+        {
+          message_id: "m_summary",
+          time_created: 31,
+          data: { type: "compaction", tail_start_id: "m_old" },
+        },
+        {
+          message_id: "m_after",
+          time_created: 40,
+          data: { type: "text", text: "after compact" },
+        },
+      ],
+    });
+    const session = ocSession("s1");
+    const turns = opencodeExtractDialogue(session);
+    expect(turns).toHaveLength(3);
+    expect(turns[1]?.kind).toBe("marker");
+    expect(turns[1]?.text).toContain("[compaction boundary]");
+    expect(turns[1]?.text).toContain("summary of earlier work");
+    // The summarized rows are still in the database, so recall finds them and
+    // the marker stays out of the search denominator.
+    expect(opencodeSearch(session, "old-secret").count).toBe(1);
+    expect(opencodeSearch(session, "old-secret").totalTurns).toBe(2);
+  });
+
+  it("skips rows whose `data` JSON is malformed or hostile", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m2", session_id: "s1", time_created: 20, role: "user" },
+      ],
+      parts: [
+        { message_id: "m1", time_created: 10, data: {}, rawData: "{not json" },
+        {
+          message_id: "m1",
+          time_created: 11,
+          data: {},
+          rawData: '["array","not","object"]',
+        },
+        {
+          message_id: "m1",
+          time_created: 12,
+          data: {},
+          rawData: '{"__proto__": {"polluted": true}, "type": "text", "text": "still parsed"}',
+        },
+        {
+          message_id: "m2",
+          time_created: 20,
+          data: { type: "text", text: "healthy row" },
+        },
+      ],
+    });
+    const turns = opencodeExtractDialogue(ocSession("s1"));
+    expect(turns.map((t) => t.text)).toEqual(["still parsed", "healthy row"]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("degrades an out-of-range timestamp to no timestamp instead of throwing", () => {
+    // new Date(9e15).toISOString() throws RangeError; a hostile time_created
+    // must cost that session its timestamp, not fail the whole command.
+    buildOpencodeDb({
+      sessions: [
+        { id: "s_bad", directory: "/p", time_created: 9e15, time_updated: 9e15 },
+        { id: "s_ok", directory: "/p", time_created: 1000, time_updated: 2000 },
+      ],
+    });
+    const rows = opencodeListSessions(mkFilter({ cwd: undefined }));
+    expect(rows.map((r) => r.id).sort()).toEqual(["s_bad", "s_ok"]);
+    const bad = rows.find((r) => r.id === "s_bad");
+    expect(bad?.created).toBeUndefined();
+  });
+
+  it("search counts user/assistant occurrences", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+        { id: "m2", session_id: "s1", time_created: 20, role: "assistant" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "find the hook bug" },
+        },
+        {
+          message_id: "m2",
+          time_created: 20,
+          data: { type: "text", text: "the hook is here" },
+        },
+      ],
+    });
+    const hit = opencodeSearch(ocSession("s1"), "hook");
+    expect(hit.count).toBeGreaterThanOrEqual(2);
+    expect(hit.userCount).toBe(1);
+    expect(hit.asstCount).toBe(1);
+  });
+
+  it("serves sessions from a prepared search store and forgets it on release", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "stored once" },
+        },
+      ],
+    });
+    prepareOpencodeSessionStore(OPENCODE_DB);
+    // Deleting the file proves the prepared store, not a re-read, served this.
+    nodeFs.rmSync(OPENCODE_DB, { force: true });
+    expect(opencodeExtractDialogue(ocSession("s1")).map((t) => t.text)).toEqual(
+      ["stored once"],
+    );
+    releaseOpencodeSessionStore();
+    expect(opencodeExtractDialogue(ocSession("s1"))).toEqual([]);
+  });
+
+  // ---------- degradation ----------
+
+  it("warns once with opencode-db-unreadable when the file is not a database", () => {
+    nodeFs.mkdirSync(nodePath.dirname(OPENCODE_DB), { recursive: true });
+    nodeFs.writeFileSync(OPENCODE_DB, "not a sqlite file");
+    const warnings: { code: string; message: string }[] = [];
+    expect(opencodeListSessions(mkFilter({ cwd: undefined }), warnings)).toEqual(
+      [],
+    );
+    expect(opencodeExtractDialogue(ocSession("anything"), warnings)).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.code).toBe("opencode-db-unreadable");
+  });
+
+  it("warns with opencode-db-schema-unsupported when a required table is gone", () => {
+    buildOpencodeDb({ sessions: [{ id: "s1", directory: "/p" }] });
+    runPython(
+      `import sqlite3\ndb = sqlite3.connect(${JSON.stringify(OPENCODE_DB)})\ndb.execute("DROP TABLE session")\ndb.commit()\ndb.close()\n`,
+    );
+    const warnings: { code: string; message: string }[] = [];
+    expect(opencodeListSessions(mkFilter({ cwd: undefined }), warnings)).toEqual(
+      [],
+    );
+    expect(warnings[0]?.code).toBe("opencode-db-schema-unsupported");
+    expect(warnings[0]?.message).toContain("session");
+  });
+
+  it("warns with opencode-db-schema-unsupported when no known cwd column exists", () => {
+    buildOpencodeDb({
+      cwdColumn: "workspace_path",
+      sessions: [{ id: "s1", directory: "/p" }],
+    });
+    const warnings: { code: string; message: string }[] = [];
+    expect(opencodeListSessions(mkFilter({ cwd: undefined }), warnings)).toEqual(
+      [],
+    );
+    expect(warnings[0]?.code).toBe("opencode-db-schema-unsupported");
+    expect(warnings[0]?.message).toContain("directory / cwd");
+  });
+
+  it("fails closed with a retry warning when the snapshot stays unstable", () => {
+    buildOpencodeDb({ sessions: [{ id: "s1", directory: "/p" }] });
+    try {
+      snapshotTestState.unstablePath = OPENCODE_DB;
+      snapshotTestState.mainDbStatReads = 0;
+      const warnings: { code: string; message: string }[] = [];
+      expect(
+        opencodeListSessions(mkFilter({ cwd: undefined }), warnings),
+      ).toEqual([]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.code).toBe("opencode-db-snapshot-unstable");
+    } finally {
+      snapshotTestState.unstablePath = null;
+    }
+  });
+
+  it("returns nothing when the session's db path has been replaced", () => {
+    buildOpencodeDb({
+      sessions: [{ id: "s1", directory: "/p" }],
+      messages: [
+        { id: "m1", session_id: "s1", time_created: 10, role: "user" },
+      ],
+      parts: [
+        {
+          message_id: "m1",
+          time_created: 10,
+          data: { type: "text", text: "gone" },
+        },
+      ],
+    });
+    const stale = ocSession("s1", {
+      filePath: nodePath.join(fakeHome, "removed", "opencode.db"),
+    });
+    const warnings: { code: string; message: string }[] = [];
+    expect(opencodeExtractDialogue(stale, warnings)).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+});
+
+// =============================================================================
+// ZCode adapter — reads from `~/.zcode/cli/db/db.sqlite` via the zero-dependency
+// SQLite parser. Fixtures are built with the system python sqlite3 module; the
+// whole block is skipped when no python interpreter is available so CI without
+// python does not regress.
+// =============================================================================
+
+const ZCODE_PY = SQLITE_PY;
 
 /** Build a ZCode-shaped SQLite db at ZCODE_DB with session/message/part rows.
  * Columns are kept to the subset the adapter reads. */

--- a/packages/core/test/mem/api.test.ts
+++ b/packages/core/test/mem/api.test.ts
@@ -208,6 +208,162 @@ afterAll(() => {
   nodeFs.rmSync(fakeHome, { recursive: true, force: true });
 });
 
+// ---------- OpenCode sub-agent fixture ----------
+//
+// OpenCode is the only platform with a native `parent_id`, so the
+// `--include-children` merge can only be exercised end-to-end here. The
+// fixture is built with the system python's sqlite3 stdlib module and the
+// block skips when no interpreter is present.
+
+function findPythonForSqlite(): string | null {
+  const { execFileSync } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("node:child_process") as typeof import("node:child_process");
+  for (const cmd of process.platform === "win32"
+    ? ["py", "python"]
+    : ["python3", "python"]) {
+    try {
+      execFileSync(cmd, ["-c", "import sqlite3"], { stdio: "ignore" });
+      return cmd;
+    } catch {
+      /* next */
+    }
+  }
+  return null;
+}
+
+const SQLITE_PY = findPythonForSqlite();
+const OPENCODE_DB = nodePath.join(
+  fakeHome,
+  ".local",
+  "share",
+  "opencode",
+  "opencode.db",
+);
+
+/** One parent session plus one sub-agent child, each with a single user turn. */
+function seedOpencodeParentChild(): void {
+  if (!SQLITE_PY) throw new Error("python unavailable");
+  const { execFileSync } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("node:child_process") as typeof import("node:child_process");
+  nodeFs.mkdirSync(nodePath.dirname(OPENCODE_DB), { recursive: true });
+  const script = `
+import sqlite3, json, os
+db_path = ${JSON.stringify(OPENCODE_DB)}
+if os.path.exists(db_path):
+    os.remove(db_path)
+db = sqlite3.connect(db_path)
+db.execute("CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER)")
+db.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)")
+db.execute("CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)")
+cwd = json.loads(${JSON.stringify(JSON.stringify(projectCwd))})
+db.execute("INSERT INTO session VALUES ('ses_parent', NULL, 'parent', ?, 1000, 2000)", (cwd,))
+db.execute("INSERT INTO session VALUES ('ses_child', 'ses_parent', 'sub-agent', ?, 1100, 1900)", (cwd,))
+db.execute("INSERT INTO message VALUES ('m_parent', 'ses_parent', 1000, ?)", (json.dumps({"role": "user"}),))
+db.execute("INSERT INTO message VALUES ('m_child', 'ses_child', 1100, ?)", (json.dumps({"role": "user"}),))
+db.execute("INSERT INTO part VALUES ('p1', 'm_parent', 'ses_parent', 1000, ?)", (json.dumps({"type": "text", "text": "parent mentions orchards"}),))
+db.execute("INSERT INTO part VALUES ('p2', 'm_child', 'ses_child', 1100, ?)", (json.dumps({"type": "text", "text": "child found the marmalade recipe"}),))
+db.commit()
+db.close()
+`;
+  const pyDir = nodeFs.mkdtempSync(nodePath.join(fakeHome, "py-api-"));
+  const pyFile = nodePath.join(pyDir, "fixture.py");
+  nodeFs.writeFileSync(pyFile, script);
+  try {
+    execFileSync(SQLITE_PY, [pyFile], { stdio: "ignore" });
+  } finally {
+    nodeFs.rmSync(pyDir, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!SQLITE_PY)("OpenCode sub-agent merging", () => {
+  const savedXdg = process.env.XDG_DATA_HOME;
+  const savedDb = process.env.OPENCODE_DB;
+
+  beforeEach(() => {
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.OPENCODE_DB;
+    seedOpencodeParentChild();
+  });
+
+  afterEach(() => {
+    nodeFs.rmSync(nodePath.join(fakeHome, ".local"), {
+      recursive: true,
+      force: true,
+    });
+    if (savedXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = savedXdg;
+    if (savedDb === undefined) delete process.env.OPENCODE_DB;
+    else process.env.OPENCODE_DB = savedDb;
+  });
+
+  it("lists both sessions and exposes the parent link", () => {
+    const rows = listMemSessions({
+      filter: { platform: "opencode", cwd: projectCwd, limit: 50 },
+    });
+    expect(rows.map((s) => s.id).sort()).toEqual(["ses_child", "ses_parent"]);
+    expect(rows.find((s) => s.id === "ses_child")?.parent_id).toBe(
+      "ses_parent",
+    );
+  });
+
+  it("without --include-children, a child-only keyword matches the child alone", () => {
+    const result = searchMemSessions({
+      keyword: "marmalade",
+      filter: { platform: "opencode", cwd: projectCwd, limit: 50 },
+    });
+    expect(result.matches.map((m) => m.session.id)).toEqual(["ses_child"]);
+  });
+
+  it("with --include-children, the child's text is absorbed into the parent", () => {
+    const result = searchMemSessions({
+      keyword: "marmalade",
+      filter: { platform: "opencode", cwd: projectCwd, limit: 50 },
+      includeChildren: true,
+    });
+    expect(result.matches.map((m) => m.session.id)).toEqual(["ses_parent"]);
+    expect(result.matches[0]?.descendantsMerged).toBe(1);
+  });
+
+  it("readMemContext merges the child's turns when asked", () => {
+    const merged = readMemContext({
+      sessionId: "ses_parent",
+      filter: { platform: "opencode", cwd: projectCwd },
+      includeChildren: true,
+      turns: 10,
+    });
+    expect(merged.mergedChildren).toBe(1);
+    expect(merged.turns.map((t) => t.text)).toEqual([
+      "parent mentions orchards",
+      "child found the marmalade recipe",
+    ]);
+
+    const alone = readMemContext({
+      sessionId: "ses_parent",
+      filter: { platform: "opencode", cwd: projectCwd },
+      turns: 10,
+    });
+    expect(alone.turns.map((t) => t.text)).toEqual([
+      "parent mentions orchards",
+    ]);
+  });
+
+  it("extractMemDialogue warns but returns the full dialogue for --phase", () => {
+    const result = extractMemDialogue({
+      sessionId: "ses_parent",
+      filter: { platform: "opencode", cwd: projectCwd },
+      phase: "brainstorm",
+    });
+    expect(result.warnings.map((w) => w.code)).toEqual([
+      "opencode-phase-unsupported",
+    ]);
+    expect(result.turns.map((t) => t.text)).toEqual([
+      "parent mentions orchards",
+    ]);
+  });
+});
+
 describe("listMemSessions", () => {
   it("reports a structured warning when the ZCode database is corrupt", () => {
     nodeFs.mkdirSync(nodePath.dirname(ZCODE_DB), { recursive: true });


### PR DESCRIPTION
Slice **A** of the #534 resplit, per your landing order. Branched off current `main` (`64e66369`), not off the old branch.

## What this does

`packages/core/src/mem/adapters/opencode.ts` on `main` is still the 34-line silent no-op left behind by the `better-sqlite3` revert. This restores a real reader on the **zero-dependency read-only SQLite parser that already ships in core** (`internal/sqlite-readonly.ts` — unchanged here, and byte-identical between this branch and `main`, which is what makes the slice self-contained).

No native module, no WASM, no install-time build step, so the install-failure regression that forced the revert cannot return.

- name-matched schema validation — a future OpenCode layout change degrades to a structured warning instead of malformed rows
- WAL-consistent snapshots; the database is opened read-only and is byte-identical after a read
- `parent_id` child-session merging for `--include-children`

## Files (6)

| File | Why |
|---|---|
| `core/src/mem/adapters/opencode.ts` | the reader |
| `core/src/mem/internal/paths.ts` | `opencodeDbPath` |
| `core/src/mem/sessions.ts` | dispatch into the restored adapter |
| `core/test/mem/adapters.test.ts`, `core/test/mem/api.test.ts` | coverage |
| `cli/src/commands/mem.ts` | required, not optional: it removes the "OpenCode reader unavailable" notice, which becomes a false statement the moment the reader works. Warning presentation stays a CLI concern. |

## One deviation from your list, flagged for your call

You listed the `configurators/opencode.ts` docstring fix (`2d06433b`) as keep-able. **I left it out**, because its premise does not hold on `main`: upstream's `templates/opencode/package.json` still declares `@opencode-ai/plugin`, so the existing docstring is *accurate* there. The fork's "correction" describes the bare `{"type": "module"}` template produced by the pre-start-gate work — which you excluded from every slice. Applying it here would make the comment wrong. Say the word and I'll add it.

## Scope hygiene

None of the following appear in the diff: `.trellis/workspace/sven/`, task archives, `-sd.N` version identity (both packages stay at `0.6.15`), the marketplace gitlink move, Opus pinning, the pre-start gate.

## Testing

```
pnpm build   → ok
core         → Test Files 19 passed | Tests 371 passed, 1 skipped
cli          → Test Files 76 passed | Tests 1708 passed
```

Note for reviewers running locally: the marketplace submodule must be at this branch's recorded gitlink (`7310a50c`), or `trellis.test.ts > marketplace native workflow mirror` fails spuriously.

B–E follow in your stated order; #534 is being closed with links to the replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only support for browsing OpenCode sessions stored in SQLite databases.
  * Added session filtering by workspace and time range, dialogue extraction, compaction summaries, and keyword search.
  * Added support for parent and sub-agent sessions, including optional child-session merging.
  * Added automatic database discovery and support for configurable database locations.

* **Bug Fixes**
  * Improved handling of malformed data, unsupported schemas, unreadable databases, and unstable database files with user-facing warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->