### PR TITLE
fix(pi): resolve trellis project root from session cwd

### DIFF
--- a/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/pi/extensions/trellis/index.ts.txt
@@ -19,6 +19,7 @@ interface PiToolResult {
   details?: unknown;
 }
 interface PiExtensionContext {
+  cwd?: string;
   hasUI?: boolean;
   model?: {
     provider?: string;
@@ -964,11 +965,33 @@ function readJsonlEntries(basePath: string, jsonlPath: string): JsonlEntry[] {
 function findRoot(start: string): string {
   let c = resolve(start);
   while (true) {
-    if (existsSync(join(c, ".trellis")) || existsSync(join(c, ".pi"))) return c;
+    // Only a directory with `.trellis/` is a Trellis project root. A bare
+    // `.pi` can be pi's global config (`~/.pi`) or an unrelated project, so
+    // accepting it here made root resolution stop too early (e.g. on `~`).
+    // Also reject a regular file named `.trellis` — the marker must be a
+    // directory.
+    const marker = join(c, ".trellis");
+    if (existsSync(marker) && statSync(marker).isDirectory()) return c;
     const p = dirname(c);
     if (p === c) return resolve(start);
     c = p;
   }
+}
+// Resolve the project root from the session working directory when available
+// (pi's ExtensionContext.cwd), falling back to the pi host process cwd.
+// process.cwd() is the host's launch directory and can differ from the
+// session cwd (pi-web / RPC / multi-project hosts), which made .pi/agents
+// lookups fail or resolve to the wrong project.
+function resolveRoot(ctx?: PiExtensionContext): string {
+  return findRoot(ctx?.cwd ?? process.cwd());
+}
+// Cache key scoping per-session state by both the session key and the
+// resolved project root. With dynamic root resolution a session can observe
+// different ctx.cwd values over its lifetime (pi-web / RPC / project
+// switching); keying caches by the session key alone would leak one
+// project's startup/task context into another.
+function cacheKey(k: string | null, ctx?: PiExtensionContext): string {
+  return `${k ?? "default"}::${resolveRoot(ctx)}`;
 }
 function splitFM(c: string) {
   const m = c.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
@@ -1665,7 +1688,9 @@ export default function trellisExtension(pi: {
   getThinkingLevel?: () => string;
 }): void {
   if (process.env.TRELLIS_SUBAGENT_CHILD === "1") return;
-  const root = findRoot(process.cwd());
+  // Process-level fallback; call sites with a session context re-resolve via
+  // resolveRoot(ctx) so the active project (session cwd) is used instead.
+  const root = resolveRoot();
   const procKey = `pi_process_${hash([root, process.pid, Date.now(), randomBytes(8).toString("hex")].join(":"))}`;
   let curKey: string | null = null;
 
@@ -1677,20 +1702,22 @@ export default function trellisExtension(pi: {
 
   // Per-turn cache to avoid double-spawning python
   let turnCache: {
-    key: string | null;
+    key: string;
     ts: number;
     wf: string;
     ov: string;
   } | null = null;
-  const getTurnCtx = (k: string | null) => {
+  const getTurnCtx = (k: string | null, ctx?: PiExtensionContext) => {
     const now = Date.now();
-    if (turnCache && turnCache.key === k && now - turnCache.ts < 1500)
+    const ck = cacheKey(k, ctx);
+    if (turnCache && turnCache.key === ck && now - turnCache.ts < 1500)
       return turnCache;
+    const r = resolveRoot(ctx);
     turnCache = {
-      key: k,
+      key: ck,
       ts: now,
-      wf: workflowBreadcrumb(root, k),
-      ov: sessionOverview(root, k),
+      wf: workflowBreadcrumb(r, k),
+      ov: sessionOverview(r, k),
     };
     return turnCache;
   };
@@ -1702,11 +1729,12 @@ export default function trellisExtension(pi: {
   const getStartupCtx = (
     k: string | null,
     turn: { ov: string },
+    ctx?: PiExtensionContext,
   ): string => {
-    const key = k ?? "default";
+    const key = cacheKey(k, ctx);
     let startup = startupCtxCache.get(key);
     if (startup === undefined) {
-      startup = buildStartupContext(root, k, turn.ov);
+      startup = buildStartupContext(resolveRoot(ctx), k, turn.ov);
       startupCtxCache.set(key, startup);
     }
     return startup;
@@ -1714,6 +1742,14 @@ export default function trellisExtension(pi: {
   const taskCtxSnapshot = new Map<string, string>();
   const lastSentTaskCtx = new Map<string, string>();
   const lastSentRuntimeCtx = new Map<string, string>();
+  // Session-level "most recently persisted" project root. The root-scoped
+  // lastSent* maps suppress re-emission for an unchanged root, but when a
+  // session switches projects (A -> B -> A) the latest persisted update
+  // would otherwise stay B's — and its <trellis-task-context-update>
+  // explicitly supersedes the system-prompt context. Re-assert the current
+  // root's task/runtime context on every root transition so the agent never
+  // keeps following the previous project's instructions.
+  const lastPersistedRoot = new Map<string, string>();
 
   // Toggle only the latest subagent native card; do not use Pi global tool expansion.
   const toggleDetail = (ctx: PiExtensionContext) => {
@@ -1781,6 +1817,7 @@ export default function trellisExtension(pi: {
       ctx?: PiExtensionContext,
     ) => {
       activeSubagentToolCallId = id;
+      const root = resolveRoot(ctx);
       const agentName = normalizeAgent(input.agent);
       if (!isTrellisAgent(root, agentName)) {
         return {
@@ -1931,10 +1968,11 @@ export default function trellisExtension(pi: {
   });
   pi.on?.("before_agent_start", (event, ctx) => {
     const k = getKey(event, ctx);
-    const key = k ?? "default";
+    const key = cacheKey(k, ctx);
     const cur = (event as { systemPrompt?: string }).systemPrompt ?? "";
-    const turn = getTurnCtx(k);
-    const startup = getStartupCtx(k, turn);
+    const root = resolveRoot(ctx);
+    const turn = getTurnCtx(k, ctx);
+    const startup = getStartupCtx(k, turn, ctx);
     // Task context is snapshotted into systemPrompt once; later on-disk
     // changes are delivered as persisted messages so the prefix stays stable.
     const freshTaskCtx = buildContext(root, "trellis-implement", k);
@@ -1946,11 +1984,23 @@ export default function trellisExtension(pi: {
     }
     const updates: string[] = [];
     const runtimeContext = [turn.wf, turn.ov].filter(Boolean).join("\n\n");
-    if (runtimeContext && runtimeContext !== lastSentRuntimeCtx.get(key)) {
+    // Re-assert the current root's context on project switches: when the
+    // session returns to an unchanged root, the root-scoped lastSent* maps
+    // alone would leave the previous project's persisted update as the most
+    // recent one in history.
+    const prevRoot = lastPersistedRoot.get(k ?? "default");
+    const switchedRoot = prevRoot !== undefined && prevRoot !== root;
+    if (
+      runtimeContext &&
+      (runtimeContext !== lastSentRuntimeCtx.get(key) || switchedRoot)
+    ) {
       lastSentRuntimeCtx.set(key, runtimeContext);
       updates.push(runtimeContext);
     }
-    if (freshTaskCtx !== lastSentTaskCtx.get(key)) {
+    if (
+      freshTaskCtx !== lastSentTaskCtx.get(key) ||
+      switchedRoot
+    ) {
       lastSentTaskCtx.set(key, freshTaskCtx);
       updates.push(
         "<trellis-task-context-update>\nTask context changed on disk. This supersedes the Trellis Task Context in the system prompt.\n\n" +
@@ -1958,6 +2008,7 @@ export default function trellisExtension(pi: {
           "\n</trellis-task-context-update>",
       );
     }
+    if (updates.length > 0) lastPersistedRoot.set(k ?? "default", root);
     const content = updates.join("\n\n");
     return {
       message: content

--- a/packages/cli/test/templates/pi.test.ts
+++ b/packages/cli/test/templates/pi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createRequire } from "node:module";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -574,6 +574,117 @@ describe("pi templates", () => {
     }
   });
 
+  it("scopes per-session caches by resolved root when ctx.cwd changes", () => {
+    const root1 = createMinimalTrellisRoot();
+    const root2 = createMinimalTrellisRoot();
+    const sessionsDir1 = join(root1, ".trellis", ".runtime", "sessions");
+    const sessionsDir2 = join(root2, ".trellis", ".runtime", "sessions");
+    const taskDir1 = join(root1, ".trellis", "tasks", "shared-task");
+    const taskDir2 = join(root2, ".trellis", "tasks", "shared-task");
+    mkdirSync(sessionsDir1, { recursive: true });
+    mkdirSync(sessionsDir2, { recursive: true });
+    mkdirSync(taskDir1, { recursive: true });
+    mkdirSync(taskDir2, { recursive: true });
+    writeFileSync(join(taskDir1, "prd.md"), "ROOT ONE PRD CONTENT");
+    writeFileSync(join(taskDir2, "prd.md"), "ROOT TWO PRD CONTENT");
+    const sessionRef = JSON.stringify({ current_task: "tasks/shared-task" });
+    writeFileSync(join(sessionsDir1, "pi_shared-session.json"), sessionRef);
+    writeFileSync(join(sessionsDir2, "pi_shared-session.json"), sessionRef);
+
+    try {
+      const { trellisExtension } = loadExtensionInternals();
+      const handlers = new Map<
+        string,
+        (event: unknown, ctx?: unknown) => unknown
+      >();
+      trellisExtension({
+        registerTool: vi.fn(),
+        registerShortcut: vi.fn(),
+        on(event, handler) {
+          handlers.set(event, handler);
+        },
+      });
+      const fire = (cwd: string) =>
+        handlers.get("before_agent_start")?.(
+          { type: "before_agent_start", systemPrompt: "BASE" },
+          { cwd, sessionManager: { getSessionId: () => "shared-session" } },
+        ) as { systemPrompt?: string; message?: { content?: string } };
+
+      const first = fire(root1);
+      expect(first.systemPrompt).toContain("ROOT ONE PRD CONTENT");
+
+      // Same session key but a different session cwd must NOT reuse the
+      // first project's cached startup/task context.
+      const second = fire(root2);
+      expect(second.systemPrompt).toContain("ROOT TWO PRD CONTENT");
+      expect(second.systemPrompt).not.toContain("ROOT ONE PRD CONTENT");
+    } finally {
+      rmSync(root1, { recursive: true, force: true });
+      rmSync(root2, { recursive: true, force: true });
+    }
+  });
+
+  it("re-asserts the current root's task context when a session switches back", () => {
+    const root1 = createMinimalTrellisRoot();
+    const root2 = createMinimalTrellisRoot();
+    const sessionsDir1 = join(root1, ".trellis", ".runtime", "sessions");
+    const sessionsDir2 = join(root2, ".trellis", ".runtime", "sessions");
+    const taskDir1 = join(root1, ".trellis", "tasks", "shared-task");
+    const taskDir2 = join(root2, ".trellis", "tasks", "shared-task");
+    mkdirSync(sessionsDir1, { recursive: true });
+    mkdirSync(sessionsDir2, { recursive: true });
+    mkdirSync(taskDir1, { recursive: true });
+    mkdirSync(taskDir2, { recursive: true });
+    writeFileSync(join(taskDir1, "prd.md"), "ROOT ONE PRD CONTENT");
+    writeFileSync(join(taskDir2, "prd.md"), "ROOT TWO PRD CONTENT");
+    const sessionRef = JSON.stringify({ current_task: "tasks/shared-task" });
+    writeFileSync(join(sessionsDir1, "pi_shared-session.json"), sessionRef);
+    writeFileSync(join(sessionsDir2, "pi_shared-session.json"), sessionRef);
+
+    try {
+      const { trellisExtension } = loadExtensionInternals();
+      const handlers = new Map<
+        string,
+        (event: unknown, ctx?: unknown) => unknown
+      >();
+      trellisExtension({
+        registerTool: vi.fn(),
+        registerShortcut: vi.fn(),
+        on(event, handler) {
+          handlers.set(event, handler);
+        },
+      });
+      const fire = (cwd: string) =>
+        handlers.get("before_agent_start")?.(
+          { type: "before_agent_start", systemPrompt: "BASE" },
+          { cwd, sessionManager: { getSessionId: () => "shared-session" } },
+        ) as { systemPrompt?: string; message?: { content?: string } };
+
+      // A: first visit seeds the snapshot into the system prompt; the
+      // persisted history carries only the runtime context.
+      const a1 = fire(root1);
+      expect(a1.message?.content ?? "").not.toContain(
+        "<trellis-task-context-update>",
+      );
+
+      // A -> B: the switch re-asserts B's task context as a persisted
+      // update (it supersedes the system-prompt context).
+      const b = fire(root2);
+      expect(b.message?.content).toContain("<trellis-task-context-update>");
+      expect(b.message?.content).toContain("ROOT TWO PRD CONTENT");
+
+      // B -> A with unchanged A on disk: A's task context must be re-emitted
+      // so the most recent persisted update belongs to A, not B.
+      const a2 = fire(root1);
+      expect(a2.message?.content).toContain("<trellis-task-context-update>");
+      expect(a2.message?.content).toContain("ROOT ONE PRD CONTENT");
+      expect(a2.message?.content).not.toContain("ROOT TWO PRD CONTENT");
+    } finally {
+      rmSync(root1, { recursive: true, force: true });
+      rmSync(root2, { recursive: true, force: true });
+    }
+  });
+
   it("extension tool_result handler marks failed/cancelled subagent runs as errors", () => {
     const extension = getExtensionTemplate();
 
@@ -793,10 +904,12 @@ fallbackModels:
   });
 
   it("passes the invoking Pi model to the spawned child process", async () => {
-    const root = createMinimalTrellisRoot();
-    const agentDir = join(root, ".pi", "agents");
-    const fakeCli = join(root, "fake-pi.cjs");
-    const capturedArgs = join(root, "child-args.json");
+    const hostRoot = createMinimalTrellisRoot();
+    const sessionRoot = createMinimalTrellisRoot();
+    const agentDir = join(sessionRoot, ".pi", "agents");
+    const fakeCli = join(sessionRoot, "fake-pi.cjs");
+    const capturedArgs = join(sessionRoot, "child-args.json");
+    const capturedCwd = join(sessionRoot, "child-cwd.txt");
     mkdirSync(agentDir, { recursive: true });
     writeFileSync(
       join(agentDir, "trellis-implement.md"),
@@ -807,13 +920,14 @@ fallbackModels:
       [
         'const { writeFileSync } = require("node:fs");',
         `writeFileSync(${JSON.stringify(capturedArgs)}, JSON.stringify(process.argv.slice(2)));`,
+        `writeFileSync(${JSON.stringify(capturedCwd)}, process.cwd());`,
         'process.stdout.write(JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "fake child ok" }] } }) + "\\n");',
         "",
       ].join("\n"),
     );
 
     try {
-      const { trellisExtension } = loadExtensionInternals(root, {
+      const { trellisExtension } = loadExtensionInternals(hostRoot, {
         TRELLIS_PI_CLI_JS: fakeCli,
       });
       let registeredTool: RegisteredPiTool | undefined;
@@ -832,10 +946,16 @@ fallbackModels:
         { agent: "trellis-implement", prompt: "Implement the task" },
         undefined,
         undefined,
-        { model: { provider: "openai-proxy", id: "gpt-5.6-sol" } },
+        {
+          cwd: sessionRoot,
+          model: { provider: "openai-proxy", id: "gpt-5.6-sol" },
+        },
       );
 
       expect(result.content[0]?.text).toBe("fake child ok");
+      expect(realpathSync(readFileSync(capturedCwd, "utf-8"))).toBe(
+        realpathSync(sessionRoot),
+      );
       expect(JSON.parse(readFileSync(capturedArgs, "utf-8"))).toEqual([
         "--mode",
         "json",
@@ -845,7 +965,8 @@ fallbackModels:
         "openai-proxy/gpt-5.6-sol:xhigh",
       ]);
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      rmSync(hostRoot, { recursive: true, force: true });
+      rmSync(sessionRoot, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Background

The Pi extension template resolved the Trellis project root once at extension load time via `findRoot(process.cwd())`. `process.cwd()` is the **pi host process's launch directory**, which can differ from the session working directory in pi-web / RPC / multi-project setups.

When the two diverge (e.g. a host launched in one project while a session runs in another), the extension fails to locate the active project's `./.pi/agents/*.md` definitions and `trellis_subagent` errors out with "trellis_subagent is only for Trellis workflow agents with a definition file in .pi/agents/", or worse, resolves root to the wrong project (subagent spawn `cwd` and `task.py current` lookups follow the wrong root).

A second, compounding issue: `findRoot` treats any directory containing either `.trellis` **or** `.pi` as a project root. pi's global config directory (`~/.pi`) or an unrelated project's bare `.pi` both satisfy this, so resolution can stop too early (e.g. at the user's home directory).

## Changes

- **Resolve root from the session working directory**: add `cwd` to the `PiExtensionContext` interface and introduce `resolveRoot(ctx)` = `findRoot(ctx?.cwd ?? process.cwd())`, preferring pi's `ExtensionContext.cwd` (the session cwd) with `process.cwd()` as a fallback when no context is available.
- **Re-resolve at each call site** instead of capturing root once at load: subagent execution (`trellis_subagent`), agent-start context injection (`before_agent_start`), and turn/startup context builders all resolve against the current session, so the active project is always used.
- **Tighten `findRoot`**: only a directory containing `.trellis/` counts as a Trellis project root; a bare `.pi` (pi's global config or an unrelated project) no longer short-circuits the walk.

## Verification

- `pnpm build` succeeds; generated Pi template includes the new `resolveRoot`.
- Full test suite passes: 1708 tests (core + cli), including `test/templates/pi.test.ts`.
- Manual smoke: with host cwd ≠ session cwd, `trellis_subagent` now resolves the session project's `.pi/agents/trellis-*.md` and spawns the child with the correct project root.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project detection using the active session’s working directory.
  * Projects are recognized only when they contain a `.trellis` directory.
  * Extension actions consistently use the correct project location.
  * Prevented cached context from being reused across different projects.
  * Refreshed task context when switching between projects during a session.
  * Child processes now run from the active project directory.
  * Added regression coverage for project-specific context and working-directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->