### PR TITLE
feat(scripts): make add_session a resumable state machine

### DIFF
--- a/.trellis/scripts/add_session.py
+++ b/.trellis/scripts/add_session.py
@@ -15,6 +15,27 @@ Usage:
     # Structured content (repeatable; a section with no bullets is omitted):
     python3 add_session.py --title "Title" --change "Did X" --test "Ran Y" --next-step "Do Z"
 
+    # Commit evidence that cannot be resolved from the local object database
+    # (amended, not yet fetched) needs an explicit subject, one per OID:
+    python3 add_session.py --title "Title" --commit "abc1234" \
+        --commit-subject "abc1234=fix(cli): stop truncating the manifest"
+
+Commit evidence:
+    Every --commit token is a bounded hex OID (7-40 chars). Each one is
+    resolved to its real subject from the local object database BEFORE
+    anything is written. An OID that cannot be resolved fails the command
+    before the journal or index is touched — no placeholder prose is ever
+    recorded. Pass "-" (the default) for a planning session with no commits.
+
+Retry convergence:
+    The journal append, the index row and the optional auto-commit are one
+    resumable operation. Every entry carries a fingerprint marker derived from
+    its own inputs, so re-running an interrupted command repairs the pending
+    record instead of appending a second one, and a failed auto-commit exits
+    non-zero with the checkpoint to resume from. A record that is already
+    committed is never reused: an identical later request is a new session
+    unless an explicit --idempotency-key says otherwise.
+
 Branch resolution order:
     1. --branch CLI arg (explicit)
     2. task.json branch field (from active task, if still exists)
@@ -25,6 +46,8 @@ Branch resolution order:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import re
 import sys
 from datetime import datetime
@@ -40,7 +63,8 @@ from common.paths import (
     get_workspace_dir,
 )
 from common.developer import ensure_developer
-from common.git import run_git
+from common.git import branch_exists_locally, run_git
+from common.io import write_text_atomic
 from common.log import Colors, colored
 from common.safe_commit import (
     print_gitignore_warning,
@@ -58,6 +82,41 @@ from common.config import (
     resolve_package,
     validate_package,
 )
+
+
+# Bounded, argv-safe input shapes. Anything outside them is rejected during
+# preflight, before a single byte is written.
+COMMIT_TOKEN_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+MAX_SUBJECT_LEN = 500
+
+# Machine-readable record identity. An HTML comment renders as nothing, so the
+# human evidence in the entry is unchanged by its presence.
+MARKER_PREFIX = "<!-- trellis-session:"
+# Bumped when the fingerprint inputs change. Untagged markers are v1, whose
+# fingerprint mixed in the calendar date; see compute_record_fingerprint.
+MARKER_VERSION = 2
+LEGACY_MARKER_RE = re.compile(r"^<!-- trellis-session: fp=([0-9a-f]{16}) -->$")
+ENTRY_DATE_RE = re.compile(r"^\*\*Date\*\*: (\d{4}-\d{2}-\d{2})\s*$")
+SESSION_HEADING_RE = re.compile(r"^## Session (\d+):", re.MULTILINE)
+
+# Recording states, in the order the operation walks them.
+STATE_ABSENT = "absent"
+STATE_JOURNAL_RECORDED = "journal-recorded"
+STATE_INDEX_RECORDED = "index-recorded"
+STATE_COMMITTED = "committed"
+
+# Auto-commit outcomes.
+COMMIT_DONE = "committed"
+COMMIT_SKIPPED = "skipped"
+COMMIT_BLOCKED = "blocked"
+COMMIT_FAILED = "failed"
+
+# Git probes against other refs are best-effort; never let one hang a session.
+GIT_PROBE_TIMEOUT = 15.0
+# Upper bound on the refs folded into session numbering. A repo with hundreds
+# of stale branches must not turn session recording into a tree walk.
+MAX_CONVERGENCE_REFS = 100
 
 
 # =============================================================================
@@ -97,12 +156,23 @@ def get_current_session(index_file: Path) -> int:
         return 0
 
     content = index_file.read_text(encoding="utf-8")
+    return _max_session_in_index(content)
+
+
+def _max_session_in_index(content: str) -> int:
+    """Read the `Total Sessions` counter out of an index.md body."""
     for line in content.splitlines():
         if "Total Sessions" in line:
             match = re.search(r":\s*(\d+)", line)
             if match:
                 return int(match.group(1))
     return 0
+
+
+def _max_session_in_journal(content: str) -> int:
+    """Highest `## Session N:` heading in a journal body (0 when none)."""
+    numbers = [int(m.group(1)) for m in SESSION_HEADING_RE.finditer(content)]
+    return max(numbers) if numbers else 0
 
 
 def _extract_journal_num(filename: str) -> int:
@@ -226,8 +296,8 @@ def warn_if_parallel_worktree(repo_root: Path) -> None:
 
 def create_new_journal_file(
     dev_dir: Path, num: int, developer: str, today: str, max_lines: int = 2000,
-) -> Path:
-    """Create a new journal file."""
+) -> Path | None:
+    """Create a new journal file. Returns None when the write fails."""
     prev_num = num - 1
     new_file = dev_dir / f"{FILE_JOURNAL_PREFIX}{num}.md"
 
