### PR TITLE
fix(hooks): contain jsonl-referenced file reads inside the task base path (#580)

### DIFF
--- a/.claude/hooks/inject-subagent-context.py
+++ b/.claude/hooks/inject-subagent-context.py
@@ -251,6 +251,15 @@ class _Budget:
 def _read_file_bytes(base_path: str, file_path: str) -> bytes | None:
     """Read raw file bytes, return None if file doesn't exist."""
     full_path = os.path.join(base_path, file_path)
+    try:
+        root_real = os.path.realpath(base_path)
+        full_real = os.path.realpath(full_path)
+        # ValueError on Windows when the two sit on different drives; that is
+        # outside base_path by definition, so it fails closed below.
+        if os.path.commonpath([root_real, full_real]) != root_real:
+            return None
+    except (OSError, ValueError):
+        return None
     if os.path.exists(full_path) and os.path.isfile(full_path):
         try:
             with open(full_path, "rb") as f:

--- a/.codex/hooks/inject-subagent-context.py
+++ b/.codex/hooks/inject-subagent-context.py
@@ -251,6 +251,15 @@ class _Budget:
 def _read_file_bytes(base_path: str, file_path: str) -> bytes | None:
     """Read raw file bytes, return None if file doesn't exist."""
     full_path = os.path.join(base_path, file_path)
+    try:
+        root_real = os.path.realpath(base_path)
+        full_real = os.path.realpath(full_path)
+        # ValueError on Windows when the two sit on different drives; that is
+        # outside base_path by definition, so it fails closed below.
+        if os.path.commonpath([root_real, full_real]) != root_real:
+            return None
+    except (OSError, ValueError):
+        return None
     if os.path.exists(full_path) and os.path.isfile(full_path):
         try:
             with open(full_path, "rb") as f:

--- a/.cursor/hooks/inject-subagent-context.py
+++ b/.cursor/hooks/inject-subagent-context.py
@@ -251,6 +251,15 @@ class _Budget:
 def _read_file_bytes(base_path: str, file_path: str) -> bytes | None:
     """Read raw file bytes, return None if file doesn't exist."""
     full_path = os.path.join(base_path, file_path)
+    try:
+        root_real = os.path.realpath(base_path)
+        full_real = os.path.realpath(full_path)
+        # ValueError on Windows when the two sit on different drives; that is
+        # outside base_path by definition, so it fails closed below.
+        if os.path.commonpath([root_real, full_real]) != root_real:
+            return None
+    except (OSError, ValueError):
+        return None
     if os.path.exists(full_path) and os.path.isfile(full_path):
         try:
             with open(full_path, "rb") as f:

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -251,6 +251,15 @@ class _Budget:
 def _read_file_bytes(base_path: str, file_path: str) -> bytes | None:
     """Read raw file bytes, return None if file doesn't exist."""
     full_path = os.path.join(base_path, file_path)
+    try:
+        root_real = os.path.realpath(base_path)
+        full_real = os.path.realpath(full_path)
+        # ValueError on Windows when the two sit on different drives; that is
+        # outside base_path by definition, so it fails closed below.
+        if os.path.commonpath([root_real, full_real]) != root_real:
+            return None
+    except (OSError, ValueError):
+        return None
     if os.path.exists(full_path) and os.path.isfile(full_path):
         try:
             with open(full_path, "rb") as f:

--- a/packages/cli/test/scripts/context-injection-limits.integration.test.ts
+++ b/packages/cli/test/scripts/context-injection-limits.integration.test.ts
@@ -623,6 +623,76 @@ print("all-valid")
       });
     });
 