@@ -239,9 +309,564 @@ def create_new_journal_file(
 ---
 
 """
-    new_file.write_text(content, encoding="utf-8")
+    if not write_text_atomic(new_file, content):
+        return None
     return new_file
 
+
+# =============================================================================
+# Commit evidence (R1) — accurate subjects or nothing
+# =============================================================================
+
+def parse_commit_tokens(commit: str) -> tuple[list[str], str | None]:
+    """Split --commit into bounded hex OIDs. Returns (tokens, error)."""
+    raw = (commit or "").strip()
+    if not raw or raw == "-":
+        return [], None
+
+    tokens: list[str] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if not COMMIT_TOKEN_RE.match(token):
+            return [], (
+                f"invalid --commit token '{token}': expected a 7-40 character hex "
+                "commit OID, or '-' for a planning session with no commits"
+            )
+        token = token.lower()
+        if token not in tokens:
+            tokens.append(token)
+    return tokens, None
+
+
+def parse_subject_overrides(values: list[str] | None) -> tuple[dict[str, str], str | None]:
+    """Parse `--commit-subject <oid>=<subject>` into a one-to-one mapping."""
+    overrides: dict[str, str] = {}
+    for raw in values or []:
+        if "=" not in raw:
+            return {}, (
+                f"invalid --commit-subject '{raw}': expected <oid>=<subject>"
+            )
+        oid_part, subject = raw.split("=", 1)
+        oid = oid_part.strip().lower()
+        subject = subject.strip()
+        if not COMMIT_TOKEN_RE.match(oid):
+            return {}, (
+                f"invalid --commit-subject key '{oid_part.strip()}': expected a "
+                "7-40 character hex commit OID"
+            )
+        if not subject:
+            return {}, f"invalid --commit-subject for '{oid}': subject is empty"
+        if len(subject) > MAX_SUBJECT_LEN:
+            return {}, (
+                f"invalid --commit-subject for '{oid}': subject exceeds "
+                f"{MAX_SUBJECT_LEN} characters"
+            )
+        if oid in overrides:
+            return {}, f"duplicate --commit-subject mapping for '{oid}'"
+        overrides[oid] = subject
+    return overrides, None
+
+
+def resolve_commit_subject(repo_root: Path, oid: str) -> str | None:
+    """Resolve one OID to its subject from the local object database.
+
+    Passed as argv (never interpolated into a shell) and peeled with
+    ``^{commit}`` so a hex-looking ref name cannot resolve to a tree or tag.
+    Returns None when the object is missing, ambiguous, or has no subject.
+    """
+    rc, out, _ = run_git(
+        ["show", "-s", "--format=%s", f"{oid}^{{commit}}", "--"], cwd=repo_root
+    )
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        subject = line.strip()
+        if subject:
+            return subject[:MAX_SUBJECT_LEN]
+    return None
+
+
+def build_commit_evidence(
+    repo_root: Path,
+    tokens: list[str],
+    overrides: dict[str, str],
+) -> tuple[list[tuple[str, str]], str | None]:
+    """Pair every commit OID with an accurate subject, or fail.
+
+    There is no placeholder path: an OID that neither resolves locally nor
+    carries an explicit mapping stops the command before any mutation.
+    """
+    evidence: list[tuple[str, str]] = []
+    unresolved: list[str] = []
+
+    for oid in tokens:
+        if oid in overrides:
+            evidence.append((oid, overrides[oid]))
+            continue
+        subject = resolve_commit_subject(repo_root, oid)
+        if subject is None:
+            unresolved.append(oid)
+            continue
+        evidence.append((oid, subject))
+
+    if unresolved:
+        return [], (
+            "cannot resolve commit evidence for: "
+            + ", ".join(unresolved)
+            + ". Fetch the objects, correct the OID, or pass the exact subject "
+            "with --commit-subject <oid>=<subject>. Nothing was written."
+        )
+
+    unused = sorted(oid for oid in overrides if oid not in tokens)
+    if unused:
+        return [], (
+            "--commit-subject supplied for OIDs that are not in --commit: "
+            + ", ".join(unused)
+            + ". The mapping must be one-to-one. Nothing was written."
+        )
+
+    return evidence, None
+
+
+def escape_markdown_cell(text: str) -> str:
+    """Make a commit subject safe inside a Markdown table cell."""
+    collapsed = " ".join(text.split())
+    return collapsed.replace("\\", "\\\\").replace("|", "\\|")
+
+
+# =============================================================================
+# Record identity (R2)
+# =============================================================================
+
+def _normalize_text(value: str | None) -> str:
+    return " ".join((value or "").split())
+
+
+def _fingerprint_payload(
+    developer: str,
+    title: str,
+    summary: str,
+    package: str | None,
+    branch: str | None,
+    evidence: list[tuple[str, str]],
+    changes: list[str] | None,
+    extra_content: str | None,
+    tests: list[str] | None,
+    next_steps: list[str] | None,
+    idempotency_key: str | None,
+) -> dict:
+    """Normalized semantic inputs of one record, shared by both schemes."""
+    return {
+        "developer": developer,
+        "title": _normalize_text(title),
+        "summary": _normalize_text(summary),
+        "package": package or "",
+        "branch": branch or "",
+        "commits": [[oid, _normalize_text(subject)] for oid, subject in evidence],
+        "changes": [_normalize_text(c) for c in changes or []],
+        "extra": _normalize_text(extra_content),
+        "tests": [_normalize_text(t) for t in tests or []],
+        "next_steps": [_normalize_text(n) for n in next_steps or []],
+        "idempotency_key": idempotency_key or "",
+    }
+
+
+def _hash_payload(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def compute_record_fingerprint(payload: dict) -> str:
+    """Bounded fingerprint over the normalized semantic inputs of one record.
+
+    This is the retry key while the record is still pending in the worktree —
+    not a global dedupe key. Two genuinely separate sessions with identical
+    prose differ only if the caller says so, which is why an already-committed
+    match is never adopted (see classify_record).
+
+    Deliberately date-free (v2). v1 mixed in the calendar date, which made a
+    record unfindable by its own retry across a midnight rollover: the journal
+    and index were already written, the commit had failed, and the recomputed
+    fingerprint no longer matched the marker sitting in the journal, so the
+    retry appended a second entry for one session.
+
+    Dropping the date cannot over-collapse two same-day sessions, because the
+    date was equal for both of them anyway. Across days it only ever separated
+    records with byte-identical prose, commits, branch and package — and a
+    *committed* record of that shape is already refused for reuse by
+    cmd_add_session, which maps STATE_COMMITTED to STATE_ABSENT. What is left
+    is exactly the question this key should answer: is there an uncommitted
+    record in this worktree matching these inputs?
+    """
+    return _hash_payload(payload)
+
+
+def compute_legacy_fingerprint(payload: dict, date: str) -> str:
+    """The v1 fingerprint, for resolving markers written before the change.
+
+    Lookup only — nothing writes this scheme any more.
+    """
+    return _hash_payload({**payload, "date": date})
+
+
+def render_marker(fingerprint: str) -> str:
+    """Machine-readable record marker; renders as nothing in Markdown."""
+    return f"{MARKER_PREFIX} v={MARKER_VERSION} fp={fingerprint} -->"
+
+
+def render_legacy_marker(fingerprint: str) -> str:
+    """The v1 marker form: no version tag. Read, never written."""
+    return f"{MARKER_PREFIX} fp={fingerprint} -->"
+
+
+# =============================================================================
+# Session numbering (collision-proof across concurrent branches)
+# =============================================================================
+
+def _repo_relative(repo_root: Path, path: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _default_branch_local(repo_root: Path) -> str | None:
+    """Resolve the default branch without ever touching the network.
+
+    `resolve_default_branch()` falls back to `git remote show origin`, which
+    can block on a fetch. Session recording is a hot path, so it stops at the
+    local symbolic ref and the two conventional names.
+    """
+    rc, out, _ = run_git(
+        ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+        cwd=repo_root,
+        timeout=GIT_PROBE_TIMEOUT,
+    )
+    if rc == 0 and out.strip():
+        return out.strip().rsplit("/", 1)[-1]
+    for candidate in ("main", "master"):
+        if branch_exists_locally(candidate, repo_root):
+            return candidate
+    return None
+
+
+def _convergence_refs(repo_root: Path) -> list[str]:
+    """Refs whose recorded workspace state must be folded into the counter.
+
+    Ordered by how much they matter, then capped: HEAD and the default branch
+    first (the merge target every branch eventually meets), then every other
+    local head — a parallel worktree's branch lives there and is the case that
+    actually collided — then remote-tracking refs.
+    """
+    refs: list[str] = []
+
+    def add(ref: str) -> None:
+        if ref not in refs:
+            refs.append(ref)
+
+    rc, _, _ = run_git(["rev-parse", "--verify", "--quiet", "HEAD"], cwd=repo_root)
+    if rc == 0:
+        add("HEAD")
+
+    default = _default_branch_local(repo_root)
+    if default:
+        for ref in (f"refs/heads/{default}", f"refs/remotes/origin/{default}"):
+            rc, _, _ = run_git(
+                ["show-ref", "--verify", "--quiet", ref], cwd=repo_root
+            )
+            if rc == 0:
+                add(ref)
+
+    for pattern in ("refs/heads/", "refs/remotes/"):
+        rc, out, _ = run_git(
+            ["for-each-ref", "--format=%(refname)", pattern],
+            cwd=repo_root,
+            timeout=GIT_PROBE_TIMEOUT,
+        )
+        if rc != 0:
+            continue
+        for line in out.splitlines():
+            ref = line.strip()
+            # A symbolic ref like refs/remotes/origin/HEAD is a duplicate of
+            # the branch it points at and git grep rejects some of them.
+            if ref and not ref.endswith("/HEAD"):
+                add(ref)
+
+    return refs[:MAX_CONVERGENCE_REFS]
+
+
+def _max_session_across_refs(repo_root: Path, refs: list[str], dev_rel: str) -> int:
+    """Highest session number recorded under `dev_rel` in any of `refs`.
+
+    One `git grep` over every ref rather than an ls-tree + show per ref: the
+    number of branches in a real repo is unbounded, the per-ref cost is not.
+    Exit status 1 (no match) is a normal outcome, not an error.
+    """
+    if not refs:
+        return 0
+
+    rc, out, _ = run_git(
+        [
+            "grep",
+            "--no-color",
+            "-h",
+            "-E",
+            "-e",
+            r"^## Session [0-9]+:",
+            "-e",
+            r"Total Sessions",
+        ]
+        + refs
+        + ["--", dev_rel],
+        cwd=repo_root,
+        timeout=GIT_PROBE_TIMEOUT,
+    )
+    if rc > 1 or not out:
+        return 0
+
+    # `git grep` prefixes each hit with `<rev>:<path>:`, so the numbers are
+    # matched anywhere in the line rather than anchored.
+    numbers = [int(m.group(1)) for m in re.finditer(r"## Session (\d+):", out)]
+    numbers += [
+        int(m.group(1)) for m in re.finditer(r"Total Sessions[^\d]{0,8}(\d+)", out)
+    ]
+    return max(numbers) if numbers else 0
+
+
+def max_local_session(dev_dir: Path, index_file: Path) -> int:
+    """Highest session number visible in the working tree."""
+    highest = get_current_session(index_file)
+    for f in dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md"):
+        if not f.is_file():
+            continue
+        try:
+            content = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        highest = max(highest, _max_session_in_journal(content))
+    return highest
+
+
+def resolve_next_session(repo_root: Path, dev_dir: Path, index_file: Path) -> int:
+    """Next session number, converged across the local tree and other branches.
+
+    Deriving the number from the working tree alone lets two branches that
+    each record before merging claim the same number (observed twice on
+    2026-08-06). Taking the union with every recorded ref — the default
+    branch, and the other local heads a parallel worktree records on — makes
+    the number monotonic across concurrent branches; `journal-*.md`
+    merge=union then keeps both entries when the branches meet.
+    """
+    highest = max_local_session(dev_dir, index_file)
+
+    dev_rel = _repo_relative(repo_root, dev_dir)
+    if dev_rel:
+        highest = max(
+            highest,
+            _max_session_across_refs(
+                repo_root, _convergence_refs(repo_root), dev_rel
+            ),
+        )
+
+    return highest + 1
+
+
+# =============================================================================
+# Pending-record classifier (R3/R4)
+# =============================================================================
+
+def find_marker_entries(dev_dir: Path, marker: str) -> list[tuple[Path, int | None]]:
+    """Locate every journal entry carrying `marker`.
+
+    Returns (journal_file, session_number); the number is None when the marker
+    is not directly under a `## Session N:` heading, which is malformed
+    pending evidence and must never be guessed into completion.
+    """
+    hits: list[tuple[Path, int | None]] = []
+    for f in sorted(dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md")):
+        if not f.is_file():
+            continue
+        try:
+            lines = f.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            if line.strip() != marker:
+                continue
+            session_num: int | None = None
+            for j in range(i - 1, max(-1, i - 4), -1):
+                match = SESSION_HEADING_RE.match(lines[j])
+                if match:
+                    session_num = int(match.group(1))
+                    break
+            hits.append((f, session_num))
+    return hits
+
+
+def content_at_head(repo_root: Path, path: Path) -> str | None:
+    """File content as committed at HEAD, or None when it isn't there.
+
+    The `./` prefix makes the path cwd-relative. `HEAD:<path>` alone is
+    relative to the *git* toplevel, which is not always `repo_root` — the
+    Trellis root is the nearest directory holding `.trellis/`, which can sit
+    below the git root. Without it, every lookup in that layout fails and a
+    committed record looks pending.
+    """
+    rel = _repo_relative(repo_root, path)
+    if not rel:
+        return None
+    rc, out, _ = run_git(["show", f"HEAD:./{rel}"], cwd=repo_root)
+    return out if rc == 0 else None
+
+
+def index_has_session_row(index_file: Path, session_num: int) -> bool:
+    """Whether the session-history block already holds this session's row."""
+    if not index_file.is_file():
+        return False
+    try:
+        lines = index_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+
+    row_re = re.compile(r"^\|\s*%d\s*\|" % session_num)
+    in_history = False
+    for line in lines:
+        if "@@@auto:session-history" in line:
+            in_history = True
+            continue
+        if "@@@/auto:session-history" in line:
+            in_history = False
+            continue
+        if in_history and row_re.match(line):
+            return True
+    return False
+
+
+def _entry_date_at(lines: list[str], marker_index: int) -> str | None:
+    """The `**Date**:` value belonging to the entry whose marker is at `marker_index`.
+
+    `generate_session_content` renders it two lines below the marker. Scanning
+    a short window rather than a fixed offset keeps this working if blank-line
+    spacing around the header ever changes, and stops well before it could
+    reach the next entry.
+    """
+    for line in lines[marker_index + 1:marker_index + 6]:
+        match = ENTRY_DATE_RE.match(line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def resolve_effective_marker(
+    dev_dir: Path,
+    payload: dict,
+    marker: str,
+) -> tuple[str, str | None]:
+    """The marker this record actually carries, across both schemes.
+
+    Returns (marker, error). The v2 marker wins whenever an entry carries it,
+    which is every record written since the change and costs one scan.
+
+    Otherwise this looks for a pending record written under v1. Those markers
+    are only a hash, but the entry renders its own `**Date**:` line right
+    below, so the date that produced the v1 fingerprint is recoverable from
+    the entry itself: recompute with that date and compare against what is
+    actually written there. That is exact, and unlike a +/-1 day window it does
+    not quietly fail a retry resumed after a weekend.
+
+    Returning the v1 marker leaves the entry untouched — it is an in-flight
+    record about to be committed, and rewriting its marker mid-repair would
+    move it to a state the machine does not model.
+    """
+    if find_marker_entries(dev_dir, marker):
+        return marker, None
+
+    matches: set[str] = set()
+    for journal in sorted(dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md")):
+        if not journal.is_file():
+            continue
+        try:
+            lines = journal.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            legacy = LEGACY_MARKER_RE.match(line.strip())
+            if not legacy:
+                continue
+            date = _entry_date_at(lines, i)
+            if date is None:
+                continue
+            if compute_legacy_fingerprint(payload, date) == legacy.group(1):
+                matches.add(line.strip())
+
+    if len(matches) > 1:
+        return "", (
+            f"found {len(matches)} pending journal entries matching this record "
+            "under the pre-versioning marker scheme. Refusing to guess which one "
+            "to resume — remove the duplicate entry or pass --idempotency-key to "
+            "record a new session."
+        )
+    if matches:
+        return matches.pop(), None
+    return marker, None
+
+
+def classify_record(
+    repo_root: Path,
+    dev_dir: Path,
+    index_file: Path,
+    marker: str,
+) -> tuple[str, Path | None, int | None, str | None]:
+    """Classify the current state of this exact record.
+
+    Returns (state, journal_file, session_num, error). Only a unique, exact,
+    still-uncommitted match is ever adopted; anything ambiguous, malformed or
+    partially written comes back as an error so the caller fails safely.
+    """
+    hits = find_marker_entries(dev_dir, marker)
+
+    if not hits:
+        return STATE_ABSENT, None, None, None
+
+    if len(hits) > 1:
+        files = ", ".join(sorted({p.name for p, _ in hits}))
+        return "", None, None, (
+            f"found {len(hits)} journal entries carrying this record's marker "
+            f"({files}). Refusing to guess which one to resume — remove the "
+            "duplicate entry or pass --idempotency-key to record a new session."
+        )
+
+    journal_file, session_num = hits[0]
+    if session_num is None:
+        return "", None, None, (
+            f"{journal_file.name} carries this record's marker without a "
+            "'## Session N:' heading above it. The pending record is malformed; "
+            "repair it by hand before retrying."
+        )
+
+    head_content = content_at_head(repo_root, journal_file)
+    if head_content is not None and marker in head_content:
+        return STATE_COMMITTED, journal_file, session_num, None
+
+    if index_has_session_row(index_file, session_num):
+        return STATE_INDEX_RECORDED, journal_file, session_num, None
+
+    recorded_total = get_current_session(index_file)
+    if recorded_total > session_num:
+        return "", None, None, (
+            f"journal entry for session {session_num} has no index row, but "
+            f"index.md already counts {recorded_total} sessions. Repairing the "
+            "row would rewrite a later record — resolve index.md by hand."
+        )
+
+    return STATE_JOURNAL_RECORDED, journal_file, session_num, None
+
+
+# =============================================================================
+# Rendering
+# =============================================================================
 
 def _render_bullet_section(header: str, items: list[str], bullet_prefix: str = "- ") -> str:
     """Render a Markdown section as bullets, or "" when there is no content.
@@ -267,9 +892,10 @@ def _render_main_changes(changes: list[str], extra_content: str | None) -> str:
 def generate_session_content(
     session_num: int,
     title: str,
-    commit: str,
+    evidence: list[tuple[str, str]],
     summary: str,
     today: str,
+    marker: str,
     package: str | None = None,
     branch: str | None = None,
     changes: list[str] | None = None,
@@ -278,12 +904,11 @@ def generate_session_content(
     next_steps: list[str] | None = None,
 ) -> str:
     """Generate session content."""
-    if commit and commit != "-":
+    if evidence:
         commit_table = """| Hash | Message |
 |------|---------|"""
-        for c in commit.split(","):
-            c = c.strip()
-            commit_table += f"\n| `{c}` | (see git log) |"
+        for oid, subject in evidence:
+            commit_table += f"\n| `{oid}` | {escape_markdown_cell(subject)} |"
     else:
         commit_table = "(No commits - planning session)"
 
@@ -297,6 +922,7 @@ def generate_session_content(
     return f"""
 
 ## Session {session_num}: {title}
+{marker}
 
 **Date**: {today}
 **Task**: {title}{package_line}{branch_line}
@@ -315,21 +941,25 @@ def generate_session_content(
 """
 
 
+def format_commit_display(evidence: list[tuple[str, str]]) -> str:
+    """Index-table rendering of the commit OIDs."""
+    if not evidence:
+        return "-"
+    return ", ".join(f"`{oid}`" for oid, _ in evidence)
+
+
 def update_index(
     index_file: Path,
     dev_dir: Path,
     title: str,
-    commit: str,
+    evidence: list[tuple[str, str]],
     new_session: int,
     active_file: str,
     today: str,
     branch: str | None = None,
 ) -> bool:
     """Update index.md with new session info."""
-    # Format commit for display
-    commit_display = "-"
-    if commit and commit != "-":
-        commit_display = re.sub(r"([a-f0-9]{7,})", r"`\1`", commit.replace(",", ", "))
+    commit_display = format_commit_display(evidence)
 
     # Get file number from active_file name
     match = re.search(r"(\d+)", active_file)
@@ -425,7 +1055,9 @@ def update_index(
 
         new_lines.append(line)
 
-    index_file.write_text("\n".join(new_lines), encoding="utf-8")
+    if not write_text_atomic(index_file, "\n".join(new_lines)):
+        print(f"Error: failed to write {index_file}", file=sys.stderr)
+        return False
     print("[OK] Updated index.md successfully!")
     return True
 
@@ -434,7 +1066,7 @@ def update_index(
 # Main Function
 # =============================================================================
 
-def _auto_commit_workspace(repo_root: Path) -> None:
+def _auto_commit_workspace(repo_root: Path) -> str:
     """Stage Trellis-owned workspace + current-task paths and commit.
 
     Path scope is restricted to specific products: the current developer's
@@ -447,13 +1079,30 @@ def _auto_commit_workspace(repo_root: Path) -> None:
     Honors ``session_auto_commit`` in ``.trellis/config.yaml``: when set to
     ``false``, this function returns immediately without touching git
     (journal/index files are still written to disk by the caller).
+
+    Returns one of ``COMMIT_DONE`` / ``COMMIT_SKIPPED`` / ``COMMIT_BLOCKED`` /
+    ``COMMIT_FAILED``. ``COMMIT_BLOCKED`` is the gitignored-`.trellis/` case:
+    the user has told git to stay out of this tree, so it is a configured skip
+    like ``session_auto_commit: false``, not a failure to retry.
     """
     if not get_session_auto_commit(repo_root):
         print(
             "[OK] session_auto_commit: false — skipping git stage/commit.",
             file=sys.stderr,
         )
-        return
+        return COMMIT_SKIPPED
+
+    # Not a git repository at all: like the gitignored case, this is an
+    # environment the user configured, not a transient git error — a retry
+    # can never succeed, so it must not be COMMIT_FAILED's exit-1 loop.
+    rc, _, _ = run_git(["rev-parse", "--is-inside-work-tree"], cwd=repo_root)
+    if rc != 0:
+        print(
+            "[WARN] Not a git repository — journal/index written, "
+            "skipping auto-commit.",
+            file=sys.stderr,
+        )
+        return COMMIT_BLOCKED
 
     commit_msg = get_session_commit_message(repo_root)
     # Resolve the current task so staging is scoped to its dir only. The ref
@@ -475,18 +1124,18 @@ def _auto_commit_workspace(repo_root: Path) -> None:
         ]
     if not paths:
         print("[OK] No workspace changes to commit.", file=sys.stderr)
-        return
+        return COMMIT_SKIPPED
 
     success, _, err = safe_git_add(paths, repo_root)
     if not success:
         if err and "ignored by" in err.lower():
             print_gitignore_warning(paths)
-        else:
-            print(
-                f"[WARN] git add failed: {err.strip() if err else 'unknown error'}",
-                file=sys.stderr,
-            )
-        return
+            return COMMIT_BLOCKED
+        print(
+            f"[WARN] git add failed: {err.strip() if err else 'unknown error'}",
+            file=sys.stderr,
+        )
+        return COMMIT_FAILED
 
     # Check if there are staged changes for the paths we just staged.
     rc, _, _ = run_git(
@@ -494,16 +1143,39 @@ def _auto_commit_workspace(repo_root: Path) -> None:
     )
     if rc == 0:
         print("[OK] No workspace changes to commit.", file=sys.stderr)
-        return
+        return COMMIT_SKIPPED
 
     rc, _, commit_err = run_git(["commit", "-m", commit_msg], cwd=repo_root)
     if rc == 0:
         print(f"[OK] Auto-committed: {commit_msg}", file=sys.stderr)
-    else:
-        print(
-            f"[WARN] Auto-commit failed: {commit_err.strip()}",
-            file=sys.stderr,
-        )
+        return COMMIT_DONE
+
+    print(
+        f"[WARN] Auto-commit failed: {commit_err.strip()}",
+        file=sys.stderr,
+    )
+    return COMMIT_FAILED
+
+
+def _print_commit_checkpoint(session_num: int, journal_name: str) -> None:
+    """Actionable checkpoint for a failed auto-commit (R5)."""
+    print("", file=sys.stderr)
+    print(
+        f"[BLOCKED] Checkpoint: session {session_num} is recorded in "
+        f"{journal_name} and index.md, but the auto-commit did not complete.",
+        file=sys.stderr,
+    )
+    print(
+        "[BLOCKED] The pending record was left exactly as written — nothing was "
+        "rolled back.",
+        file=sys.stderr,
+    )
+    print(
+        "[BLOCKED] Fix the git error above, then re-run the identical "
+        "add_session.py command: it resumes at the commit step and will not add "
+        "a second session.",
+        file=sys.stderr,
+    )
 
 
 def add_session(
@@ -517,8 +1189,10 @@ def add_session(
     auto_commit: bool = True,
     package: str | None = None,
     branch: str | None = None,
+    commit_subjects: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> int:
-    """Add a new session."""
+    """Add a new session, resuming an interrupted one instead of duplicating it."""
     repo_root = get_repo_root()
     warn_if_parallel_worktree(repo_root)
     ensure_developer(repo_root)
@@ -533,66 +1207,188 @@ def add_session(
         print("Error: Workspace directory not found", file=sys.stderr)
         return 1
 
-    max_lines = get_max_journal_lines(repo_root)
+    # -------------------------------------------------------------------
+    # Preflight — no writes happen until every one of these succeeds.
+    # -------------------------------------------------------------------
+    if idempotency_key is not None and not IDEMPOTENCY_KEY_RE.match(idempotency_key):
+        print(
+            f"Error: invalid --idempotency-key '{idempotency_key}': expected 1-64 "
+            "characters from [A-Za-z0-9._-]",
+            file=sys.stderr,
+        )
+        return 1
 
+    tokens, token_error = parse_commit_tokens(commit)
+    if token_error:
+        print(f"Error: {token_error}", file=sys.stderr)
+        return 1
+
+    overrides, override_error = parse_subject_overrides(commit_subjects)
+    if override_error:
+        print(f"Error: {override_error}", file=sys.stderr)
+        return 1
+
+    evidence, evidence_error = build_commit_evidence(repo_root, tokens, overrides)
+    if evidence_error:
+        print(f"Error: {evidence_error}", file=sys.stderr)
+        return 1
+
+    max_lines = get_max_journal_lines(repo_root)
     index_file = dev_dir / "index.md"
     today = datetime.now().strftime("%Y-%m-%d")
 
-    journal_file, current_num, current_lines = get_latest_journal_info(dev_dir)
-    current_session = get_current_session(index_file)
-    new_session = current_session + 1
-
-    session_content = generate_session_content(
-        new_session, title, commit, summary, today, package, branch,
-        changes=changes, extra_content=extra_content, tests=tests,
-        next_steps=next_steps,
+    payload = _fingerprint_payload(
+        developer, title, summary, package, branch, evidence,
+        changes, extra_content, tests, next_steps, idempotency_key,
     )
-    content_lines = len(session_content.splitlines())
+    marker = render_marker(compute_record_fingerprint(payload))
+
+    # `today` is no longer a fingerprint input; a record has to be findable by
+    # its own retry after a date rollover. It still dates the rendered entry.
+    marker, resolve_error = resolve_effective_marker(dev_dir, payload, marker)
+    if resolve_error:
+        print(f"Error: {resolve_error}", file=sys.stderr)
+        return 1
+
+    state, matched_file, matched_num, classify_error = classify_record(
+        repo_root, dev_dir, index_file, marker
+    )
+    if classify_error:
+        print(f"Error: {classify_error}", file=sys.stderr)
+        return 1
+
+    if state == STATE_COMMITTED:
+        if idempotency_key:
+            print(
+                f"[OK] Session {matched_num} with idempotency key "
+                f"'{idempotency_key}' is already recorded and committed in "
+                f"{matched_file.name if matched_file else 'the journal'}; "
+                "nothing to do.",
+                file=sys.stderr,
+            )
+            return 0
+        # A committed record is finished. An identical later request is a
+        # legitimately new session, so fall through and append one.
+        state = STATE_ABSENT
+        matched_file = None
+        matched_num = None
 
     print("========================================", file=sys.stderr)
     print("ADD SESSION", file=sys.stderr)
     print("========================================", file=sys.stderr)
     print("", file=sys.stderr)
-    print(f"Session: {new_session}", file=sys.stderr)
-    print(f"Title: {title}", file=sys.stderr)
-    print(f"Commit: {commit}", file=sys.stderr)
-    print("", file=sys.stderr)
-    print(f"Current journal file: {FILE_JOURNAL_PREFIX}{current_num}.md", file=sys.stderr)
-    print(f"Current lines: {current_lines}", file=sys.stderr)
-    print(f"New content lines: {content_lines}", file=sys.stderr)
-    print(f"Total after append: {current_lines + content_lines}", file=sys.stderr)
-    print("", file=sys.stderr)
 
-    target_file = journal_file
-    target_num = current_num
+    # -------------------------------------------------------------------
+    # Absent → journal-recorded
+    # -------------------------------------------------------------------
+    target_file: Path | None
+    target_num: int
+    new_session: int
 
-    if current_lines + content_lines > max_lines:
-        target_num = current_num + 1
-        print(f"[!] Exceeds {max_lines} lines, creating {FILE_JOURNAL_PREFIX}{target_num}.md", file=sys.stderr)
-        target_file = create_new_journal_file(dev_dir, target_num, developer, today, max_lines)
-        print(f"Created: {target_file}", file=sys.stderr)
+    if state == STATE_ABSENT:
+        journal_file, current_num, current_lines = get_latest_journal_info(dev_dir)
+        new_session = resolve_next_session(repo_root, dev_dir, index_file)
 
-    # Append session content
-    if target_file:
-        with target_file.open("a", encoding="utf-8") as f:
-            f.write(session_content)
+        session_content = generate_session_content(
+            new_session, title, evidence, summary, today, marker, package, branch,
+            changes=changes, extra_content=extra_content, tests=tests,
+            next_steps=next_steps,
+        )
+        content_lines = len(session_content.splitlines())
+
+        print(f"Session: {new_session}", file=sys.stderr)
+        print(f"Title: {title}", file=sys.stderr)
+        print(f"Commit: {format_commit_display(evidence)}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"Current journal file: {FILE_JOURNAL_PREFIX}{current_num}.md", file=sys.stderr)
+        print(f"Current lines: {current_lines}", file=sys.stderr)
+        print(f"New content lines: {content_lines}", file=sys.stderr)
+        print(f"Total after append: {current_lines + content_lines}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+        target_file = journal_file
+        target_num = current_num
+
+        if current_lines + content_lines > max_lines:
+            target_num = current_num + 1
+            print(f"[!] Exceeds {max_lines} lines, creating {FILE_JOURNAL_PREFIX}{target_num}.md", file=sys.stderr)
+            target_file = create_new_journal_file(dev_dir, target_num, developer, today, max_lines)
+            if target_file is None:
+                print(
+                    f"Error: failed to create {FILE_JOURNAL_PREFIX}{target_num}.md; "
+                    "nothing was recorded.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Created: {target_file}", file=sys.stderr)
+
+        if target_file is None:
+            print(
+                "Error: no journal file to append to. Run init_developer.py first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            existing = target_file.read_text(encoding="utf-8") if target_file.is_file() else ""
+        except OSError as exc:
+            print(f"Error: cannot read {target_file}: {exc}", file=sys.stderr)
+            return 1
+
+        if not write_text_atomic(target_file, existing + session_content):
+            print(
+                f"Error: failed to append the session to {target_file.name}; "
+                "the previous journal content is intact and nothing was recorded.",
+                file=sys.stderr,
+            )
+            return 1
         print(f"[OK] Appended session to {target_file.name}", file=sys.stderr)
+        state = STATE_JOURNAL_RECORDED
+    else:
+        if matched_file is None or matched_num is None:
+            print(
+                f"Error: resumed state '{state}' without a matching journal entry.",
+                file=sys.stderr,
+            )
+            return 1
+        target_file = matched_file
+        new_session = matched_num
+        target_num = _extract_journal_num(target_file.stem)
+        print(
+            f"[RESUME] Session {new_session} is already in {target_file.name} and "
+            f"uncommitted; continuing from '{state}' instead of appending again.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
 
     print("", file=sys.stderr)
 
-    # Update index.md
+    # -------------------------------------------------------------------
+    # Journal-recorded → index-recorded
+    # -------------------------------------------------------------------
     active_file = f"{FILE_JOURNAL_PREFIX}{target_num}.md"
-    if not update_index(
-        index_file,
-        dev_dir,
-        title,
-        commit,
-        new_session,
-        active_file,
-        today,
-        branch,
-    ):
-        return 1
+    if state == STATE_JOURNAL_RECORDED:
+        if not update_index(
+            index_file,
+            dev_dir,
+            title,
+            evidence,
+            new_session,
+            active_file,
+            today,
+            branch,
+        ):
+            print(
+                f"[BLOCKED] Checkpoint: session {new_session} is in "
+                f"{active_file} but index.md was not updated. Fix index.md, then "
+                "re-run the identical command to repair the row without adding a "
+                "second session.",
+                file=sys.stderr,
+            )
+            return 1
+        state = STATE_INDEX_RECORDED
+    else:
+        print(f"[OK] index.md already records session {new_session}.", file=sys.stderr)
 
     print("", file=sys.stderr)
     print("========================================", file=sys.stderr)
@@ -603,10 +1399,31 @@ def add_session(
     print(f"  - {target_file.name if target_file else 'journal'}", file=sys.stderr)
     print("  - index.md", file=sys.stderr)
 
-    # Auto-commit workspace changes
-    if auto_commit:
-        print("", file=sys.stderr)
-        _auto_commit_workspace(repo_root)
+    # -------------------------------------------------------------------
+    # Index-recorded → committed
+    # -------------------------------------------------------------------
+    if not auto_commit:
+        return 0
+
+    print("", file=sys.stderr)
+    outcome = _auto_commit_workspace(repo_root)
+
+    if outcome == COMMIT_FAILED:
+        _print_commit_checkpoint(
+            new_session, target_file.name if target_file else "the journal"
+        )
+        return 1
+
+    if outcome == COMMIT_DONE and target_file is not None:
+        committed = content_at_head(repo_root, target_file)
+        if committed is None or marker not in committed:
+            print(
+                f"[WARN] Auto-commit reported success but {target_file.name} at "
+                "HEAD does not contain this session's record.",
+                file=sys.stderr,
+            )
+            _print_commit_checkpoint(new_session, target_file.name)
+            return 1
 
     return 0
 
@@ -621,7 +1438,24 @@ def main() -> int:
         description="Add a new session to journal file and update index.md"
     )
     parser.add_argument("--title", required=True, help="Session title")
-    parser.add_argument("--commit", default="-", help="Comma-separated commit hashes")
+    parser.add_argument(
+        "--commit",
+        default="-",
+        help=(
+            "Comma-separated commit OIDs (7-40 hex chars each). Each one is "
+            "resolved to its real subject before anything is written; an "
+            "unresolvable OID fails the command. Use '-' for a planning session."
+        ),
+    )
+    parser.add_argument(
+        "--commit-subject",
+        action="append",
+        metavar="OID=SUBJECT",
+        help=(
+            "Explicit subject for a commit that cannot be resolved locally "
+            "(repeatable). The mapping must be one-to-one with --commit."
+        ),
+    )
     parser.add_argument("--summary", default="Session summary was not supplied.", help="Brief summary")
     parser.add_argument("--content-file", help="Path to file with detailed content")
     parser.add_argument("--package", help="Package name tag (e.g., cli, docs-site)")
@@ -629,6 +1463,13 @@ def main() -> int:
     parser.add_argument("--change", action="append", help="Main Changes bullet (repeatable)")
     parser.add_argument("--test", action="append", help="Testing bullet (repeatable)")
     parser.add_argument("--next-step", action="append", help="Next Steps bullet (repeatable)")
+    parser.add_argument(
+        "--idempotency-key",
+        help=(
+            "Caller-supplied retry key ([A-Za-z0-9._-], 1-64 chars). Makes an "
+            "already-committed identical record a no-op instead of a new session."
+        ),
+    )
     parser.add_argument("--no-commit", action="store_true",
                         help="Skip auto-commit of workspace changes")
     parser.add_argument("--stdin", action="store_true",
@@ -674,6 +1515,8 @@ def main() -> int:
         auto_commit=not args.no_commit,
         package=package,
         branch=branch,
+        commit_subjects=args.commit_subject,
+        idempotency_key=args.idempotency_key,
     )
 
 

--- a/.trellis/scripts/add_session.py
+++ b/.trellis/scripts/add_session.py
@@ -496,7 +496,8 @@ def compute_record_fingerprint(payload: dict) -> str:
     date was equal for both of them anyway. Across days it only ever separated
     records with byte-identical prose, commits, branch and package — and a
     *committed* record of that shape is already refused for reuse by
-    cmd_add_session, which maps STATE_COMMITTED to STATE_ABSENT. What is left
+    cmd_add_session, which steps to the next `generation` of the payload
+    rather than reusing the committed marker. What is left
     is exactly the question this key should answer: is there an uncommitted
     record in this worktree matching these inputs?
     """
@@ -1257,21 +1258,36 @@ def add_session(
         print(f"Error: {classify_error}", file=sys.stderr)
         return 1
 
-    if state == STATE_COMMITTED:
-        if idempotency_key:
-            print(
-                f"[OK] Session {matched_num} with idempotency key "
-                f"'{idempotency_key}' is already recorded and committed in "
-                f"{matched_file.name if matched_file else 'the journal'}; "
-                "nothing to do.",
-                file=sys.stderr,
-            )
-            return 0
-        # A committed record is finished. An identical later request is a
-        # legitimately new session, so fall through and append one.
-        state = STATE_ABSENT
-        matched_file = None
-        matched_num = None
+    if state == STATE_COMMITTED and idempotency_key:
+        print(
+            f"[OK] Session {matched_num} with idempotency key "
+            f"'{idempotency_key}' is already recorded and committed in "
+            f"{matched_file.name if matched_file else 'the journal'}; "
+            "nothing to do.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # A committed record is finished, so an identical later request is a
+    # legitimately new session. It must not reuse the committed marker: two
+    # entries carrying one marker make every later run ambiguous, and
+    # classify_record refuses to guess between them. Step to the next
+    # generation of this record instead. The marker stays a pure function of
+    # (payload, generation), so a retry of the new entry recomputes the same
+    # marker and still resumes; generation 0 omits the field entirely, leaving
+    # first-time markers byte-identical to what this scheme already writes.
+    generation = 0
+    while state == STATE_COMMITTED:
+        generation += 1
+        marker = render_marker(
+            compute_record_fingerprint({**payload, "generation": generation})
+        )
+        state, matched_file, matched_num, classify_error = classify_record(
+            repo_root, dev_dir, index_file, marker
+        )
+        if classify_error:
+            print(f"Error: {classify_error}", file=sys.stderr)
+            return 1
 
     print("========================================", file=sys.stderr)
     print("ADD SESSION", file=sys.stderr)

--- a/.trellis/scripts/common/io.py
+++ b/.trellis/scripts/common/io.py
@@ -1,8 +1,9 @@
 """
-JSON file I/O utilities.
+File I/O utilities.
 
-Provides read_json and write_json as the single source of truth
-for JSON file operations across all Trellis scripts.
+Provides read_json / write_json as the single source of truth for JSON file
+operations, plus write_text_atomic for the Markdown state files (journal,
+index.md) that carry durable session state.
 """
 
 from __future__ import annotations
@@ -34,7 +35,19 @@ def write_json(path: Path, data: dict) -> bool:
 
     Returns True on success, False on error.
     """
-    payload = json.dumps(data, indent=2, ensure_ascii=False)
+    return write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def write_text_atomic(path: Path, text: str) -> bool:
+    """Write text to a file atomically (temp in same dir, then replace).
+
+    The same never-truncate-in-place guarantee as :func:`write_json`, for the
+    Markdown state files that hold durable session state (journal files,
+    index.md). A crash or Ctrl-C mid-write leaves the previous content intact
+    instead of a half-written record that no retry can classify.
+
+    Returns True on success, False on error.
+    """
     try:
         fd, tmp = tempfile.mkstemp(
             dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
@@ -50,7 +63,7 @@ def write_json(path: Path, data: dict) -> bool:
             os.close(fd)
             raise
         with f:
-            f.write(payload)
+            f.write(text)
         os.replace(tmp, path)
         return True
     except OSError:
@@ -59,3 +72,10 @@ def write_json(path: Path, data: dict) -> bool:
         except OSError:
             pass
         return False
+    except BaseException:
+        # Ctrl-C mid-write: drop the temp file, then let the interrupt through.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/.trellis/spec/cli/backend/filesystem-safety.md
+++ b/.trellis/spec/cli/backend/filesystem-safety.md
@@ -34,9 +34,18 @@ export function writeFileAtomic(filePath: string, data: string | Uint8Array): vo
 ```python
 # templates/trellis/scripts/common/io.py
 def write_json(path: Path, data: dict) -> bool
+def write_text_atomic(path: Path, text: str) -> bool
 # tempfile.mkstemp(dir=path.parent) -> os.fdopen write -> os.replace(tmp, path);
 # unlinks tmp and re-raises on BaseException (Ctrl-C included).
+# write_json serializes and delegates, so both share one implementation.
 ```
+
+`write_text_atomic` covers the Markdown state files, not just JSON:
+`add_session.py` appends to `journal-*.md` and rewrites `index.md` through it.
+Those two carry the session record that a retry classifies, so a half-written
+one is not a cosmetic defect — it is pending evidence nothing can resume from.
+The append is read-all + write-all rather than `open("a")` for exactly that
+reason.
 
 ### Wrong vs Correct
 

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -1570,16 +1570,29 @@ an error. Generic prose (`(see git log)`, `not recorded`, `(Add details)`) is
 never substituted — that is the whole point of the requirement.
 
 **Record identity is a retry key, not a dedupe key.** The fingerprint is a
-SHA-256 over the normalized semantic inputs (developer, date, title, summary,
+SHA-256 over the normalized semantic inputs (developer, title, summary,
 package, branch, resolved commits *and their subjects*, changes, extra
 content, tests, next steps, idempotency key), truncated to 16 hex chars, and
-persisted as `<!-- trellis-session: fp=<hash> -->` on the line directly under
-the `## Session N:` heading. An HTML comment renders as nothing, so the human
-evidence is unchanged by its presence. The marker only matches a record that
-is **still uncommitted in this worktree**: once the entry is present in
-`git show HEAD:<journal>`, an identical later request is a legitimately new
-session and gets a new number. `--idempotency-key` is the one way to say
-otherwise — with a key, an already-committed match is reported and exits 0.
+persisted as `<!-- trellis-session: v=2 fp=<hash> -->` on the line directly
+under the `## Session N:` heading. An HTML comment renders as nothing, so the
+human evidence is unchanged by its presence.
+
+The calendar date is **not** an input. v1 mixed it in and wrote the marker
+unversioned as `<!-- trellis-session: fp=<hash> -->`; a retry resumed after a
+midnight rollover then recomputed a fingerprint that no longer matched the
+marker already sitting in the journal, and appended a second entry for one
+session. v1 markers are still read — the entry's own `**Date**:` line supplies
+the date to recompute with — but never written.
+
+The marker only matches a record that is **still uncommitted in this
+worktree**: once the entry is present in `git show HEAD:<journal>`, an
+identical later request is a legitimately new session and gets a new number.
+That new session cannot carry the committed marker, or two entries would share
+one and every later run would be ambiguous, so the run steps to the next
+`generation` of the payload and fingerprints that instead. Generation 0 omits
+the field, so a first-time marker is unaffected. `--idempotency-key` is the one
+way to say otherwise — with a key, an already-committed match is reported and
+exits 0.
 
 **Five states, one direction.** `classify_record` returns `absent`,
 `journal-recorded`, `index-recorded`, or `committed`, and the run walks them
@@ -1638,12 +1651,12 @@ could classify. See
 | `--commit` token is not 7-40 hex chars | Exit 1, names the token; nothing written |
 | `--commit` OID does not resolve locally | Exit 1, names the OID and the `--commit-subject` remedy; nothing written |
 | `--commit-subject` for an OID not in `--commit`, duplicated, or empty | Exit 1; nothing written |
-| `--commit-subject` subject contains `|` or newlines | Accepted; escaped for the Markdown cell |
+| `--commit-subject` subject contains `\|` or newlines | Accepted; escaped for the Markdown cell |
 | `--commit -` (default) | `(No commits - planning session)`; no git resolution at all |
 | `--idempotency-key` outside `[A-Za-z0-9._-]{1,64}` | Exit 1; nothing written |
 | Retry after a failed index update | Index row repaired, journal entry count unchanged |
 | Retry after a failed auto-commit | Only the commit is retried; journal and index unchanged |
-| Retry of an already-committed record, no idempotency key | New session, new number |
+| Retry of an already-committed record, no idempotency key | New session, new number, and a next-generation marker so neither entry is ambiguous |
 | Retry of an already-committed record, with idempotency key | Exit 0, reports "already recorded"; nothing written |
 | Marker found in two entries | Exit 1, names the files; nothing written |
 | Marker with no `## Session N:` heading above it | Exit 1, "malformed"; nothing written |

--- a/.trellis/spec/cli/backend/script-conventions.md
+++ b/.trellis/spec/cli/backend/script-conventions.md
@@ -350,14 +350,15 @@ _mark_attempted(repo_root)
 
 ## Shared Module API Reference
 
-### `common/io.py` — JSON File I/O
+### `common/io.py` — File I/O
 
-The single source of truth for all JSON file operations. Replaces 8 duplicated `_read_json_file` and 5 duplicated `_write_json_file` functions.
+The single source of truth for all JSON file operations. Replaces 8 duplicated `_read_json_file` and 5 duplicated `_write_json_file` functions. It also owns `write_text_atomic`, the same never-truncate-in-place guarantee for the Markdown state files (`journal-*.md`, `index.md`) that hold durable session state.
 
 | Function | Signature | Returns | Error Behavior |
 |----------|-----------|---------|----------------|
 | `read_json` | `(path: Path) -> dict \| None` | Parsed dict, or `None` | Returns `None` on `FileNotFoundError`, `JSONDecodeError`, `OSError` |
 | `write_json` | `(path: Path, data: dict) -> bool` | `True` on success | Returns `False` on `OSError`, `IOError` |
+| `write_text_atomic` | `(path: Path, text: str) -> bool` | `True` on success | Returns `False` on `OSError`; unlinks the temp file and re-raises on `BaseException` (Ctrl-C) |
 
 **Contracts**:
 - Always uses `encoding="utf-8"` and `ensure_ascii=False`
@@ -1465,11 +1466,14 @@ from common.safe_commit import (
 )
 from common.config import get_session_auto_commit
 
-def _auto_commit_workspace(repo_root: Path) -> None:
+def _auto_commit_workspace(repo_root: Path) -> str:
+    # Returns COMMIT_DONE / COMMIT_SKIPPED / COMMIT_BLOCKED / COMMIT_FAILED.
+    # The caller turns COMMIT_FAILED into a non-zero exit + checkpoint; see
+    # "Session recording is a resumable state machine" below.
     if not get_session_auto_commit(repo_root):
         print("[OK] session_auto_commit: false — skipping git stage/commit.",
               file=sys.stderr)
-        return
+        return COMMIT_SKIPPED
 
     # Scope staging to the CURRENT task only (#303) — never iterdir all tasks.
     current = get_current_task(repo_root)
@@ -1502,12 +1506,16 @@ Behavior contract:
   non-existent arguments to `git`.
 - `safe_git_add` runs `git add -- <paths>` exactly once. No retry, no `-f`.
 - On `ignored by` failure → call `print_gitignore_warning(paths)`.
-  `add_session.py` returns after writing files to disk. `task.py archive`
-  returns success only when the archived source was not tracked; if tracked
-  task files were moved and the archive commit cannot be created, `archive`
-  exits non-zero so callers do not continue to journal over dirty deletes.
-- On any other failure → log the stderr and return. Do not re-attempt with
-  different flags.
+  `add_session.py` returns `COMMIT_BLOCKED` and still exits 0: a gitignored
+  `.trellis/` is the user telling git to stay out of this tree, which is the
+  same configured skip as `session_auto_commit: false`, not a failure worth
+  retrying. `task.py archive` returns success only when the archived source
+  was not tracked; if tracked task files were moved and the archive commit
+  cannot be created, `archive` exits non-zero so callers do not continue to
+  journal over dirty deletes.
+- On any other failure → log the stderr and return `COMMIT_FAILED`. Do not
+  re-attempt with different flags. `add_session.py` exits non-zero and prints
+  the resume checkpoint.
 - `task.py archive` is stricter than `add_session.py`: when `session_auto_commit`
   is enabled and the source task had tracked files, the archive move must be
   accompanied by a successful bookkeeping commit. A failed commit leaves the
@@ -1516,6 +1524,180 @@ Behavior contract:
 - `used_force` in `safe_git_add`'s return tuple is kept for signature
   compatibility but is always `False`. Do not introduce a code path that
   sets it to `True`.
+
+### Scenario: Session recording is a resumable state machine
+
+#### 1. Scope / Trigger
+
+Any change to `add_session.py`'s rendering, journal append, index update,
+auto-commit, or session numbering. Recording used to be three unguarded steps
+in a row: append, update index, best-effort commit. A crash or a failed commit
+between them left a half-recorded session that the next identical run happily
+appended a *second* time, and the commit table rendered `(see git log)` for
+every hash because no code ever asked git what the commit said.
+
+#### 2. Signatures
+
+```python
+# add_session.py
+def parse_commit_tokens(commit: str) -> tuple[list[str], str | None]
+def parse_subject_overrides(values: list[str] | None) -> tuple[dict[str, str], str | None]
+def resolve_commit_subject(repo_root: Path, oid: str) -> str | None
+def build_commit_evidence(repo_root, tokens, overrides) -> tuple[list[tuple[str, str]], str | None]
+def escape_markdown_cell(text: str) -> str
+def compute_record_fingerprint(...) -> str          # 16 hex chars
+def render_marker(fingerprint: str) -> str          # HTML comment
+def classify_record(repo_root, dev_dir, index_file, marker
+    ) -> tuple[str, Path | None, int | None, str | None]
+def resolve_next_session(repo_root, dev_dir, index_file) -> int
+def _auto_commit_workspace(repo_root: Path) -> str
+```
+
+New CLI surface: `--commit-subject OID=SUBJECT` (repeatable) and
+`--idempotency-key <key>`.
+
+#### 3. Contracts
+
+**Accurate commit evidence, or no write at all.** Every `--commit` token is a
+bounded hex OID (`^[0-9a-fA-F]{7,40}$`); anything else is rejected. Each OID is
+resolved to its real subject with `git show -s --format=%s <oid>^{commit} --`
+— argv, never shell interpolation, and peeled to `commit` so a hex-looking ref
+name cannot resolve to a tree. An OID that does not resolve fails the command
+**before the journal or index is touched**. The only escape hatch is an
+explicit, one-to-one `--commit-subject <oid>=<subject>` mapping; a mapping for
+an OID that is not in `--commit`, a duplicate mapping, or an empty subject is
+an error. Generic prose (`(see git log)`, `not recorded`, `(Add details)`) is
+never substituted — that is the whole point of the requirement.
+
+**Record identity is a retry key, not a dedupe key.** The fingerprint is a
+SHA-256 over the normalized semantic inputs (developer, date, title, summary,
+package, branch, resolved commits *and their subjects*, changes, extra
+content, tests, next steps, idempotency key), truncated to 16 hex chars, and
+persisted as `<!-- trellis-session: fp=<hash> -->` on the line directly under
+the `## Session N:` heading. An HTML comment renders as nothing, so the human
+evidence is unchanged by its presence. The marker only matches a record that
+is **still uncommitted in this worktree**: once the entry is present in
+`git show HEAD:<journal>`, an identical later request is a legitimately new
+session and gets a new number. `--idempotency-key` is the one way to say
+otherwise — with a key, an already-committed match is reported and exits 0.
+
+**Five states, one direction.** `classify_record` returns `absent`,
+`journal-recorded`, `index-recorded`, or `committed`, and the run walks them
+in order:
+
+| From | Step | To |
+| --- | --- | --- |
+| absent | atomically append the complete marked entry | journal-recorded |
+| journal-recorded | write the exact index row | index-recorded |
+| index-recorded | stage the scoped paths and commit | committed |
+
+A retry re-enters at whichever state it finds. `journal-recorded` repairs
+*only* the index row — it never appends a second entry. `index-recorded`
+retries *only* the commit.
+
+**Only a unique exact match is ever adopted.** Two entries carrying the same
+marker, a marker with no `## Session N:` heading above it, or a missing index
+row while `Total Sessions` already counts past this session all return an
+error and change nothing. Ambiguous or malformed pending evidence is never
+guessed into completion.
+
+**A failed auto-commit is a failure.** `_auto_commit_workspace` returns
+`COMMIT_DONE` / `COMMIT_SKIPPED` / `COMMIT_BLOCKED` / `COMMIT_FAILED`. On
+`COMMIT_FAILED` the command exits 1 after printing a `[BLOCKED] Checkpoint:`
+block naming the session, the journal file, and the fact that re-running the
+identical command resumes rather than duplicates. Reporting overall success
+because the append worked is what made the producer gap invisible. After a
+reported-successful commit the marker is re-read from `HEAD:<journal>`; if it
+is not there, the same checkpoint fires.
+
+**Session numbers converge across branches.** The next number is
+`max(...) + 1` over the working tree (index `Total Sessions` plus every
+`## Session N:` heading in every local `journal-*.md`) **and** every recorded
+ref. The refs come from `for-each-ref` — HEAD and the default branch first,
+then the other local heads (where a parallel worktree's branch lives, which is
+the case that actually collided twice on 2026-08-06), then remote-tracking
+refs — capped at `MAX_CONVERGENCE_REFS` and read with a single `git grep` over
+all of them, not an `ls-tree` + `show` per ref. Deriving the number from the
+working tree alone lets two branches claim the same number; the
+`journal-*.md merge=union` driver then merges two *different* sessions that
+both call themselves N. The default branch is resolved locally only
+(`refs/remotes/origin/HEAD`, then `main`/`master`) — `resolve_default_branch`
+falls back to `git remote show origin`, which can block on the network, and
+session recording is a hot path.
+
+**Writes are crash-safe.** The journal append and the index rewrite both go
+through `io.write_text_atomic` (temp in the same dir, then `os.replace`), so a
+crash mid-write leaves the previous content rather than a half-record no retry
+could classify. See
+[Filesystem Safety](./filesystem-safety.md#1-atomic-writes--never-truncate-a-state-file-in-place).
+
+#### 4. Validation & Error Matrix
+
+| Condition | Behavior |
+| --- | --- |
+| `--commit` token is not 7-40 hex chars | Exit 1, names the token; nothing written |
+| `--commit` OID does not resolve locally | Exit 1, names the OID and the `--commit-subject` remedy; nothing written |
+| `--commit-subject` for an OID not in `--commit`, duplicated, or empty | Exit 1; nothing written |
+| `--commit-subject` subject contains `|` or newlines | Accepted; escaped for the Markdown cell |
+| `--commit -` (default) | `(No commits - planning session)`; no git resolution at all |
+| `--idempotency-key` outside `[A-Za-z0-9._-]{1,64}` | Exit 1; nothing written |
+| Retry after a failed index update | Index row repaired, journal entry count unchanged |
+| Retry after a failed auto-commit | Only the commit is retried; journal and index unchanged |
+| Retry of an already-committed record, no idempotency key | New session, new number |
+| Retry of an already-committed record, with idempotency key | Exit 0, reports "already recorded"; nothing written |
+| Marker found in two entries | Exit 1, names the files; nothing written |
+| Marker with no `## Session N:` heading above it | Exit 1, "malformed"; nothing written |
+| Auto-commit fails | Exit 1 with the `[BLOCKED] Checkpoint:` block |
+| `.trellis/` is gitignored | `print_gitignore_warning`, exit 0 (configured skip) |
+| Not a git repository | `COMMIT_BLOCKED`, exit 0 — retry could never succeed, so it is not `COMMIT_FAILED` |
+| `session_auto_commit: false` | Stops after verified journal + index, exit 0 |
+
+#### 5. Good / Base / Bad Cases
+
+- **Good** — a session recorded with three real OIDs renders three real
+  subjects; a later interrupted run of the same command lands on the same
+  fingerprint, sees the entry uncommitted with no index row, writes the row,
+  commits, and exits 0 with one journal entry.
+- **Base** — a planning session (`--commit -`) with auto-commit disabled.
+  No git resolution, no staging, exit 0 once journal and index agree.
+- **Bad** — "the append succeeded, so report success and warn about the
+  commit." The next identical run then appends a second entry for a session
+  the user believes is already recorded.
+
+#### 6. Tests Required
+
+`test/scripts/add-session.integration.test.ts`, real `python3` against real
+git repos — not source-string assertions. Subject rendering and escaping,
+unresolved-OID fail-before-write (assertion point: the journal file is byte
+unchanged), explicit mapping accepted, planning `-`, auto-commit disabled,
+rotation, fault injection at each of append / index / commit with a retry that
+proves convergence, a repeated committed record producing a *new* session, the
+idempotency-key no-op, concurrent-branch numbering, a malformed marker, and
+the staging scope staying inside Trellis-owned paths.
+
+#### 7. Wrong vs Correct
+
+##### Wrong
+
+```python
+for c in commit.split(","):
+    commit_table += f"\n| `{c.strip()}` | (see git log) |"
+```
+
+The table has a Message column and this fills it with an instruction to go
+look somewhere else. Every consumer of the journal then reads evidence that
+says nothing.
+
+##### Correct
+
+```python
+evidence, error = build_commit_evidence(repo_root, tokens, overrides)
+if error:
+    print(f"Error: {error}", file=sys.stderr)
+    return 1                      # before any mutation
+for oid, subject in evidence:
+    commit_table += f"\n| `{oid}` | {escape_markdown_cell(subject)} |"
+```
 
 ### Pattern: `session_auto_commit` config gate (added 0.5.11)
 

--- a/packages/cli/src/templates/trellis/scripts/add_session.py
+++ b/packages/cli/src/templates/trellis/scripts/add_session.py
@@ -15,6 +15,27 @@ Usage:
     # Structured content (repeatable; a section with no bullets is omitted):
     python3 add_session.py --title "Title" --change "Did X" --test "Ran Y" --next-step "Do Z"
 
+    # Commit evidence that cannot be resolved from the local object database
+    # (amended, not yet fetched) needs an explicit subject, one per OID:
+    python3 add_session.py --title "Title" --commit "abc1234" \
+        --commit-subject "abc1234=fix(cli): stop truncating the manifest"
+
+Commit evidence:
+    Every --commit token is a bounded hex OID (7-40 chars). Each one is
+    resolved to its real subject from the local object database BEFORE
+    anything is written. An OID that cannot be resolved fails the command
+    before the journal or index is touched — no placeholder prose is ever
+    recorded. Pass "-" (the default) for a planning session with no commits.
+
+Retry convergence:
+    The journal append, the index row and the optional auto-commit are one
+    resumable operation. Every entry carries a fingerprint marker derived from
+    its own inputs, so re-running an interrupted command repairs the pending
+    record instead of appending a second one, and a failed auto-commit exits
+    non-zero with the checkpoint to resume from. A record that is already
+    committed is never reused: an identical later request is a new session
+    unless an explicit --idempotency-key says otherwise.
+
 Branch resolution order:
     1. --branch CLI arg (explicit)
     2. task.json branch field (from active task, if still exists)
@@ -25,6 +46,8 @@ Branch resolution order:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import re
 import sys
 from datetime import datetime
@@ -40,7 +63,8 @@ from common.paths import (
     get_workspace_dir,
 )
 from common.developer import ensure_developer
-from common.git import run_git
+from common.git import branch_exists_locally, run_git
+from common.io import write_text_atomic
 from common.log import Colors, colored
 from common.safe_commit import (
     print_gitignore_warning,
@@ -58,6 +82,41 @@ from common.config import (
     resolve_package,
     validate_package,
 )
+
+
+# Bounded, argv-safe input shapes. Anything outside them is rejected during
+# preflight, before a single byte is written.
+COMMIT_TOKEN_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+MAX_SUBJECT_LEN = 500
+
+# Machine-readable record identity. An HTML comment renders as nothing, so the
+# human evidence in the entry is unchanged by its presence.
+MARKER_PREFIX = "<!-- trellis-session:"
+# Bumped when the fingerprint inputs change. Untagged markers are v1, whose
+# fingerprint mixed in the calendar date; see compute_record_fingerprint.
+MARKER_VERSION = 2
+LEGACY_MARKER_RE = re.compile(r"^<!-- trellis-session: fp=([0-9a-f]{16}) -->$")
+ENTRY_DATE_RE = re.compile(r"^\*\*Date\*\*: (\d{4}-\d{2}-\d{2})\s*$")
+SESSION_HEADING_RE = re.compile(r"^## Session (\d+):", re.MULTILINE)
+
+# Recording states, in the order the operation walks them.
+STATE_ABSENT = "absent"
+STATE_JOURNAL_RECORDED = "journal-recorded"
+STATE_INDEX_RECORDED = "index-recorded"
+STATE_COMMITTED = "committed"
+
+# Auto-commit outcomes.
+COMMIT_DONE = "committed"
+COMMIT_SKIPPED = "skipped"
+COMMIT_BLOCKED = "blocked"
+COMMIT_FAILED = "failed"
+
+# Git probes against other refs are best-effort; never let one hang a session.
+GIT_PROBE_TIMEOUT = 15.0
+# Upper bound on the refs folded into session numbering. A repo with hundreds
+# of stale branches must not turn session recording into a tree walk.
+MAX_CONVERGENCE_REFS = 100
 
 
 # =============================================================================
@@ -97,12 +156,23 @@ def get_current_session(index_file: Path) -> int:
         return 0
 
     content = index_file.read_text(encoding="utf-8")
+    return _max_session_in_index(content)
+
+
+def _max_session_in_index(content: str) -> int:
+    """Read the `Total Sessions` counter out of an index.md body."""
     for line in content.splitlines():
         if "Total Sessions" in line:
             match = re.search(r":\s*(\d+)", line)
             if match:
                 return int(match.group(1))
     return 0
+
+
+def _max_session_in_journal(content: str) -> int:
+    """Highest `## Session N:` heading in a journal body (0 when none)."""
+    numbers = [int(m.group(1)) for m in SESSION_HEADING_RE.finditer(content)]
+    return max(numbers) if numbers else 0
 
 
 def _extract_journal_num(filename: str) -> int:
@@ -226,8 +296,8 @@ def warn_if_parallel_worktree(repo_root: Path) -> None:
 
 def create_new_journal_file(
     dev_dir: Path, num: int, developer: str, today: str, max_lines: int = 2000,
-) -> Path:
-    """Create a new journal file."""
+) -> Path | None:
+    """Create a new journal file. Returns None when the write fails."""
     prev_num = num - 1
     new_file = dev_dir / f"{FILE_JOURNAL_PREFIX}{num}.md"
 
@@ -239,9 +309,564 @@ def create_new_journal_file(
 ---
 
 """
-    new_file.write_text(content, encoding="utf-8")
+    if not write_text_atomic(new_file, content):
+        return None
     return new_file
 
+
+# =============================================================================
+# Commit evidence (R1) — accurate subjects or nothing
+# =============================================================================
+
+def parse_commit_tokens(commit: str) -> tuple[list[str], str | None]:
+    """Split --commit into bounded hex OIDs. Returns (tokens, error)."""
+    raw = (commit or "").strip()
+    if not raw or raw == "-":
+        return [], None
+
+    tokens: list[str] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if not COMMIT_TOKEN_RE.match(token):
+            return [], (
+                f"invalid --commit token '{token}': expected a 7-40 character hex "
+                "commit OID, or '-' for a planning session with no commits"
+            )
+        token = token.lower()
+        if token not in tokens:
+            tokens.append(token)
+    return tokens, None
+
+
+def parse_subject_overrides(values: list[str] | None) -> tuple[dict[str, str], str | None]:
+    """Parse `--commit-subject <oid>=<subject>` into a one-to-one mapping."""
+    overrides: dict[str, str] = {}
+    for raw in values or []:
+        if "=" not in raw:
+            return {}, (
+                f"invalid --commit-subject '{raw}': expected <oid>=<subject>"
+            )
+        oid_part, subject = raw.split("=", 1)
+        oid = oid_part.strip().lower()
+        subject = subject.strip()
+        if not COMMIT_TOKEN_RE.match(oid):
+            return {}, (
+                f"invalid --commit-subject key '{oid_part.strip()}': expected a "
+                "7-40 character hex commit OID"
+            )
+        if not subject:
+            return {}, f"invalid --commit-subject for '{oid}': subject is empty"
+        if len(subject) > MAX_SUBJECT_LEN:
+            return {}, (
+                f"invalid --commit-subject for '{oid}': subject exceeds "
+                f"{MAX_SUBJECT_LEN} characters"
+            )
+        if oid in overrides:
+            return {}, f"duplicate --commit-subject mapping for '{oid}'"
+        overrides[oid] = subject
+    return overrides, None
+
+
+def resolve_commit_subject(repo_root: Path, oid: str) -> str | None:
+    """Resolve one OID to its subject from the local object database.
+
+    Passed as argv (never interpolated into a shell) and peeled with
+    ``^{commit}`` so a hex-looking ref name cannot resolve to a tree or tag.
+    Returns None when the object is missing, ambiguous, or has no subject.
+    """
+    rc, out, _ = run_git(
+        ["show", "-s", "--format=%s", f"{oid}^{{commit}}", "--"], cwd=repo_root
+    )
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        subject = line.strip()
+        if subject:
+            return subject[:MAX_SUBJECT_LEN]
+    return None
+
+
+def build_commit_evidence(
+    repo_root: Path,
+    tokens: list[str],
+    overrides: dict[str, str],
+) -> tuple[list[tuple[str, str]], str | None]:
+    """Pair every commit OID with an accurate subject, or fail.
+
+    There is no placeholder path: an OID that neither resolves locally nor
+    carries an explicit mapping stops the command before any mutation.
+    """
+    evidence: list[tuple[str, str]] = []
+    unresolved: list[str] = []
+
+    for oid in tokens:
+        if oid in overrides:
+            evidence.append((oid, overrides[oid]))
+            continue
+        subject = resolve_commit_subject(repo_root, oid)
+        if subject is None:
+            unresolved.append(oid)
+            continue
+        evidence.append((oid, subject))
+
+    if unresolved:
+        return [], (
+            "cannot resolve commit evidence for: "
+            + ", ".join(unresolved)
+            + ". Fetch the objects, correct the OID, or pass the exact subject "
+            "with --commit-subject <oid>=<subject>. Nothing was written."
+        )
+
+    unused = sorted(oid for oid in overrides if oid not in tokens)
+    if unused:
+        return [], (
+            "--commit-subject supplied for OIDs that are not in --commit: "
+            + ", ".join(unused)
+            + ". The mapping must be one-to-one. Nothing was written."
+        )
+
+    return evidence, None
+
+
+def escape_markdown_cell(text: str) -> str:
+    """Make a commit subject safe inside a Markdown table cell."""
+    collapsed = " ".join(text.split())
+    return collapsed.replace("\\", "\\\\").replace("|", "\\|")
+
+
+# =============================================================================
+# Record identity (R2)
+# =============================================================================
+
+def _normalize_text(value: str | None) -> str:
+    return " ".join((value or "").split())
+
+
+def _fingerprint_payload(
+    developer: str,
+    title: str,
+    summary: str,
+    package: str | None,
+    branch: str | None,
+    evidence: list[tuple[str, str]],
+    changes: list[str] | None,
+    extra_content: str | None,
+    tests: list[str] | None,
+    next_steps: list[str] | None,
+    idempotency_key: str | None,
+) -> dict:
+    """Normalized semantic inputs of one record, shared by both schemes."""
+    return {
+        "developer": developer,
+        "title": _normalize_text(title),
+        "summary": _normalize_text(summary),
+        "package": package or "",
+        "branch": branch or "",
+        "commits": [[oid, _normalize_text(subject)] for oid, subject in evidence],
+        "changes": [_normalize_text(c) for c in changes or []],
+        "extra": _normalize_text(extra_content),
+        "tests": [_normalize_text(t) for t in tests or []],
+        "next_steps": [_normalize_text(n) for n in next_steps or []],
+        "idempotency_key": idempotency_key or "",
+    }
+
+
+def _hash_payload(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def compute_record_fingerprint(payload: dict) -> str:
+    """Bounded fingerprint over the normalized semantic inputs of one record.
+
+    This is the retry key while the record is still pending in the worktree —
+    not a global dedupe key. Two genuinely separate sessions with identical
+    prose differ only if the caller says so, which is why an already-committed
+    match is never adopted (see classify_record).
+
+    Deliberately date-free (v2). v1 mixed in the calendar date, which made a
+    record unfindable by its own retry across a midnight rollover: the journal
+    and index were already written, the commit had failed, and the recomputed
+    fingerprint no longer matched the marker sitting in the journal, so the
+    retry appended a second entry for one session.
+
+    Dropping the date cannot over-collapse two same-day sessions, because the
+    date was equal for both of them anyway. Across days it only ever separated
+    records with byte-identical prose, commits, branch and package — and a
+    *committed* record of that shape is already refused for reuse by
+    cmd_add_session, which maps STATE_COMMITTED to STATE_ABSENT. What is left
+    is exactly the question this key should answer: is there an uncommitted
+    record in this worktree matching these inputs?
+    """
+    return _hash_payload(payload)
+
+
+def compute_legacy_fingerprint(payload: dict, date: str) -> str:
+    """The v1 fingerprint, for resolving markers written before the change.
+
+    Lookup only — nothing writes this scheme any more.
+    """
+    return _hash_payload({**payload, "date": date})
+
+
+def render_marker(fingerprint: str) -> str:
+    """Machine-readable record marker; renders as nothing in Markdown."""
+    return f"{MARKER_PREFIX} v={MARKER_VERSION} fp={fingerprint} -->"
+
+
+def render_legacy_marker(fingerprint: str) -> str:
+    """The v1 marker form: no version tag. Read, never written."""
+    return f"{MARKER_PREFIX} fp={fingerprint} -->"
+
+
+# =============================================================================
+# Session numbering (collision-proof across concurrent branches)
+# =============================================================================
+
+def _repo_relative(repo_root: Path, path: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _default_branch_local(repo_root: Path) -> str | None:
+    """Resolve the default branch without ever touching the network.
+
+    `resolve_default_branch()` falls back to `git remote show origin`, which
+    can block on a fetch. Session recording is a hot path, so it stops at the
+    local symbolic ref and the two conventional names.
+    """
+    rc, out, _ = run_git(
+        ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+        cwd=repo_root,
+        timeout=GIT_PROBE_TIMEOUT,
+    )
+    if rc == 0 and out.strip():
+        return out.strip().rsplit("/", 1)[-1]
+    for candidate in ("main", "master"):
+        if branch_exists_locally(candidate, repo_root):
+            return candidate
+    return None
+
+
+def _convergence_refs(repo_root: Path) -> list[str]:
+    """Refs whose recorded workspace state must be folded into the counter.
+
+    Ordered by how much they matter, then capped: HEAD and the default branch
+    first (the merge target every branch eventually meets), then every other
+    local head — a parallel worktree's branch lives there and is the case that
+    actually collided — then remote-tracking refs.
+    """
+    refs: list[str] = []
+
+    def add(ref: str) -> None:
+        if ref not in refs:
+            refs.append(ref)
+
+    rc, _, _ = run_git(["rev-parse", "--verify", "--quiet", "HEAD"], cwd=repo_root)
+    if rc == 0:
+        add("HEAD")
+
+    default = _default_branch_local(repo_root)
+    if default:
+        for ref in (f"refs/heads/{default}", f"refs/remotes/origin/{default}"):
+            rc, _, _ = run_git(
+                ["show-ref", "--verify", "--quiet", ref], cwd=repo_root
+            )
+            if rc == 0:
+                add(ref)
+
+    for pattern in ("refs/heads/", "refs/remotes/"):
+        rc, out, _ = run_git(
+            ["for-each-ref", "--format=%(refname)", pattern],
+            cwd=repo_root,
+            timeout=GIT_PROBE_TIMEOUT,
+        )
+        if rc != 0:
+            continue
+        for line in out.splitlines():
+            ref = line.strip()
+            # A symbolic ref like refs/remotes/origin/HEAD is a duplicate of
+            # the branch it points at and git grep rejects some of them.
+            if ref and not ref.endswith("/HEAD"):
+                add(ref)
+
+    return refs[:MAX_CONVERGENCE_REFS]
+
+
+def _max_session_across_refs(repo_root: Path, refs: list[str], dev_rel: str) -> int:
+    """Highest session number recorded under `dev_rel` in any of `refs`.
+
+    One `git grep` over every ref rather than an ls-tree + show per ref: the
+    number of branches in a real repo is unbounded, the per-ref cost is not.
+    Exit status 1 (no match) is a normal outcome, not an error.
+    """
+    if not refs:
+        return 0
+
+    rc, out, _ = run_git(
+        [
+            "grep",
+            "--no-color",
+            "-h",
+            "-E",
+            "-e",
+            r"^## Session [0-9]+:",
+            "-e",
+            r"Total Sessions",
+        ]
+        + refs
+        + ["--", dev_rel],
+        cwd=repo_root,
+        timeout=GIT_PROBE_TIMEOUT,
+    )
+    if rc > 1 or not out:
+        return 0
+
+    # `git grep` prefixes each hit with `<rev>:<path>:`, so the numbers are
+    # matched anywhere in the line rather than anchored.
+    numbers = [int(m.group(1)) for m in re.finditer(r"## Session (\d+):", out)]
+    numbers += [
+        int(m.group(1)) for m in re.finditer(r"Total Sessions[^\d]{0,8}(\d+)", out)
+    ]
+    return max(numbers) if numbers else 0
+
+
+def max_local_session(dev_dir: Path, index_file: Path) -> int:
+    """Highest session number visible in the working tree."""
+    highest = get_current_session(index_file)
+    for f in dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md"):
+        if not f.is_file():
+            continue
+        try:
+            content = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        highest = max(highest, _max_session_in_journal(content))
+    return highest
+
+
+def resolve_next_session(repo_root: Path, dev_dir: Path, index_file: Path) -> int:
+    """Next session number, converged across the local tree and other branches.
+
+    Deriving the number from the working tree alone lets two branches that
+    each record before merging claim the same number (observed twice on
+    2026-08-06). Taking the union with every recorded ref — the default
+    branch, and the other local heads a parallel worktree records on — makes
+    the number monotonic across concurrent branches; `journal-*.md`
+    merge=union then keeps both entries when the branches meet.
+    """
+    highest = max_local_session(dev_dir, index_file)
+
+    dev_rel = _repo_relative(repo_root, dev_dir)
+    if dev_rel:
+        highest = max(
+            highest,
+            _max_session_across_refs(
+                repo_root, _convergence_refs(repo_root), dev_rel
+            ),
+        )
+
+    return highest + 1
+
+
+# =============================================================================
+# Pending-record classifier (R3/R4)
+# =============================================================================
+
+def find_marker_entries(dev_dir: Path, marker: str) -> list[tuple[Path, int | None]]:
+    """Locate every journal entry carrying `marker`.
+
+    Returns (journal_file, session_number); the number is None when the marker
+    is not directly under a `## Session N:` heading, which is malformed
+    pending evidence and must never be guessed into completion.
+    """
+    hits: list[tuple[Path, int | None]] = []
+    for f in sorted(dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md")):
+        if not f.is_file():
+            continue
+        try:
+            lines = f.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            if line.strip() != marker:
+                continue
+            session_num: int | None = None
+            for j in range(i - 1, max(-1, i - 4), -1):
+                match = SESSION_HEADING_RE.match(lines[j])
+                if match:
+                    session_num = int(match.group(1))
+                    break
+            hits.append((f, session_num))
+    return hits
+
+
+def content_at_head(repo_root: Path, path: Path) -> str | None:
+    """File content as committed at HEAD, or None when it isn't there.
+
+    The `./` prefix makes the path cwd-relative. `HEAD:<path>` alone is
+    relative to the *git* toplevel, which is not always `repo_root` — the
+    Trellis root is the nearest directory holding `.trellis/`, which can sit
+    below the git root. Without it, every lookup in that layout fails and a
+    committed record looks pending.
+    """
+    rel = _repo_relative(repo_root, path)
+    if not rel:
+        return None
+    rc, out, _ = run_git(["show", f"HEAD:./{rel}"], cwd=repo_root)
+    return out if rc == 0 else None
+
+
+def index_has_session_row(index_file: Path, session_num: int) -> bool:
+    """Whether the session-history block already holds this session's row."""
+    if not index_file.is_file():
+        return False
+    try:
+        lines = index_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+
+    row_re = re.compile(r"^\|\s*%d\s*\|" % session_num)
+    in_history = False
+    for line in lines:
+        if "@@@auto:session-history" in line:
+            in_history = True
+            continue
+        if "@@@/auto:session-history" in line:
+            in_history = False
+            continue
+        if in_history and row_re.match(line):
+            return True
+    return False
+
+
+def _entry_date_at(lines: list[str], marker_index: int) -> str | None:
+    """The `**Date**:` value belonging to the entry whose marker is at `marker_index`.
+
+    `generate_session_content` renders it two lines below the marker. Scanning
+    a short window rather than a fixed offset keeps this working if blank-line
+    spacing around the header ever changes, and stops well before it could
+    reach the next entry.
+    """
+    for line in lines[marker_index + 1:marker_index + 6]:
+        match = ENTRY_DATE_RE.match(line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def resolve_effective_marker(
+    dev_dir: Path,
+    payload: dict,
+    marker: str,
+) -> tuple[str, str | None]:
+    """The marker this record actually carries, across both schemes.
+
+    Returns (marker, error). The v2 marker wins whenever an entry carries it,
+    which is every record written since the change and costs one scan.
+
+    Otherwise this looks for a pending record written under v1. Those markers
+    are only a hash, but the entry renders its own `**Date**:` line right
+    below, so the date that produced the v1 fingerprint is recoverable from
+    the entry itself: recompute with that date and compare against what is
+    actually written there. That is exact, and unlike a +/-1 day window it does
+    not quietly fail a retry resumed after a weekend.
+
+    Returning the v1 marker leaves the entry untouched — it is an in-flight
+    record about to be committed, and rewriting its marker mid-repair would
+    move it to a state the machine does not model.
+    """
+    if find_marker_entries(dev_dir, marker):
+        return marker, None
+
+    matches: set[str] = set()
+    for journal in sorted(dev_dir.glob(f"{FILE_JOURNAL_PREFIX}*.md")):
+        if not journal.is_file():
+            continue
+        try:
+            lines = journal.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            legacy = LEGACY_MARKER_RE.match(line.strip())
+            if not legacy:
+                continue
+            date = _entry_date_at(lines, i)
+            if date is None:
+                continue
+            if compute_legacy_fingerprint(payload, date) == legacy.group(1):
+                matches.add(line.strip())
+
+    if len(matches) > 1:
+        return "", (
+            f"found {len(matches)} pending journal entries matching this record "
+            "under the pre-versioning marker scheme. Refusing to guess which one "
+            "to resume — remove the duplicate entry or pass --idempotency-key to "
+            "record a new session."
+        )
+    if matches:
+        return matches.pop(), None
+    return marker, None
+
+
+def classify_record(
+    repo_root: Path,
+    dev_dir: Path,
+    index_file: Path,
+    marker: str,
+) -> tuple[str, Path | None, int | None, str | None]:
+    """Classify the current state of this exact record.
+
+    Returns (state, journal_file, session_num, error). Only a unique, exact,
+    still-uncommitted match is ever adopted; anything ambiguous, malformed or
+    partially written comes back as an error so the caller fails safely.
+    """
+    hits = find_marker_entries(dev_dir, marker)
+
+    if not hits:
+        return STATE_ABSENT, None, None, None
+
+    if len(hits) > 1:
+        files = ", ".join(sorted({p.name for p, _ in hits}))
+        return "", None, None, (
+            f"found {len(hits)} journal entries carrying this record's marker "
+            f"({files}). Refusing to guess which one to resume — remove the "
+            "duplicate entry or pass --idempotency-key to record a new session."
+        )
+
+    journal_file, session_num = hits[0]
+    if session_num is None:
+        return "", None, None, (
+            f"{journal_file.name} carries this record's marker without a "
+            "'## Session N:' heading above it. The pending record is malformed; "
+            "repair it by hand before retrying."
+        )
+
+    head_content = content_at_head(repo_root, journal_file)
+    if head_content is not None and marker in head_content:
+        return STATE_COMMITTED, journal_file, session_num, None
+
+    if index_has_session_row(index_file, session_num):
+        return STATE_INDEX_RECORDED, journal_file, session_num, None
+
+    recorded_total = get_current_session(index_file)
+    if recorded_total > session_num:
+        return "", None, None, (
+            f"journal entry for session {session_num} has no index row, but "
+            f"index.md already counts {recorded_total} sessions. Repairing the "
+            "row would rewrite a later record — resolve index.md by hand."
+        )
+
+    return STATE_JOURNAL_RECORDED, journal_file, session_num, None
+
+
+# =============================================================================
+# Rendering
+# =============================================================================
 
 def _render_bullet_section(header: str, items: list[str], bullet_prefix: str = "- ") -> str:
     """Render a Markdown section as bullets, or "" when there is no content.
@@ -267,9 +892,10 @@ def _render_main_changes(changes: list[str], extra_content: str | None) -> str:
 def generate_session_content(
     session_num: int,
     title: str,
-    commit: str,
+    evidence: list[tuple[str, str]],
     summary: str,
     today: str,
+    marker: str,
     package: str | None = None,
     branch: str | None = None,
     changes: list[str] | None = None,
@@ -278,12 +904,11 @@ def generate_session_content(
     next_steps: list[str] | None = None,
 ) -> str:
     """Generate session content."""
-    if commit and commit != "-":
+    if evidence:
         commit_table = """| Hash | Message |
 |------|---------|"""
-        for c in commit.split(","):
-            c = c.strip()
-            commit_table += f"\n| `{c}` | (see git log) |"
+        for oid, subject in evidence:
+            commit_table += f"\n| `{oid}` | {escape_markdown_cell(subject)} |"
     else:
         commit_table = "(No commits - planning session)"
 
@@ -297,6 +922,7 @@ def generate_session_content(
     return f"""
 
 ## Session {session_num}: {title}
+{marker}
 
 **Date**: {today}
 **Task**: {title}{package_line}{branch_line}
@@ -315,21 +941,25 @@ def generate_session_content(
 """
 
 
+def format_commit_display(evidence: list[tuple[str, str]]) -> str:
+    """Index-table rendering of the commit OIDs."""
+    if not evidence:
+        return "-"
+    return ", ".join(f"`{oid}`" for oid, _ in evidence)
+
+
 def update_index(
     index_file: Path,
     dev_dir: Path,
     title: str,
-    commit: str,
+    evidence: list[tuple[str, str]],
     new_session: int,
     active_file: str,
     today: str,
     branch: str | None = None,
 ) -> bool:
     """Update index.md with new session info."""
-    # Format commit for display
-    commit_display = "-"
-    if commit and commit != "-":
-        commit_display = re.sub(r"([a-f0-9]{7,})", r"`\1`", commit.replace(",", ", "))
+    commit_display = format_commit_display(evidence)
 
     # Get file number from active_file name
     match = re.search(r"(\d+)", active_file)
@@ -425,7 +1055,9 @@ def update_index(
 
         new_lines.append(line)
 
-    index_file.write_text("\n".join(new_lines), encoding="utf-8")
+    if not write_text_atomic(index_file, "\n".join(new_lines)):
+        print(f"Error: failed to write {index_file}", file=sys.stderr)
+        return False
     print("[OK] Updated index.md successfully!")
     return True
 
@@ -434,7 +1066,7 @@ def update_index(
 # Main Function
 # =============================================================================
 
-def _auto_commit_workspace(repo_root: Path) -> None:
+def _auto_commit_workspace(repo_root: Path) -> str:
     """Stage Trellis-owned workspace + current-task paths and commit.
 
     Path scope is restricted to specific products: the current developer's
@@ -447,13 +1079,30 @@ def _auto_commit_workspace(repo_root: Path) -> None:
     Honors ``session_auto_commit`` in ``.trellis/config.yaml``: when set to
     ``false``, this function returns immediately without touching git
     (journal/index files are still written to disk by the caller).
+
+    Returns one of ``COMMIT_DONE`` / ``COMMIT_SKIPPED`` / ``COMMIT_BLOCKED`` /
+    ``COMMIT_FAILED``. ``COMMIT_BLOCKED`` is the gitignored-`.trellis/` case:
+    the user has told git to stay out of this tree, so it is a configured skip
+    like ``session_auto_commit: false``, not a failure to retry.
     """
     if not get_session_auto_commit(repo_root):
         print(
             "[OK] session_auto_commit: false — skipping git stage/commit.",
             file=sys.stderr,
         )
-        return
+        return COMMIT_SKIPPED
+
+    # Not a git repository at all: like the gitignored case, this is an
+    # environment the user configured, not a transient git error — a retry
+    # can never succeed, so it must not be COMMIT_FAILED's exit-1 loop.
+    rc, _, _ = run_git(["rev-parse", "--is-inside-work-tree"], cwd=repo_root)
+    if rc != 0:
+        print(
+            "[WARN] Not a git repository — journal/index written, "
+            "skipping auto-commit.",
+            file=sys.stderr,
+        )
+        return COMMIT_BLOCKED
 
     commit_msg = get_session_commit_message(repo_root)
     # Resolve the current task so staging is scoped to its dir only. The ref
@@ -475,18 +1124,18 @@ def _auto_commit_workspace(repo_root: Path) -> None:
         ]
     if not paths:
         print("[OK] No workspace changes to commit.", file=sys.stderr)
-        return
+        return COMMIT_SKIPPED
 
     success, _, err = safe_git_add(paths, repo_root)
     if not success:
         if err and "ignored by" in err.lower():
             print_gitignore_warning(paths)
-        else:
-            print(
-                f"[WARN] git add failed: {err.strip() if err else 'unknown error'}",
-                file=sys.stderr,
-            )
-        return
+            return COMMIT_BLOCKED
+        print(
+            f"[WARN] git add failed: {err.strip() if err else 'unknown error'}",
+            file=sys.stderr,
+        )
+        return COMMIT_FAILED
 
     # Check if there are staged changes for the paths we just staged.
     rc, _, _ = run_git(
@@ -494,16 +1143,39 @@ def _auto_commit_workspace(repo_root: Path) -> None:
     )
     if rc == 0:
         print("[OK] No workspace changes to commit.", file=sys.stderr)
-        return
+        return COMMIT_SKIPPED
 
     rc, _, commit_err = run_git(["commit", "-m", commit_msg], cwd=repo_root)
     if rc == 0:
         print(f"[OK] Auto-committed: {commit_msg}", file=sys.stderr)
-    else:
-        print(
-            f"[WARN] Auto-commit failed: {commit_err.strip()}",
-            file=sys.stderr,
-        )
+        return COMMIT_DONE
+
+    print(
+        f"[WARN] Auto-commit failed: {commit_err.strip()}",
+        file=sys.stderr,
+    )
+    return COMMIT_FAILED
+
+
+def _print_commit_checkpoint(session_num: int, journal_name: str) -> None:
+    """Actionable checkpoint for a failed auto-commit (R5)."""
+    print("", file=sys.stderr)
+    print(
+        f"[BLOCKED] Checkpoint: session {session_num} is recorded in "
+        f"{journal_name} and index.md, but the auto-commit did not complete.",
+        file=sys.stderr,
+    )
+    print(
+        "[BLOCKED] The pending record was left exactly as written — nothing was "
+        "rolled back.",
+        file=sys.stderr,
+    )
+    print(
+        "[BLOCKED] Fix the git error above, then re-run the identical "
+        "add_session.py command: it resumes at the commit step and will not add "
+        "a second session.",
+        file=sys.stderr,
+    )
 
 
 def add_session(
@@ -517,8 +1189,10 @@ def add_session(
     auto_commit: bool = True,
     package: str | None = None,
     branch: str | None = None,
+    commit_subjects: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> int:
-    """Add a new session."""
+    """Add a new session, resuming an interrupted one instead of duplicating it."""
     repo_root = get_repo_root()
     warn_if_parallel_worktree(repo_root)
     ensure_developer(repo_root)
@@ -533,66 +1207,188 @@ def add_session(
         print("Error: Workspace directory not found", file=sys.stderr)
         return 1
 
-    max_lines = get_max_journal_lines(repo_root)
+    # -------------------------------------------------------------------
+    # Preflight — no writes happen until every one of these succeeds.
+    # -------------------------------------------------------------------
+    if idempotency_key is not None and not IDEMPOTENCY_KEY_RE.match(idempotency_key):
+        print(
+            f"Error: invalid --idempotency-key '{idempotency_key}': expected 1-64 "
+            "characters from [A-Za-z0-9._-]",
+            file=sys.stderr,
+        )
+        return 1
 
+    tokens, token_error = parse_commit_tokens(commit)
+    if token_error:
+        print(f"Error: {token_error}", file=sys.stderr)
+        return 1
+
+    overrides, override_error = parse_subject_overrides(commit_subjects)
+    if override_error:
+        print(f"Error: {override_error}", file=sys.stderr)
+        return 1
+
+    evidence, evidence_error = build_commit_evidence(repo_root, tokens, overrides)
+    if evidence_error:
+        print(f"Error: {evidence_error}", file=sys.stderr)
+        return 1
+
+    max_lines = get_max_journal_lines(repo_root)
     index_file = dev_dir / "index.md"
     today = datetime.now().strftime("%Y-%m-%d")
 
-    journal_file, current_num, current_lines = get_latest_journal_info(dev_dir)
-    current_session = get_current_session(index_file)
-    new_session = current_session + 1
-
-    session_content = generate_session_content(
-        new_session, title, commit, summary, today, package, branch,
-        changes=changes, extra_content=extra_content, tests=tests,
-        next_steps=next_steps,
+    payload = _fingerprint_payload(
+        developer, title, summary, package, branch, evidence,
+        changes, extra_content, tests, next_steps, idempotency_key,
     )
-    content_lines = len(session_content.splitlines())
+    marker = render_marker(compute_record_fingerprint(payload))
+
+    # `today` is no longer a fingerprint input; a record has to be findable by
+    # its own retry after a date rollover. It still dates the rendered entry.
+    marker, resolve_error = resolve_effective_marker(dev_dir, payload, marker)
+    if resolve_error:
+        print(f"Error: {resolve_error}", file=sys.stderr)
+        return 1
+
+    state, matched_file, matched_num, classify_error = classify_record(
+        repo_root, dev_dir, index_file, marker
+    )
+    if classify_error:
+        print(f"Error: {classify_error}", file=sys.stderr)
+        return 1
+
+    if state == STATE_COMMITTED:
+        if idempotency_key:
+            print(
+                f"[OK] Session {matched_num} with idempotency key "
+                f"'{idempotency_key}' is already recorded and committed in "
+                f"{matched_file.name if matched_file else 'the journal'}; "
+                "nothing to do.",
+                file=sys.stderr,
+            )
+            return 0
+        # A committed record is finished. An identical later request is a
+        # legitimately new session, so fall through and append one.
+        state = STATE_ABSENT
+        matched_file = None
+        matched_num = None
 
     print("========================================", file=sys.stderr)
     print("ADD SESSION", file=sys.stderr)
     print("========================================", file=sys.stderr)
     print("", file=sys.stderr)
-    print(f"Session: {new_session}", file=sys.stderr)
-    print(f"Title: {title}", file=sys.stderr)
-    print(f"Commit: {commit}", file=sys.stderr)
-    print("", file=sys.stderr)
-    print(f"Current journal file: {FILE_JOURNAL_PREFIX}{current_num}.md", file=sys.stderr)
-    print(f"Current lines: {current_lines}", file=sys.stderr)
-    print(f"New content lines: {content_lines}", file=sys.stderr)
-    print(f"Total after append: {current_lines + content_lines}", file=sys.stderr)
-    print("", file=sys.stderr)
 
-    target_file = journal_file
-    target_num = current_num
+    # -------------------------------------------------------------------
+    # Absent → journal-recorded
+    # -------------------------------------------------------------------
+    target_file: Path | None
+    target_num: int
+    new_session: int
 
-    if current_lines + content_lines > max_lines:
-        target_num = current_num + 1
-        print(f"[!] Exceeds {max_lines} lines, creating {FILE_JOURNAL_PREFIX}{target_num}.md", file=sys.stderr)
-        target_file = create_new_journal_file(dev_dir, target_num, developer, today, max_lines)
-        print(f"Created: {target_file}", file=sys.stderr)
+    if state == STATE_ABSENT:
+        journal_file, current_num, current_lines = get_latest_journal_info(dev_dir)
+        new_session = resolve_next_session(repo_root, dev_dir, index_file)
 
-    # Append session content
-    if target_file:
-        with target_file.open("a", encoding="utf-8") as f:
-            f.write(session_content)
+        session_content = generate_session_content(
+            new_session, title, evidence, summary, today, marker, package, branch,
+            changes=changes, extra_content=extra_content, tests=tests,
+            next_steps=next_steps,
+        )
+        content_lines = len(session_content.splitlines())
+
+        print(f"Session: {new_session}", file=sys.stderr)
+        print(f"Title: {title}", file=sys.stderr)
+        print(f"Commit: {format_commit_display(evidence)}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"Current journal file: {FILE_JOURNAL_PREFIX}{current_num}.md", file=sys.stderr)
+        print(f"Current lines: {current_lines}", file=sys.stderr)
+        print(f"New content lines: {content_lines}", file=sys.stderr)
+        print(f"Total after append: {current_lines + content_lines}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+        target_file = journal_file
+        target_num = current_num
+
+        if current_lines + content_lines > max_lines:
+            target_num = current_num + 1
+            print(f"[!] Exceeds {max_lines} lines, creating {FILE_JOURNAL_PREFIX}{target_num}.md", file=sys.stderr)
+            target_file = create_new_journal_file(dev_dir, target_num, developer, today, max_lines)
+            if target_file is None:
+                print(
+                    f"Error: failed to create {FILE_JOURNAL_PREFIX}{target_num}.md; "
+                    "nothing was recorded.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Created: {target_file}", file=sys.stderr)
+
+        if target_file is None:
+            print(
+                "Error: no journal file to append to. Run init_developer.py first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            existing = target_file.read_text(encoding="utf-8") if target_file.is_file() else ""
+        except OSError as exc:
+            print(f"Error: cannot read {target_file}: {exc}", file=sys.stderr)
+            return 1
+
+        if not write_text_atomic(target_file, existing + session_content):
+            print(
+                f"Error: failed to append the session to {target_file.name}; "
+                "the previous journal content is intact and nothing was recorded.",
+                file=sys.stderr,
+            )
+            return 1
         print(f"[OK] Appended session to {target_file.name}", file=sys.stderr)
+        state = STATE_JOURNAL_RECORDED
+    else:
+        if matched_file is None or matched_num is None:
+            print(
+                f"Error: resumed state '{state}' without a matching journal entry.",
+                file=sys.stderr,
+            )
+            return 1
+        target_file = matched_file
+        new_session = matched_num
+        target_num = _extract_journal_num(target_file.stem)
+        print(
+            f"[RESUME] Session {new_session} is already in {target_file.name} and "
+            f"uncommitted; continuing from '{state}' instead of appending again.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
 
     print("", file=sys.stderr)
 
-    # Update index.md
+    # -------------------------------------------------------------------
+    # Journal-recorded → index-recorded
+    # -------------------------------------------------------------------
     active_file = f"{FILE_JOURNAL_PREFIX}{target_num}.md"
-    if not update_index(
-        index_file,
-        dev_dir,
-        title,
-        commit,
-        new_session,
-        active_file,
-        today,
-        branch,
-    ):
-        return 1
+    if state == STATE_JOURNAL_RECORDED:
+        if not update_index(
+            index_file,
+            dev_dir,
+            title,
+            evidence,
+            new_session,
+            active_file,
+            today,
+            branch,
+        ):
+            print(
+                f"[BLOCKED] Checkpoint: session {new_session} is in "
+                f"{active_file} but index.md was not updated. Fix index.md, then "
+                "re-run the identical command to repair the row without adding a "
+                "second session.",
+                file=sys.stderr,
+            )
+            return 1
+        state = STATE_INDEX_RECORDED
+    else:
+        print(f"[OK] index.md already records session {new_session}.", file=sys.stderr)
 
     print("", file=sys.stderr)
     print("========================================", file=sys.stderr)
@@ -603,10 +1399,31 @@ def add_session(
     print(f"  - {target_file.name if target_file else 'journal'}", file=sys.stderr)
     print("  - index.md", file=sys.stderr)
 
-    # Auto-commit workspace changes
-    if auto_commit:
-        print("", file=sys.stderr)
-        _auto_commit_workspace(repo_root)
+    # -------------------------------------------------------------------
+    # Index-recorded → committed
+    # -------------------------------------------------------------------
+    if not auto_commit:
+        return 0
+
+    print("", file=sys.stderr)
+    outcome = _auto_commit_workspace(repo_root)
+
+    if outcome == COMMIT_FAILED:
+        _print_commit_checkpoint(
+            new_session, target_file.name if target_file else "the journal"
+        )
+        return 1
+
+    if outcome == COMMIT_DONE and target_file is not None:
+        committed = content_at_head(repo_root, target_file)
+        if committed is None or marker not in committed:
+            print(
+                f"[WARN] Auto-commit reported success but {target_file.name} at "
+                "HEAD does not contain this session's record.",
+                file=sys.stderr,
+            )
+            _print_commit_checkpoint(new_session, target_file.name)
+            return 1
 
     return 0
 
@@ -621,7 +1438,24 @@ def main() -> int:
         description="Add a new session to journal file and update index.md"
     )
     parser.add_argument("--title", required=True, help="Session title")
-    parser.add_argument("--commit", default="-", help="Comma-separated commit hashes")
+    parser.add_argument(
+        "--commit",
+        default="-",
+        help=(
+            "Comma-separated commit OIDs (7-40 hex chars each). Each one is "
+            "resolved to its real subject before anything is written; an "
+            "unresolvable OID fails the command. Use '-' for a planning session."
+        ),
+    )
+    parser.add_argument(
+        "--commit-subject",
+        action="append",
+        metavar="OID=SUBJECT",
+        help=(
+            "Explicit subject for a commit that cannot be resolved locally "
+            "(repeatable). The mapping must be one-to-one with --commit."
+        ),
+    )
     parser.add_argument("--summary", default="Session summary was not supplied.", help="Brief summary")
     parser.add_argument("--content-file", help="Path to file with detailed content")
     parser.add_argument("--package", help="Package name tag (e.g., cli, docs-site)")
@@ -629,6 +1463,13 @@ def main() -> int:
     parser.add_argument("--change", action="append", help="Main Changes bullet (repeatable)")
     parser.add_argument("--test", action="append", help="Testing bullet (repeatable)")
     parser.add_argument("--next-step", action="append", help="Next Steps bullet (repeatable)")
+    parser.add_argument(
+        "--idempotency-key",
+        help=(
+            "Caller-supplied retry key ([A-Za-z0-9._-], 1-64 chars). Makes an "
+            "already-committed identical record a no-op instead of a new session."
+        ),
+    )
     parser.add_argument("--no-commit", action="store_true",
                         help="Skip auto-commit of workspace changes")
     parser.add_argument("--stdin", action="store_true",
@@ -674,6 +1515,8 @@ def main() -> int:
         auto_commit=not args.no_commit,
         package=package,
         branch=branch,
+        commit_subjects=args.commit_subject,
+        idempotency_key=args.idempotency_key,
     )
 
 

--- a/packages/cli/src/templates/trellis/scripts/add_session.py
+++ b/packages/cli/src/templates/trellis/scripts/add_session.py
@@ -496,7 +496,8 @@ def compute_record_fingerprint(payload: dict) -> str:
     date was equal for both of them anyway. Across days it only ever separated
     records with byte-identical prose, commits, branch and package — and a
     *committed* record of that shape is already refused for reuse by
-    cmd_add_session, which maps STATE_COMMITTED to STATE_ABSENT. What is left
+    cmd_add_session, which steps to the next `generation` of the payload
+    rather than reusing the committed marker. What is left
     is exactly the question this key should answer: is there an uncommitted
     record in this worktree matching these inputs?
     """
@@ -1257,21 +1258,36 @@ def add_session(
         print(f"Error: {classify_error}", file=sys.stderr)
         return 1
 
-    if state == STATE_COMMITTED:
-        if idempotency_key:
-            print(
-                f"[OK] Session {matched_num} with idempotency key "
-                f"'{idempotency_key}' is already recorded and committed in "
-                f"{matched_file.name if matched_file else 'the journal'}; "
-                "nothing to do.",
-                file=sys.stderr,
-            )
-            return 0
-        # A committed record is finished. An identical later request is a
-        # legitimately new session, so fall through and append one.
-        state = STATE_ABSENT
-        matched_file = None
-        matched_num = None
+    if state == STATE_COMMITTED and idempotency_key:
+        print(
+            f"[OK] Session {matched_num} with idempotency key "
+            f"'{idempotency_key}' is already recorded and committed in "
+            f"{matched_file.name if matched_file else 'the journal'}; "
+            "nothing to do.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # A committed record is finished, so an identical later request is a
+    # legitimately new session. It must not reuse the committed marker: two
+    # entries carrying one marker make every later run ambiguous, and
+    # classify_record refuses to guess between them. Step to the next
+    # generation of this record instead. The marker stays a pure function of
+    # (payload, generation), so a retry of the new entry recomputes the same
+    # marker and still resumes; generation 0 omits the field entirely, leaving
+    # first-time markers byte-identical to what this scheme already writes.
+    generation = 0
+    while state == STATE_COMMITTED:
+        generation += 1
+        marker = render_marker(
+            compute_record_fingerprint({**payload, "generation": generation})
+        )
+        state, matched_file, matched_num, classify_error = classify_record(
+            repo_root, dev_dir, index_file, marker
+        )
+        if classify_error:
+            print(f"Error: {classify_error}", file=sys.stderr)
+            return 1
 
     print("========================================", file=sys.stderr)
     print("ADD SESSION", file=sys.stderr)

--- a/packages/cli/src/templates/trellis/scripts/common/io.py
+++ b/packages/cli/src/templates/trellis/scripts/common/io.py
@@ -1,8 +1,9 @@
 """
-JSON file I/O utilities.
+File I/O utilities.
 
-Provides read_json and write_json as the single source of truth
-for JSON file operations across all Trellis scripts.
+Provides read_json / write_json as the single source of truth for JSON file
+operations, plus write_text_atomic for the Markdown state files (journal,
+index.md) that carry durable session state.
 """
 
 from __future__ import annotations
@@ -34,7 +35,19 @@ def write_json(path: Path, data: dict) -> bool:
 
     Returns True on success, False on error.
     """
-    payload = json.dumps(data, indent=2, ensure_ascii=False)
+    return write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def write_text_atomic(path: Path, text: str) -> bool:
+    """Write text to a file atomically (temp in same dir, then replace).
+
+    The same never-truncate-in-place guarantee as :func:`write_json`, for the
+    Markdown state files that hold durable session state (journal files,
+    index.md). A crash or Ctrl-C mid-write leaves the previous content intact
+    instead of a half-written record that no retry can classify.
+
+    Returns True on success, False on error.
+    """
     try:
         fd, tmp = tempfile.mkstemp(
             dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
@@ -50,7 +63,7 @@ def write_json(path: Path, data: dict) -> bool:
             os.close(fd)
             raise
         with f:
-            f.write(payload)
+            f.write(text)
         os.replace(tmp, path)
         return True
     except OSError:
@@ -59,3 +72,10 @@ def write_json(path: Path, data: dict) -> bool:
         except OSError:
             pass
         return False
+    except BaseException:
+        # Ctrl-C mid-write: drop the temp file, then let the interrupt through.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/packages/cli/test/scripts/add-session.integration.test.ts
+++ b/packages/cli/test/scripts/add-session.integration.test.ts
@@ -188,6 +188,12 @@ function countMarkers(repo: string, num = 1): number {
   return readJournal(repo, num).split("<!-- trellis-session:").length - 1;
 }
 
+/** Every distinct record marker present in a journal, in order of appearance. */
+function distinctMarkers(repo: string, num = 1): string[] {
+  const seen = readJournal(repo, num).match(/<!-- trellis-session:[^>]*-->/g) ?? [];
+  return [...new Set(seen)];
+}
+
 /** Seed a task + initial commit so HEAD and a current task both exist. */
 function seedTask(repo: string, name = "task-a"): void {
   makeTask(repo, name, `${name} prd\n`);
@@ -759,10 +765,17 @@ describe.skipIf(!hasPython())("add_session.py retry convergence (R2-R5)", () => 
   it("treats an identical request as a new session once the earlier one is committed", () => {
     runAddSession(tmp, "same prose", ["--summary", "identical summary"]);
     runAddSession(tmp, "same prose", ["--summary", "identical summary"]);
+    // A third identical run has to keep working. It would not if the new
+    // entries reused the committed record's marker: classify_record refuses
+    // to resume once a marker matches more than one entry.
+    runAddSession(tmp, "same prose", ["--summary", "identical summary"]);
 
-    expect(sessionNumbers(tmp)).toEqual([1, 2]);
-    expect(countMarkers(tmp)).toBe(2);
-    expect(readIndex(tmp)).toContain("**Total Sessions**: 2");
+    expect(sessionNumbers(tmp)).toEqual([1, 2, 3]);
+    expect(countMarkers(tmp)).toBe(3);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 3");
+    // Each generation carries its own marker; duplicates would make every
+    // later run ambiguous.
+    expect(distinctMarkers(tmp).length).toBe(3);
   });
 
   it("makes a committed record a no-op when the caller supplies an idempotency key", () => {

--- a/packages/cli/test/scripts/add-session.integration.test.ts
+++ b/packages/cli/test/scripts/add-session.integration.test.ts
@@ -1,10 +1,11 @@
 /**
- * Integration test for `add_session.py` auto-commit scope.
+ * Integration test for `add_session.py` auto-commit scope and for the
+ * recording state machine (commit evidence, retry convergence, numbering).
  *
  * The python script lives under
  * `src/templates/trellis/scripts/add_session.py`; this test stamps the real
  * templates into a fresh git repo and exercises the actual `python3
- * add_session.py` auto-commit path.
+ * add_session.py` paths — no source-string assertions.
  *
  * Scope-creep guard (#303): the session auto-commit must stage ONLY the
  * current developer's journal/index + the CURRENT task dir. Dirty changes in
@@ -50,6 +51,12 @@ function setupRepo(tmp: string): void {
   git(tmp, "init", "-q", "-b", "main");
   git(tmp, "config", "user.email", "test@example.com");
   git(tmp, "config", "user.name", "Test");
+  stampTrellis(tmp);
+}
+
+/** Create the `.trellis/` tree and developer state at `tmp`, without git. */
+function stampTrellis(tmp: string): void {
+  fs.mkdirSync(tmp, { recursive: true });
 
   // Stamp the real templates into the test repo.
   const scriptsDest = path.join(tmp, ".trellis", "scripts");
@@ -123,15 +130,81 @@ function setCurrentTask(repo: string, taskName: string): void {
   );
 }
 
-function runAddSession(repo: string, title: string, extraArgs: string[] = []): void {
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run the script and return its outcome without asserting on it. */
+function tryAddSession(
+  repo: string,
+  title: string,
+  extraArgs: string[] = [],
+): RunResult {
   const r = spawnSync(
     "python3",
     [".trellis/scripts/add_session.py", "--title", title, ...extraArgs],
     { cwd: repo, encoding: "utf-8" },
   );
+  return {
+    status: r.status ?? -1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+function runAddSession(repo: string, title: string, extraArgs: string[] = []): void {
+  const r = tryAddSession(repo, title, extraArgs);
   if (r.status !== 0) {
     throw new Error(`add_session failed: ${r.stderr}`);
   }
+}
+
+function journalPath(repo: string, num = 1): string {
+  return path.join(repo, ".trellis", "workspace", DEVELOPER, `journal-${num}.md`);
+}
+
+function indexPath(repo: string): string {
+  return path.join(repo, ".trellis", "workspace", DEVELOPER, "index.md");
+}
+
+function readJournal(repo: string, num = 1): string {
+  return fs.readFileSync(journalPath(repo, num), "utf-8");
+}
+
+function readIndex(repo: string): string {
+  return fs.readFileSync(indexPath(repo), "utf-8");
+}
+
+/** Session numbers recorded as `## Session N:` headings, in file order. */
+function sessionNumbers(repo: string, num = 1): number[] {
+  return [...readJournal(repo, num).matchAll(/^## Session (\d+):/gm)].map((m) =>
+    Number(m[1]),
+  );
+}
+
+function countMarkers(repo: string, num = 1): number {
+  return readJournal(repo, num).split("<!-- trellis-session:").length - 1;
+}
+
+/** Seed a task + initial commit so HEAD and a current task both exist. */
+function seedTask(repo: string, name = "task-a"): void {
+  makeTask(repo, name, `${name} prd\n`);
+  setCurrentTask(repo, name);
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "initial");
+}
+
+/** Install a pre-commit hook that always fails, to break the commit step. */
+function breakCommits(repo: string): void {
+  const hook = path.join(repo, ".git", "hooks", "pre-commit");
+  fs.mkdirSync(path.dirname(hook), { recursive: true });
+  fs.writeFileSync(hook, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+}
+
+function repairCommits(repo: string): void {
+  fs.rmSync(path.join(repo, ".git", "hooks", "pre-commit"), { force: true });
 }
 
 describe.skipIf(!hasPython())("add_session.py auto-commit", () => {
@@ -309,5 +382,636 @@ describe.skipIf(!hasPython())("add_session.py auto-commit", () => {
     const status = git(tmp, "status", "--porcelain");
     expect(status).toMatch(/\.trellis\/tasks\/task-a\/prd\.md/);
     expect(status).toMatch(/\.trellis\/tasks\/task-b\/prd\.md/);
+  });
+
+  it("stages only Trellis-owned paths in the session auto-commit", () => {
+    seedTask(tmp);
+    fs.writeFileSync(path.join(tmp, "unrelated.txt"), "user work in progress\n");
+
+    runAddSession(tmp, "scoped staging");
+
+    const lastFiles = git(tmp, "show", "HEAD", "--name-only", "--pretty=format:")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    expect(lastFiles.length).toBeGreaterThan(0);
+    for (const f of lastFiles) {
+      expect(f.startsWith(".trellis/"), `unexpected path in commit: ${f}`).toBe(
+        true,
+      );
+    }
+    expect(git(tmp, "status", "--porcelain")).toContain("unrelated.txt");
+  });
+});
+
+describe.skipIf(!hasPython())("add_session.py commit evidence (R1)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-evidence-"));
+    setupRepo(tmp);
+    seedTask(tmp);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("renders the real local commit subject, never a (see git log) placeholder", () => {
+    const head = git(tmp, "rev-parse", "HEAD");
+
+    runAddSession(tmp, "evidence work", ["--commit", head]);
+
+    const journal = readJournal(tmp);
+    expect(journal).toContain(`| \`${head}\` | initial |`);
+    expect(journal).not.toContain("(see git log)");
+    expect(journal).not.toContain("(Add details)");
+    expect(journal).not.toContain("(Add test results)");
+  });
+
+  it("resolves each of several commits to its own subject", () => {
+    fs.writeFileSync(path.join(tmp, "a.txt"), "a\n");
+    git(tmp, "add", "a.txt");
+    git(tmp, "commit", "-q", "-m", "feat: add a");
+    const first = git(tmp, "rev-parse", "HEAD");
+    fs.writeFileSync(path.join(tmp, "b.txt"), "b\n");
+    git(tmp, "add", "b.txt");
+    git(tmp, "commit", "-q", "-m", "fix: correct b");
+    const second = git(tmp, "rev-parse", "HEAD");
+
+    runAddSession(tmp, "two commits", ["--commit", `${first},${second}`]);
+
+    const journal = readJournal(tmp);
+    expect(journal).toContain(`| \`${first}\` | feat: add a |`);
+    expect(journal).toContain(`| \`${second}\` | fix: correct b |`);
+  });
+
+  it("fails before any journal or index write when an OID cannot be resolved", () => {
+    const journalBefore = fs.readFileSync(journalPath(tmp));
+    const indexBefore = fs.readFileSync(indexPath(tmp));
+    const logBefore = git(tmp, "log", "--oneline");
+
+    const r = tryAddSession(tmp, "unresolvable", ["--commit", "deadbeef"]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("cannot resolve commit evidence for: deadbeef");
+    expect(r.stderr).toContain("--commit-subject");
+    expect(fs.readFileSync(journalPath(tmp)).equals(journalBefore)).toBe(true);
+    expect(fs.readFileSync(indexPath(tmp)).equals(indexBefore)).toBe(true);
+    expect(git(tmp, "log", "--oneline")).toBe(logBefore);
+  });
+
+  it("rejects a --commit token that is not a bounded hex OID", () => {
+    const journalBefore = fs.readFileSync(journalPath(tmp));
+
+    const r = tryAddSession(tmp, "bad token", ["--commit", "HEAD~1"]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("invalid --commit token 'HEAD~1'");
+    expect(fs.readFileSync(journalPath(tmp)).equals(journalBefore)).toBe(true);
+  });
+
+  it("accepts an explicit one-to-one subject mapping and escapes it for the table", () => {
+    const r = tryAddSession(tmp, "mapped evidence", [
+      "--commit",
+      "deadbeef",
+      "--commit-subject",
+      "deadbeef=feat: pipe | and \\ in the subject",
+    ]);
+
+    expect(r.status).toBe(0);
+    const journal = readJournal(tmp);
+    // The cell keeps one row: `|` and `\` are escaped rather than splitting it.
+    expect(journal).toContain(
+      "| `deadbeef` | feat: pipe \\| and \\\\ in the subject |",
+    );
+    expect(readIndex(tmp)).toContain("`deadbeef`");
+  });
+
+  it("refuses a --commit-subject that is not one-to-one with --commit", () => {
+    const journalBefore = fs.readFileSync(journalPath(tmp));
+
+    const r = tryAddSession(tmp, "extra mapping", [
+      "--commit",
+      "deadbeef",
+      "--commit-subject",
+      "deadbeef=real subject",
+      "--commit-subject",
+      "cafebabe=subject for an OID nobody asked about",
+    ]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("not in --commit");
+    expect(fs.readFileSync(journalPath(tmp)).equals(journalBefore)).toBe(true);
+  });
+
+  it("keeps the planning-session rendering for --commit -", () => {
+    runAddSession(tmp, "planning work", ["--commit", "-"]);
+
+    const journal = readJournal(tmp);
+    expect(journal).toContain("(No commits - planning session)");
+    expect(journal).not.toContain("| Hash | Message |");
+    expect(readIndex(tmp)).toMatch(/\|\s*1\s*\|.*\|\s*-\s*\|/);
+  });
+
+  it("rejects an out-of-shape --idempotency-key before writing", () => {
+    const journalBefore = fs.readFileSync(journalPath(tmp));
+
+    const r = tryAddSession(tmp, "bad key", ["--idempotency-key", "not ok!"]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("invalid --idempotency-key");
+    expect(fs.readFileSync(journalPath(tmp)).equals(journalBefore)).toBe(true);
+  });
+});
+
+/**
+ * Marker as the two schemes render it, for the same record inputs.
+ *
+ * Reconstructs the fingerprint payload the way `cmd_add_session` builds it,
+ * by importing the real module — so the v1 form is produced by the shipped
+ * `compute_legacy_fingerprint`, not by a copy of it here. The caller asserts
+ * that `v2` matches what is actually in the journal before trusting `v1`; if
+ * this reconstruction ever drifts from the command, that check fails loudly
+ * instead of the test quietly passing on a marker nothing would have written.
+ */
+function markersFor(
+  repo: string,
+  title: string,
+  summary: string,
+  branch: string,
+  legacyDate: string,
+): { v2: string; v1: string } {
+  const harness = [
+    "import sys, json",
+    `sys.path.insert(0, ${JSON.stringify(".trellis/scripts")})`,
+    "import add_session as a",
+    "payload = a._fingerprint_payload(",
+    `    ${JSON.stringify(DEVELOPER)}, ${JSON.stringify(title)},`,
+    `    ${JSON.stringify(summary)}, None, ${JSON.stringify(branch)},`,
+    "    [], None, None, None, None, None,",
+    ")",
+    "print(json.dumps({",
+    "  'v2': a.render_marker(a.compute_record_fingerprint(payload)),",
+    `  'v1': a.render_legacy_marker(a.compute_legacy_fingerprint(payload, ${JSON.stringify(legacyDate)})),`,
+    "}))",
+  ].join("\n");
+  const r = spawnSync("python3", ["-c", harness], {
+    cwd: repo,
+    encoding: "utf-8",
+  });
+  if (r.status !== 0) {
+    throw new Error(`marker harness failed: ${r.stderr}`);
+  }
+  return JSON.parse(r.stdout);
+}
+
+/** Rewrite the pending entry into the pre-versioning marker scheme. */
+function downgradeToLegacyMarker(
+  repo: string,
+  v2Marker: string,
+  v1Marker: string,
+  legacyDate: string,
+): void {
+  const before = readJournal(repo);
+  expect(before).toContain(v2Marker);
+  fs.writeFileSync(
+    journalPath(repo),
+    before
+      .replace(v2Marker, v1Marker)
+      .replace(/^\*\*Date\*\*: \d{4}-\d{2}-\d{2}$/m, `**Date**: ${legacyDate}`),
+  );
+}
+
+describe.skipIf(!hasPython())("add_session.py fingerprint date rollover", () => {
+  let tmp: string;
+  const TITLE = "rollover run";
+  const SUMMARY = "interrupted before the commit";
+  const BRANCH = "main";
+  const ARGS = ["--summary", SUMMARY, "--branch", BRANCH];
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-rollover-"));
+    setupRepo(tmp);
+    seedTask(tmp);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("resumes a record written yesterday under the pre-versioning scheme", () => {
+    // Interrupt after the journal and index writes, before the commit.
+    breakCommits(tmp);
+    const first = tryAddSession(tmp, TITLE, ARGS);
+    expect(first.status).toBe(1);
+    expect(first.stderr).toContain("Auto-commit failed");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    // Stage what a pre-change run would have left behind on an earlier day.
+    const { v2, v1 } = markersFor(tmp, TITLE, SUMMARY, BRANCH, "2020-01-01");
+    downgradeToLegacyMarker(tmp, v2, v1, "2020-01-01");
+
+    repairCommits(tmp);
+    const second = tryAddSession(tmp, TITLE, ARGS);
+
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("[RESUME]");
+    // The record was found and finished — not appended a second time.
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(countMarkers(tmp)).toBe(1);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 1");
+    // Its marker is left as written; an in-flight entry is not rewritten.
+    expect(readJournal(tmp)).toContain(v1);
+  });
+
+  it("resolves a same-day legacy marker too, not just one across a rollover", () => {
+    breakCommits(tmp);
+    expect(tryAddSession(tmp, TITLE, ARGS).status).toBe(1);
+
+    const today = readJournal(tmp).match(/^\*\*Date\*\*: (\d{4}-\d{2}-\d{2})$/m);
+    if (!today) throw new Error("journal entry carries no **Date** line");
+    const date = today[1];
+    const { v2, v1 } = markersFor(tmp, TITLE, SUMMARY, BRANCH, date);
+    downgradeToLegacyMarker(tmp, v2, v1, date);
+
+    repairCommits(tmp);
+    const second = tryAddSession(tmp, TITLE, ARGS);
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("[RESUME]");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(countMarkers(tmp)).toBe(1);
+  });
+
+  it("does not adopt a legacy entry whose inputs differ", () => {
+    breakCommits(tmp);
+    expect(tryAddSession(tmp, TITLE, ARGS).status).toBe(1);
+    const { v2, v1 } = markersFor(tmp, TITLE, SUMMARY, BRANCH, "2020-01-01");
+    downgradeToLegacyMarker(tmp, v2, v1, "2020-01-01");
+    repairCommits(tmp);
+
+    // A different summary is a different record; resuming it would be wrong.
+    const other = tryAddSession(tmp, TITLE, [
+      "--summary",
+      "a genuinely different session",
+      "--branch",
+      BRANCH,
+    ]);
+    expect(other.status).toBe(0);
+    expect(sessionNumbers(tmp)).toEqual([1, 2]);
+    expect(countMarkers(tmp)).toBe(2);
+  });
+
+  it("keeps two same-day sessions distinct now that the date is not an input", () => {
+    runAddSession(tmp, "first session", ["--summary", "one", "--branch", BRANCH]);
+    runAddSession(tmp, "second session", ["--summary", "two", "--branch", BRANCH]);
+    expect(sessionNumbers(tmp)).toEqual([1, 2]);
+    expect(countMarkers(tmp)).toBe(2);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 2");
+  });
+
+  it("writes the versioned marker form", () => {
+    runAddSession(tmp, TITLE, ARGS);
+    expect(readJournal(tmp)).toMatch(
+      /^<!-- trellis-session: v=2 fp=[0-9a-f]{16} -->$/m,
+    );
+  });
+});
+
+describe.skipIf(!hasPython())("add_session.py retry convergence (R2-R5)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-retry-"));
+    setupRepo(tmp);
+    seedTask(tmp);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("repairs the index row on retry when the index update failed after the append", () => {
+    const indexBefore = fs.readFileSync(indexPath(tmp), "utf-8");
+    // Break the auto-update markers so update_index refuses, after the journal
+    // append has already landed.
+    fs.writeFileSync(
+      indexPath(tmp),
+      indexBefore.replace("@@@auto:current-status", "BROKEN-MARKER"),
+    );
+
+    const first = tryAddSession(tmp, "index fault", ["--summary", "fault run"]);
+    expect(first.status).toBe(1);
+    expect(first.stderr).toContain("Markers not found in index.md");
+    expect(first.stderr).toContain("[BLOCKED] Checkpoint:");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    // Repair the index and re-run the identical command.
+    fs.writeFileSync(indexPath(tmp), indexBefore);
+    const second = tryAddSession(tmp, "index fault", ["--summary", "fault run"]);
+
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("[RESUME]");
+    expect(second.stderr).toContain("journal-recorded");
+    // No second entry, and the row for session 1 is now present.
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(countMarkers(tmp)).toBe(1);
+    expect(readIndex(tmp)).toMatch(/^\|\s*1\s*\|/m);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 1");
+  });
+
+  it("exits non-zero with a checkpoint when the auto-commit fails, then resumes at the commit step", () => {
+    breakCommits(tmp);
+
+    const first = tryAddSession(tmp, "commit fault", ["--summary", "fault run"]);
+    expect(first.status).toBe(1);
+    expect(first.stderr).toContain("Auto-commit failed");
+    expect(first.stderr).toContain("[BLOCKED] Checkpoint:");
+    expect(first.stderr).toContain("resumes at the commit step");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    // A retry while the commit is still broken must not duplicate anything.
+    const second = tryAddSession(tmp, "commit fault", ["--summary", "fault run"]);
+    expect(second.status).toBe(1);
+    expect(second.stderr).toContain("[RESUME]");
+    expect(second.stderr).toContain("index-recorded");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 1");
+
+    // With the commit repaired, the same command finishes the operation.
+    repairCommits(tmp);
+    const third = tryAddSession(tmp, "commit fault", ["--summary", "fault run"]);
+    expect(third.status).toBe(0);
+    expect(third.stderr).toContain("[RESUME]");
+    expect(third.stderr).toContain("Auto-committed");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(countMarkers(tmp)).toBe(1);
+
+    const committed = git(
+      tmp,
+      "show",
+      `HEAD:.trellis/workspace/${DEVELOPER}/journal-1.md`,
+    );
+    expect(committed).toContain("## Session 1: commit fault");
+  });
+
+  it("treats an identical request as a new session once the earlier one is committed", () => {
+    runAddSession(tmp, "same prose", ["--summary", "identical summary"]);
+    runAddSession(tmp, "same prose", ["--summary", "identical summary"]);
+
+    expect(sessionNumbers(tmp)).toEqual([1, 2]);
+    expect(countMarkers(tmp)).toBe(2);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 2");
+  });
+
+  it("makes a committed record a no-op when the caller supplies an idempotency key", () => {
+    runAddSession(tmp, "keyed work", [
+      "--summary",
+      "keyed summary",
+      "--idempotency-key",
+      "retry-001",
+    ]);
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    const second = tryAddSession(tmp, "keyed work", [
+      "--summary",
+      "keyed summary",
+      "--idempotency-key",
+      "retry-001",
+    ]);
+
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("already recorded and committed");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 1");
+  });
+
+  it("refuses to resume when two entries carry the same record marker", () => {
+    runAddSession(tmp, "dup work", ["--summary", "dup summary", "--no-commit"]);
+
+    // Duplicate the pending entry — the retry must not pick one at random.
+    const journal = readJournal(tmp);
+    const entry = journal.slice(journal.indexOf("## Session 1:"));
+    fs.writeFileSync(journalPath(tmp), journal + "\n\n" + entry);
+
+    const r = tryAddSession(tmp, "dup work", [
+      "--summary",
+      "dup summary",
+      "--no-commit",
+    ]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("journal entries carrying this record's marker");
+    expect(countMarkers(tmp)).toBe(2);
+  });
+
+  it("refuses to resume from a marker with no session heading above it", () => {
+    runAddSession(tmp, "orphan work", [
+      "--summary",
+      "orphan summary",
+      "--no-commit",
+    ]);
+
+    fs.writeFileSync(
+      journalPath(tmp),
+      readJournal(tmp).replace("## Session 1: orphan work", "## Notes"),
+    );
+
+    const r = tryAddSession(tmp, "orphan work", [
+      "--summary",
+      "orphan summary",
+      "--no-commit",
+    ]);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("without a '## Session N:' heading");
+  });
+
+  it("stops after a verified journal + index when auto-commit is disabled", () => {
+    fs.writeFileSync(
+      path.join(tmp, ".trellis", "config.yaml"),
+      "session_auto_commit: false\n",
+    );
+    const logBefore = git(tmp, "log", "--oneline");
+
+    const r = tryAddSession(tmp, "no auto commit", ["--summary", "local only"]);
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("session_auto_commit: false");
+    expect(r.stderr).not.toContain("Auto-committed");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(readIndex(tmp)).toContain("**Total Sessions**: 1");
+    expect(git(tmp, "log", "--oneline")).toBe(logBefore);
+  });
+
+  it("writes journal and index but skips git for --no-commit", () => {
+    const logBefore = git(tmp, "log", "--oneline");
+
+    const r = tryAddSession(tmp, "manual commit", ["--no-commit"]);
+
+    expect(r.status).toBe(0);
+    expect(sessionNumbers(tmp)).toEqual([1]);
+    expect(git(tmp, "log", "--oneline")).toBe(logBefore);
+    expect(git(tmp, "status", "--porcelain")).toContain("journal-1.md");
+  });
+
+  it("rotates to a new journal file and records the entry there", () => {
+    fs.writeFileSync(
+      path.join(tmp, ".trellis", "config.yaml"),
+      "session_auto_commit: true\nmax_journal_lines: 12\n",
+    );
+
+    const r = tryAddSession(tmp, "rotating work", ["--summary", "rotate"]);
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("Exceeds 12 lines");
+    expect(fs.existsSync(journalPath(tmp, 2))).toBe(true);
+    expect(sessionNumbers(tmp, 2)).toEqual([1]);
+    expect(readJournal(tmp, 1)).not.toContain("rotating work");
+    expect(readIndex(tmp)).toContain("**Active File**: `journal-2.md`");
+  });
+
+  it("resumes a rotated entry without appending a second one", () => {
+    fs.writeFileSync(
+      path.join(tmp, ".trellis", "config.yaml"),
+      "session_auto_commit: true\nmax_journal_lines: 12\n",
+    );
+    breakCommits(tmp);
+
+    const first = tryAddSession(tmp, "rotated retry", ["--summary", "rotate"]);
+    expect(first.status).toBe(1);
+
+    repairCommits(tmp);
+    const second = tryAddSession(tmp, "rotated retry", ["--summary", "rotate"]);
+
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("[RESUME]");
+    expect(sessionNumbers(tmp, 2)).toEqual([1]);
+    expect(countMarkers(tmp, 2)).toBe(1);
+    expect(fs.existsSync(journalPath(tmp, 3))).toBe(false);
+  });
+});
+
+describe.skipIf(!hasPython())("add_session.py session numbering", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-number-"));
+    setupRepo(tmp);
+    seedTask(tmp);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("does not reuse a number already claimed on a concurrent branch", () => {
+    runAddSession(tmp, "base work");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    // Branch A records (and auto-commits) session 2.
+    git(tmp, "checkout", "-q", "-b", "branch-a");
+    runAddSession(tmp, "branch A work");
+    expect(sessionNumbers(tmp)).toEqual([1, 2]);
+
+    // Branch B forks from main, so its working tree only knows about
+    // session 1. Deriving from the working tree alone would claim 2 again.
+    git(tmp, "checkout", "-q", "main");
+    git(tmp, "checkout", "-q", "-b", "branch-b");
+    expect(sessionNumbers(tmp)).toEqual([1]);
+
+    runAddSession(tmp, "branch B work");
+
+    const numbers = sessionNumbers(tmp);
+    expect(numbers).toEqual([1, 3]);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  it("keeps numbering monotonic when the index counter is behind the journal", () => {
+    runAddSession(tmp, "first");
+    // Simulate a merge that kept both journal entries (merge=union) while
+    // index.md resolved to the lower counter.
+    fs.writeFileSync(
+      indexPath(tmp),
+      readIndex(tmp).replace("**Total Sessions**: 1", "**Total Sessions**: 0"),
+    );
+
+    runAddSession(tmp, "second");
+
+    expect(sessionNumbers(tmp)).toEqual([1, 2]);
+  });
+});
+
+/**
+ * `get_repo_root` returns the nearest directory holding `.trellis/`, which is
+ * not necessarily the git toplevel. Every git path the recorder builds has to
+ * be interpreted relative to the Trellis root, not the git root.
+ */
+describe.skipIf(!hasPython())("add_session.py with .trellis below the git root", () => {
+  let outer: string;
+  let project: string;
+
+  beforeEach(() => {
+    outer = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-nested-"));
+    git(outer, "init", "-q", "-b", "main");
+    git(outer, "config", "user.email", "test@example.com");
+    git(outer, "config", "user.name", "Test");
+    project = path.join(outer, "project");
+    stampTrellis(project);
+    seedTask(project);
+  });
+
+  afterEach(() => {
+    fs.rmSync(outer, { recursive: true, force: true });
+  });
+
+  it("verifies the committed record and still numbers a repeat as a new session", () => {
+    const first = tryAddSession(project, "nested layout", [
+      "--summary",
+      "nested run",
+    ]);
+    expect(first.status).toBe(0);
+    expect(first.stderr).toContain("Auto-committed");
+    // The post-commit check re-reads the marker from `HEAD:<journal>`. A
+    // git-root-relative lookup finds nothing here and reports a false block.
+    expect(first.stderr).not.toContain("[BLOCKED] Checkpoint:");
+
+    // The record is committed, so an identical request is a new session
+    // rather than a "pending" one adopted for repair.
+    const second = tryAddSession(project, "nested layout", [
+      "--summary",
+      "nested run",
+    ]);
+    expect(second.status).toBe(0);
+    expect(second.stderr).not.toContain("[RESUME]");
+    expect(sessionNumbers(project)).toEqual([1, 2]);
+  });
+});
+
+describe.skipIf(!hasPython())("add_session.py outside any git repository", () => {
+  let project: string;
+
+  beforeEach(() => {
+    project = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-session-nogit-"));
+    stampTrellis(project);
+    // seedTask() commits via git; there is no repo here by design.
+    makeTask(project, "task-a", "task-a prd\n");
+    setCurrentTask(project, "task-a");
+  });
+
+  afterEach(() => {
+    fs.rmSync(project, { recursive: true, force: true });
+  });
+
+  it("records the session and exits 0 — a configured skip, not a retry loop", () => {
+    // No git here means auto-commit can never succeed; that must be
+    // COMMIT_BLOCKED (exit 0, like a gitignored .trellis/), not the
+    // COMMIT_FAILED checkpoint whose "fix the git error" advice never applies.
+    const result = tryAddSession(project, "no git", ["--summary", "no repo"]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("Not a git repository");
+    expect(result.stderr).not.toContain("[BLOCKED] Checkpoint:");
+    expect(sessionNumbers(project)).toEqual([1]);
   });
 });


### PR DESCRIPTION
Slice **D** of the #534 resplit: `76c53c5a` + `3a0a5f6b` + the integration test, on current `main` (`64e66369`). Independent of #576 — as you noted, it should not wait on `rename`.

## What it fixes

`add_session.py` recorded a session in one pass with no way to distinguish a half-finished run from a failed one, so a retry after an interrupted commit either duplicated the entry or reported success for work it had not done.

- commit OIDs resolved to their real subjects **before** any mutation, so an entry can't ship `(see git log)` in place of evidence
- fingerprint markers give a retry an exact re-entry point; the run resumes at journal, index, or scoped commit
- auto-commit failure returns a checkpoint instead of false success
- session numbering converges across concurrent branches
- atomic journal/index writes
- `3a0a5f6b`: the idempotency fingerprint survives a date rollover — markers carry a version, and v1 markers (whose fingerprint mixed in the calendar date) are still recognised

## The lint failure you flagged

`add-session.integration.test.ts:635` was:

```ts
const date = today![1];
```

`@typescript-eslint/no-non-null-assertion`. Now:

```ts
if (!today) throw new Error("journal entry carries no **Date** line");
const date = today[1];
```

It was the only non-null assertion in the file; `eslint` on it is clean.

## Conflict resolution

`3a0a5f6b` conflicted on `add_session.py` (both copies) at the regex block. The incoming side is a superset — same `SESSION_HEADING_RE` plus `MARKER_VERSION`, `LEGACY_MARKER_RE`, `ENTRY_DATE_RE`, and the `re.MULTILINE` the rollover fix needs — so I took it.

Task artifacts from both picks (`07-28-*`, `08-19-*`) dropped.

## Testing

```
cli    → Test Files 76 passed | Tests 1736 passed
core   → Test Files 19 passed | Tests 346 passed, 1 skipped
```

Vendored and packaged script copies byte-identical. No `.trellis/tasks/`, no workflow.md, no marketplace gitlink, version stays `0.6.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable session recording with safe retries and duplicate prevention.
  * Added commit subject resolution and `--commit-subject` overrides.
  * Added `--idempotency-key` support for repeatable session creation.
  * Session numbering now remains consistent across branches and local references.
  * Auto-commit results now provide clear status and resume checkpoints.

* **Bug Fixes**
  * Journal and index updates now use atomic writes to prevent partial records.
  * Improved validation and handling of invalid commit references.

* **Tests**
  * Expanded coverage for retries, failures, idempotency, numbering, and commit evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->