+    describe("inject-subagent-context.py: jsonl file reference containment (#580)", () => {
+      it("does not read a file outside base_path via an absolute jsonl reference", () => {
+        const taskDir = makeTask(tmp, "task-absolute-escape");
+        const secretDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "trellis-580-secret-"),
+        );
+        const secretPath = path.join(secretDir, "secret.txt");
+        fs.writeFileSync(secretPath, "TOP SECRET CONTENT", "utf-8");
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: secretPath, reason: "escape" }) + "\n",
+          "utf-8",
+        );
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+        expect(out).not.toContain("TOP SECRET CONTENT");
+        fs.rmSync(secretDir, { recursive: true, force: true });
+      });
+
+      it("does not read a file outside base_path via a ../ traversal jsonl reference", () => {
+        const taskDir = makeTask(tmp, "task-traversal-escape");
+        const secretDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "trellis-580-secret-"),
+        );
+        fs.writeFileSync(
+          path.join(secretDir, "secret.txt"),
+          "TOP SECRET CONTENT",
+          "utf-8",
+        );
+        const traversal =
+          path.relative(tmp, secretDir).split(path.sep).join("/") +
+          "/secret.txt";
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: traversal, reason: "escape" }) + "\n",
+          "utf-8",
+        );
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+        expect(out).not.toContain("TOP SECRET CONTENT");
+        fs.rmSync(secretDir, { recursive: true, force: true });
+      });
+
+      it("still reads a legitimate jsonl reference inside base_path (control)", () => {
+        const taskDir = makeTask(tmp, "task-contained-control");
+        fs.writeFileSync(
+          path.join(tmp, "inside.md"),
+          "not secret",
+          "utf-8",
+        );
+        fs.writeFileSync(
+          path.join(taskDir, "implement.jsonl"),
+          JSON.stringify({ file: "inside.md", reason: "control" }) + "\n",
+          "utf-8",
+        );
+        const relTask = path.relative(tmp, taskDir).split(path.sep).join("/");
+        const out = runHookProbe(
+          tmp,
+          `print(mod.get_implement_context(REPO_ROOT, ${JSON.stringify(relTask)}))`,
+        );
+        expect(out).toContain("=== inside.md ===\nnot secret");
+      });
+    });
+
     describe("task.py validate: JSONL hygiene warnings", () => {
       it("warns (does not error) on a jsonl entry that looks like a code file", () => {
         const taskDir = makeTask(tmp, "task-code-warn");


### PR DESCRIPTION
## Root cause

`_read_file_bytes()` (`shared-hooks/inject-subagent-context.py`) joins `base_path`
with the `file` value from an `implement.jsonl`/`check.jsonl` entry using
`os.path.join`, with no containment check. `os.path.join` discards `base_path`
entirely when `file` is an absolute path, and a `../` entry walks out of it
either way, so a curated manifest entry can read an arbitrary file on disk into
the spawned subagent's prompt.

## Fix

`_read_file_bytes` now resolves both `base_path` and the joined path with
`os.path.realpath` and requires the result to share `base_path`'s real root via
`os.path.commonpath`, failing closed (returns `None`, same as a missing file) on
mismatch or a `ValueError`/`OSError` (e.g. different drives on Windows). This
mirrors the containment check `main()` already applies to the `task_dir`
pointer read from the session file, so the two untrusted-path checks in this
file now share one pattern. Applied identically to the vendored copies under
`.claude/`, `.codex/`, and `.cursor/`, which mirror the shared-hooks source
verbatim.

## Verification

- Added `test/scripts/context-injection-limits.integration.test.ts` cases that
  drive an absolute-path and a `../` jsonl reference through
  `get_implement_context` end to end: both fail on `main` (leak the sentinel
  content) and pass on this branch, plus a control case confirming an in-tree
  reference still resolves normally.
- `pnpm typecheck`, `pnpm lint`, `pnpm --filter @mindfoldhq/trellis lint:py`,
  and `pnpm build` all pass.
- Full `pnpm test` (1711 tests) passes except one pre-existing failure in
  `atomic-write.test.ts` unrelated to this change (relies on a read-only
  directory blocking a write, which does not hold when the test runs as root);
  confirmed it also fails on unmodified `main` in the same container.
- Not verified: the directory-listing side of `_materialize_directory`
  (a malicious `dir_path` entry could still leak filenames of an arbitrary
  directory via `os.listdir`, though not their content, since content reads
  now route through the guarded `_read_file_bytes`). Left out to keep this fix
  scoped to the reported read primitive; happy to extend if you'd rather fold
  it into the same PR.

Fixes #580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented context injection from reading files outside the intended project directory.
  * Added protection against absolute-path and directory-traversal references, including cross-drive paths on Windows.
  * Preserved access to valid files within the project directory.

* **Tests**
  * Added coverage confirming out-of-bounds files are excluded while legitimate project files remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->