### PR TITLE
feat(omp): implement prompt_injection.skip_keyword escape hatch

### DIFF
--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -715,6 +715,50 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 }
 
 // ---------------------------------------------------------------------------
+// Prompt injection config (escape hatch)
+// ---------------------------------------------------------------------------
+
+// Unset config (or missing config.yaml) disables the escape hatch; only an
+// explicit prompt_injection.skip_keyword enables per-turn skipping.
+function readPromptInjectionSkipKeyword(projectRoot: string): string {
+   let config = "";
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return ""; }
+
+   let inSection = false;
+   let sectionIndent = -1;
+   for (const rawLine of config.split(/\r?\n/)) {
+      const trimmed = rawLine.trim();
+      if (!inSection) {
+         if (/^prompt_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+            inSection = true;
+            sectionIndent = rawLine.length - rawLine.trimStart().length;
+         }
+         continue;
+      }
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const indent = rawLine.length - rawLine.trimStart().length;
+      if (indent <= sectionIndent) break;
+      const match = trimmed.match(/^skip_keyword\s*:\s*(.*)$/);
+      if (!match) continue;
+      return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
+   }
+   return "";
+}
+
+// Hyphen counts as a word char so "no-trellisx" / "xno-trellis" /
+// "foo-no-trellis" don't match, but punctuation/whitespace boundaries do.
+// Empty keyword (unset config) never matches.
+function shouldSkipWorkflowState(
+   userInput: string,
+   skipKeyword: string,
+): boolean {
+   if (!skipKeyword) return false;
+   const escapedKeyword = skipKeyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+   const pattern = new RegExp(`(?<![\\w-])${escapedKeyword}(?![\\w-])`, "i");
+   return pattern.test(userInput);
+}
+
+// ---------------------------------------------------------------------------
 // Per-turn cache — prevents redundant workflow-state resolution within a
 // single event cascade (input, before_agent_start, and context fire closely)
 // ---------------------------------------------------------------------------
@@ -728,9 +772,11 @@ class TurnContextCache {
    private workflowMsg = "";
    private static readonly TTL_MS = 1500;
 
-   get(projectRoot: string, contextKey: string | null): { workflowMsg: string } {
+   get(projectRoot: string, contextKey: string | null, skipThisTurn: boolean = false): { workflowMsg: string } {
       const now = Date.now();
-      const cacheKey = `${projectRoot}:${contextKey ?? ""}`;
+      // skipThisTurn participates in the cache key: a skip turn cached within
+      // the TTL must not leak an empty message into the next (non-skip) turn.
+      const cacheKey = `${projectRoot}:${contextKey ?? ""}:${skipThisTurn ? "skip" : "full"}`;
       if (
          this.key === cacheKey &&
          now - this.timestamp < TurnContextCache.TTL_MS
@@ -756,7 +802,10 @@ class TurnContextCache {
          workflowBody = "Refer to workflow.md for current step.";
       }
 
-      this.workflowMsg = `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
+      // When skip keyword is present, skip workflow state injection this turn
+      this.workflowMsg = skipThisTurn
+         ? ""
+         : `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
 
       this.key = cacheKey;
       this.timestamp = now;
@@ -902,6 +951,9 @@ export default function(pi: ExtensionAPI): void {
       const cached = turnCache.get(projectRoot, contextKey);
       lastInjectionTs = Date.now();
 
+      // Skip turn: inject nothing (escape hatch)
+      if (!cached.workflowMsg) return;
+
       return {
          message: {
             customType: "trellis-workflow-state",
@@ -947,7 +999,16 @@ export default function(pi: ExtensionAPI): void {
       if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
 
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) return taskContextChanged ? { messages: projectedMessages } : undefined;
+      if (!cached.workflowMsg) {
+         // Skip turn (escape hatch): drop any persisted breadcrumb from an
+         // earlier turn so the skip actually takes effect.
+         const withoutBreadcrumb = projectedMessages.filter(
+            (message) => !(message.role === "custom" && message.customType === "trellis-workflow-state"),
+         );
+         if (withoutBreadcrumb.length === projectedMessages.length && !taskContextChanged) return;
+         lastInjectionTs = Date.now();
+         return { messages: withoutBreadcrumb };
+      }
 
       // Post-compaction: reverse-scan to confirm absence before injecting
       for (let i = projectedMessages.length - 1; i >= 0; i--) {
@@ -986,14 +1047,19 @@ export default function(pi: ExtensionAPI): void {
       };
    });
 
-   pi.on("input", async (_event, ctx) => {
+   pi.on("input", async (event, ctx) => {
       if (!projectRoot) {
          projectRoot = findProjectRoot(ctx.cwd);
       }
       // Resolve projectRoot on first input if session_start missed it
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
+
+      // Check if this turn should skip workflow state injection
+      const skipKeyword = readPromptInjectionSkipKeyword(projectRoot);
+      const skipThisTurn = shouldSkipWorkflowState(event.text ?? "", skipKeyword);
+
       // Pre-warm the cache so before_agent_start and context can use it
-      turnCache.get(projectRoot, contextKey);
+      turnCache.get(projectRoot, contextKey, skipThisTurn);
    });
 }

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -723,6 +723,21 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 // escape hatch entirely.
 const DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD = "no-trellis";
 
+// PyYAML-compatible resolution of scalars that parse as non-strings: null
+// (empty, ~, null variants), bool (YAML 1.1 set), and numbers. Quoted scalars
+// never reach this check and stay strings.
+function isYamlNonStringScalar(raw: string): boolean {
+   if (raw === "" || raw === "~" || /^(?:null|Null|NULL)$/.test(raw)) return true;
+   if (/^(?:true|True|TRUE|false|False|FALSE|yes|Yes|YES|no|No|NO|on|On|ON|off|Off|OFF)$/.test(raw)) return true;
+   // PyYAML int resolver: binary/octal/decimal/hex; leading-zero decimals are not ints.
+   if (/^[-+]?(?:0[bB][01_]+|0[0-7_]+|0[xX][0-9a-fA-F_]+|[1-9][\d_]*|0)$/.test(raw)) return true;
+   // PyYAML float resolver: requires a dot and a signed exponent ("1.5e+3",
+   // not "1.5e3" — the latter stays a string in PyYAML).
+   return /^[-+]?(?:\d[\d_]*\.[\d_]*|\.[\d_]+)(?:[eE][-+]\d+)?$/.test(raw) ||
+      /^[-+]?\.(?:inf|Inf|INF)$/.test(raw) ||
+      /^\.(?:nan|NaN|NAN)$/.test(raw);
+}
+
 function readPromptInjectionSkipKeyword(projectRoot: string): string {
    let config = "";
    try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD; }
@@ -743,7 +758,16 @@ function readPromptInjectionSkipKeyword(projectRoot: string): string {
       if (indent <= sectionIndent) break;
       const match = trimmed.match(/^skip_keyword\s*:\s*(.*)$/);
       if (!match) continue;
-      return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
+      const rawValue = stripInlineComment(match[1]!).trim();
+      const unquoted = unquoteYaml(rawValue);
+      // Preserve YAML scalar typing, mirroring _resolve_skip_keyword's
+      // isinstance(raw, str) check: a bare non-string scalar (bool/null/
+      // number, including an empty value) falls back to the default, while
+      // quoted scalars — including an explicit "" — stay strings.
+      if (unquoted === rawValue && isYamlNonStringScalar(rawValue)) {
+         return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
+      }
+      return unquoted.trim();
    }
    return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
 }

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -773,13 +773,20 @@ class TurnContextCache {
    private key: string | null = null;
    private timestamp = 0;
    private workflowMsg = "";
+   private skipThisTurn = false;
    private static readonly TTL_MS = 1500;
 
-   get(projectRoot: string, contextKey: string | null, skipThisTurn: boolean = false): { workflowMsg: string } {
+   // Called once per user turn (input event) with the skip decision for that
+   // turn; invalidates the cache so every reader in the cascade
+   // (before_agent_start, context) resolves the same turn state.
+   beginTurn(skipThisTurn: boolean): void {
+      this.skipThisTurn = skipThisTurn;
+      this.key = null;
+   }
+
+   get(projectRoot: string, contextKey: string | null): { workflowMsg: string } {
       const now = Date.now();
-      // skipThisTurn participates in the cache key: a skip turn cached within
-      // the TTL must not leak an empty message into the next (non-skip) turn.
-      const cacheKey = `${projectRoot}:${contextKey ?? ""}:${skipThisTurn ? "skip" : "full"}`;
+      const cacheKey = `${projectRoot}:${contextKey ?? ""}`;
       if (
          this.key === cacheKey &&
          now - this.timestamp < TurnContextCache.TTL_MS
@@ -806,7 +813,7 @@ class TurnContextCache {
       }
 
       // When skip keyword is present, skip workflow state injection this turn
-      this.workflowMsg = skipThisTurn
+      this.workflowMsg = this.skipThisTurn
          ? ""
          : `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
 
@@ -998,11 +1005,15 @@ export default function(pi: ExtensionAPI): void {
          if (replacement && !replaced) projectedMessages.push(replacement);
       }
 
-      // Fast path: no task change and no compaction — all persisted context is current.
-      if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
-
+      // Resolve the turn state before the fast path: a skip turn must still
+      // run breadcrumb cleanup even when nothing else changed.
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) {
+      const skipping = !cached.workflowMsg;
+
+      // Fast path: no task change, no compaction, not skipping — all persisted context is current.
+      if (!taskContextChanged && !skipping && lastInjectionTs > lastCompactionTs) return;
+
+      if (skipping) {
          // Skip turn (escape hatch): drop any persisted breadcrumb from an
          // earlier turn so the skip actually takes effect.
          const withoutBreadcrumb = projectedMessages.filter(
@@ -1062,7 +1073,9 @@ export default function(pi: ExtensionAPI): void {
       const skipKeyword = readPromptInjectionSkipKeyword(projectRoot);
       const skipThisTurn = shouldSkipWorkflowState(event.text ?? "", skipKeyword);
 
-      // Pre-warm the cache so before_agent_start and context can use it
-      turnCache.get(projectRoot, contextKey, skipThisTurn);
+      // Record the turn's skip decision and pre-warm the cache so
+      // before_agent_start and context can use it
+      turnCache.beginTurn(skipThisTurn);
+      turnCache.get(projectRoot, contextKey);
    });
 }

--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -718,11 +718,14 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 // Prompt injection config (escape hatch)
 // ---------------------------------------------------------------------------
 
-// Unset config (or missing config.yaml) disables the escape hatch; only an
-// explicit prompt_injection.skip_keyword enables per-turn skipping.
+// Mirrors DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD in inject-workflow-state.py:
+// the skip keyword defaults to "no-trellis"; an explicit "" disables the
+// escape hatch entirely.
+const DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD = "no-trellis";
+
 function readPromptInjectionSkipKeyword(projectRoot: string): string {
    let config = "";
-   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return ""; }
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD; }
 
    let inSection = false;
    let sectionIndent = -1;
@@ -742,12 +745,12 @@ function readPromptInjectionSkipKeyword(projectRoot: string): string {
       if (!match) continue;
       return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
    }
-   return "";
+   return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
 }
 
-// Hyphen counts as a word char so "no-trellisx" / "xno-trellis" /
-// "foo-no-trellis" don't match, but punctuation/whitespace boundaries do.
-// Empty keyword (unset config) never matches.
+// Mirrors prompt_has_skip_keyword() in inject-workflow-state.py: hyphen counts
+// as a word char so "no-trellisx" / "xno-trellis" / "foo-no-trellis" don't
+// match, but punctuation/whitespace boundaries do. Empty keyword never matches.
 function shouldSkipWorkflowState(
    userInput: string,
    skipKeyword: string,

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -715,6 +715,50 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 }
 
 // ---------------------------------------------------------------------------
+// Prompt injection config (escape hatch)
+// ---------------------------------------------------------------------------
+
+// Unset config (or missing config.yaml) disables the escape hatch; only an
+// explicit prompt_injection.skip_keyword enables per-turn skipping.
+function readPromptInjectionSkipKeyword(projectRoot: string): string {
+   let config = "";
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return ""; }
+
+   let inSection = false;
+   let sectionIndent = -1;
+   for (const rawLine of config.split(/\r?\n/)) {
+      const trimmed = rawLine.trim();
+      if (!inSection) {
+         if (/^prompt_injection\s*:\s*(#.*)?$/.test(trimmed)) {
+            inSection = true;
+            sectionIndent = rawLine.length - rawLine.trimStart().length;
+         }
+         continue;
+      }
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const indent = rawLine.length - rawLine.trimStart().length;
+      if (indent <= sectionIndent) break;
+      const match = trimmed.match(/^skip_keyword\s*:\s*(.*)$/);
+      if (!match) continue;
+      return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
+   }
+   return "";
+}
+
+// Hyphen counts as a word char so "no-trellisx" / "xno-trellis" /
+// "foo-no-trellis" don't match, but punctuation/whitespace boundaries do.
+// Empty keyword (unset config) never matches.
+function shouldSkipWorkflowState(
+   userInput: string,
+   skipKeyword: string,
+): boolean {
+   if (!skipKeyword) return false;
+   const escapedKeyword = skipKeyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+   const pattern = new RegExp(`(?<![\\w-])${escapedKeyword}(?![\\w-])`, "i");
+   return pattern.test(userInput);
+}
+
+// ---------------------------------------------------------------------------
 // Per-turn cache — prevents redundant workflow-state resolution within a
 // single event cascade (input, before_agent_start, and context fire closely)
 // ---------------------------------------------------------------------------
@@ -728,9 +772,11 @@ class TurnContextCache {
    private workflowMsg = "";
    private static readonly TTL_MS = 1500;
 
-   get(projectRoot: string, contextKey: string | null): { workflowMsg: string } {
+   get(projectRoot: string, contextKey: string | null, skipThisTurn: boolean = false): { workflowMsg: string } {
       const now = Date.now();
-      const cacheKey = `${projectRoot}:${contextKey ?? ""}`;
+      // skipThisTurn participates in the cache key: a skip turn cached within
+      // the TTL must not leak an empty message into the next (non-skip) turn.
+      const cacheKey = `${projectRoot}:${contextKey ?? ""}:${skipThisTurn ? "skip" : "full"}`;
       if (
          this.key === cacheKey &&
          now - this.timestamp < TurnContextCache.TTL_MS
@@ -756,7 +802,10 @@ class TurnContextCache {
          workflowBody = "Refer to workflow.md for current step.";
       }
 
-      this.workflowMsg = `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
+      // When skip keyword is present, skip workflow state injection this turn
+      this.workflowMsg = skipThisTurn
+         ? ""
+         : `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
 
       this.key = cacheKey;
       this.timestamp = now;
@@ -902,6 +951,9 @@ export default function(pi: ExtensionAPI): void {
       const cached = turnCache.get(projectRoot, contextKey);
       lastInjectionTs = Date.now();
 
+      // Skip turn: inject nothing (escape hatch)
+      if (!cached.workflowMsg) return;
+
       return {
          message: {
             customType: "trellis-workflow-state",
@@ -947,7 +999,16 @@ export default function(pi: ExtensionAPI): void {
       if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
 
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) return taskContextChanged ? { messages: projectedMessages } : undefined;
+      if (!cached.workflowMsg) {
+         // Skip turn (escape hatch): drop any persisted breadcrumb from an
+         // earlier turn so the skip actually takes effect.
+         const withoutBreadcrumb = projectedMessages.filter(
+            (message) => !(message.role === "custom" && message.customType === "trellis-workflow-state"),
+         );
+         if (withoutBreadcrumb.length === projectedMessages.length && !taskContextChanged) return;
+         lastInjectionTs = Date.now();
+         return { messages: withoutBreadcrumb };
+      }
 
       // Post-compaction: reverse-scan to confirm absence before injecting
       for (let i = projectedMessages.length - 1; i >= 0; i--) {
@@ -986,14 +1047,19 @@ export default function(pi: ExtensionAPI): void {
       };
    });
 
-   pi.on("input", async (_event, ctx) => {
+   pi.on("input", async (event, ctx) => {
       if (!projectRoot) {
          projectRoot = findProjectRoot(ctx.cwd);
       }
       // Resolve projectRoot on first input if session_start missed it
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
+
+      // Check if this turn should skip workflow state injection
+      const skipKeyword = readPromptInjectionSkipKeyword(projectRoot);
+      const skipThisTurn = shouldSkipWorkflowState(event.text ?? "", skipKeyword);
+
       // Pre-warm the cache so before_agent_start and context can use it
-      turnCache.get(projectRoot, contextKey);
+      turnCache.get(projectRoot, contextKey, skipThisTurn);
    });
 }

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -723,6 +723,21 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 // escape hatch entirely.
 const DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD = "no-trellis";
 
+// PyYAML-compatible resolution of scalars that parse as non-strings: null
+// (empty, ~, null variants), bool (YAML 1.1 set), and numbers. Quoted scalars
+// never reach this check and stay strings.
+function isYamlNonStringScalar(raw: string): boolean {
+   if (raw === "" || raw === "~" || /^(?:null|Null|NULL)$/.test(raw)) return true;
+   if (/^(?:true|True|TRUE|false|False|FALSE|yes|Yes|YES|no|No|NO|on|On|ON|off|Off|OFF)$/.test(raw)) return true;
+   // PyYAML int resolver: binary/octal/decimal/hex; leading-zero decimals are not ints.
+   if (/^[-+]?(?:0[bB][01_]+|0[0-7_]+|0[xX][0-9a-fA-F_]+|[1-9][\d_]*|0)$/.test(raw)) return true;
+   // PyYAML float resolver: requires a dot and a signed exponent ("1.5e+3",
+   // not "1.5e3" — the latter stays a string in PyYAML).
+   return /^[-+]?(?:\d[\d_]*\.[\d_]*|\.[\d_]+)(?:[eE][-+]\d+)?$/.test(raw) ||
+      /^[-+]?\.(?:inf|Inf|INF)$/.test(raw) ||
+      /^\.(?:nan|NaN|NAN)$/.test(raw);
+}
+
 function readPromptInjectionSkipKeyword(projectRoot: string): string {
    let config = "";
    try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD; }
@@ -743,7 +758,16 @@ function readPromptInjectionSkipKeyword(projectRoot: string): string {
       if (indent <= sectionIndent) break;
       const match = trimmed.match(/^skip_keyword\s*:\s*(.*)$/);
       if (!match) continue;
-      return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
+      const rawValue = stripInlineComment(match[1]!).trim();
+      const unquoted = unquoteYaml(rawValue);
+      // Preserve YAML scalar typing, mirroring _resolve_skip_keyword's
+      // isinstance(raw, str) check: a bare non-string scalar (bool/null/
+      // number, including an empty value) falls back to the default, while
+      // quoted scalars — including an explicit "" — stay strings.
+      if (unquoted === rawValue && isYamlNonStringScalar(rawValue)) {
+         return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
+      }
+      return unquoted.trim();
    }
    return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
 }

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -773,13 +773,20 @@ class TurnContextCache {
    private key: string | null = null;
    private timestamp = 0;
    private workflowMsg = "";
+   private skipThisTurn = false;
    private static readonly TTL_MS = 1500;
 
-   get(projectRoot: string, contextKey: string | null, skipThisTurn: boolean = false): { workflowMsg: string } {
+   // Called once per user turn (input event) with the skip decision for that
+   // turn; invalidates the cache so every reader in the cascade
+   // (before_agent_start, context) resolves the same turn state.
+   beginTurn(skipThisTurn: boolean): void {
+      this.skipThisTurn = skipThisTurn;
+      this.key = null;
+   }
+
+   get(projectRoot: string, contextKey: string | null): { workflowMsg: string } {
       const now = Date.now();
-      // skipThisTurn participates in the cache key: a skip turn cached within
-      // the TTL must not leak an empty message into the next (non-skip) turn.
-      const cacheKey = `${projectRoot}:${contextKey ?? ""}:${skipThisTurn ? "skip" : "full"}`;
+      const cacheKey = `${projectRoot}:${contextKey ?? ""}`;
       if (
          this.key === cacheKey &&
          now - this.timestamp < TurnContextCache.TTL_MS
@@ -806,7 +813,7 @@ class TurnContextCache {
       }
 
       // When skip keyword is present, skip workflow state injection this turn
-      this.workflowMsg = skipThisTurn
+      this.workflowMsg = this.skipThisTurn
          ? ""
          : `<workflow-state>\n${workflowBody}\n</workflow-state>\n\n<session-overview>\n${SESSION_OVERVIEW_TEXT}\n</session-overview>`;
 
@@ -998,11 +1005,15 @@ export default function(pi: ExtensionAPI): void {
          if (replacement && !replaced) projectedMessages.push(replacement);
       }
 
-      // Fast path: no task change and no compaction — all persisted context is current.
-      if (!taskContextChanged && lastInjectionTs > lastCompactionTs) return;
-
+      // Resolve the turn state before the fast path: a skip turn must still
+      // run breadcrumb cleanup even when nothing else changed.
       const cached = turnCache.get(projectRoot, contextKey);
-      if (!cached.workflowMsg) {
+      const skipping = !cached.workflowMsg;
+
+      // Fast path: no task change, no compaction, not skipping — all persisted context is current.
+      if (!taskContextChanged && !skipping && lastInjectionTs > lastCompactionTs) return;
+
+      if (skipping) {
          // Skip turn (escape hatch): drop any persisted breadcrumb from an
          // earlier turn so the skip actually takes effect.
          const withoutBreadcrumb = projectedMessages.filter(
@@ -1062,7 +1073,9 @@ export default function(pi: ExtensionAPI): void {
       const skipKeyword = readPromptInjectionSkipKeyword(projectRoot);
       const skipThisTurn = shouldSkipWorkflowState(event.text ?? "", skipKeyword);
 
-      // Pre-warm the cache so before_agent_start and context can use it
-      turnCache.get(projectRoot, contextKey, skipThisTurn);
+      // Record the turn's skip decision and pre-warm the cache so
+      // before_agent_start and context can use it
+      turnCache.beginTurn(skipThisTurn);
+      turnCache.get(projectRoot, contextKey);
    });
 }

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -718,11 +718,14 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
 // Prompt injection config (escape hatch)
 // ---------------------------------------------------------------------------
 
-// Unset config (or missing config.yaml) disables the escape hatch; only an
-// explicit prompt_injection.skip_keyword enables per-turn skipping.
+// Mirrors DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD in inject-workflow-state.py:
+// the skip keyword defaults to "no-trellis"; an explicit "" disables the
+// escape hatch entirely.
+const DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD = "no-trellis";
+
 function readPromptInjectionSkipKeyword(projectRoot: string): string {
    let config = "";
-   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return ""; }
+   try { config = readFileSync(join(projectRoot, ".trellis", "config.yaml"), "utf-8"); } catch { return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD; }
 
    let inSection = false;
    let sectionIndent = -1;
@@ -742,12 +745,12 @@ function readPromptInjectionSkipKeyword(projectRoot: string): string {
       if (!match) continue;
       return unquoteYaml(stripInlineComment(match[1]!).trim()).trim();
    }
-   return "";
+   return DEFAULT_PROMPT_INJECTION_SKIP_KEYWORD;
 }
 
-// Hyphen counts as a word char so "no-trellisx" / "xno-trellis" /
-// "foo-no-trellis" don't match, but punctuation/whitespace boundaries do.
-// Empty keyword (unset config) never matches.
+// Mirrors prompt_has_skip_keyword() in inject-workflow-state.py: hyphen counts
+// as a word char so "no-trellisx" / "xno-trellis" / "foo-no-trellis" don't
+// match, but punctuation/whitespace boundaries do. Empty keyword never matches.
 function shouldSkipWorkflowState(
    userInput: string,
    skipKeyword: string,


### PR DESCRIPTION
## Bug Description

The config option `prompt_injection.skip_keyword` defined in `.trellis/config.yaml` is not implemented in the OMP extension.

```yaml
prompt_injection:
  skip_keyword: "no-trellis"   # "" disables the escape hatch entirely
```

**Expected behavior:** When a user prompt contains the configured keyword as a standalone word (case-insensitive, word-boundary match), the `<workflow-state>` breadcrumb should be skipped for that turn only. Defaults to `"no-trellis"` when unset, mirroring the Python hook (`_resolve_skip_keyword` in `inject-workflow-state.py`); an explicit `""` disables the escape hatch. Does not affect SessionStart or sub-agent context injection.

**Actual behavior:** `.omp/extensions/trellis/index.ts` contains no references to `skip_keyword`, `prompt_injection`, or any related parsing logic. The skip keyword feature does not work on the OMP platform.

## Steps to Reproduce

1. Set `prompt_injection.skip_keyword: "no-trellis"` in `.trellis/config.yaml`
2. Send a prompt containing the word `no-trellis` (e.g., "do something no-trellis")
3. Observe that the `<workflow-state>` breadcrumb is still injected for that turn
4. Verify by searching `index.ts` — no code handles this config option

## Fix

Implemented in both `.omp/extensions/trellis/index.ts` and the template `packages/cli/src/templates/omp/extensions/trellis/index.ts.txt`:

1. `readPromptInjectionSkipKeyword()` — section-aware line parser for `prompt_injection.skip_keyword` (reuses `stripInlineComment`/`unquoteYaml` helpers); unset config → `"no-trellis"` default, explicit `""` disables
2. `shouldSkipWorkflowState()` — lookaround boundary match `(?<![\\w-])kw(?![\\w-])`, case-insensitive: "no-trellisfoo" / "foo-no-trellis" do not count
3. `TurnContextCache.get()` — `skipThisTurn` participates in the cache key so a skip turn never leaks an empty message into the next turn
4. `before_agent_start` — skip turn injects nothing (no empty-content message)
5. `context` — skip turn drops any persisted breadcrumb from earlier turns so the escape hatch takes effect immediately

Closes #585

## Environment

- Platform: OMP (`.omp/extensions/trellis/index.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration keyword to bypass workflow-state and session-overview context for the current turn.
  * Keyword matching is case-insensitive and recognizes complete words only.
  * Matching turns remove previously persisted workflow-state breadcrumbs.
  * Bypass behavior applies only to the matching turn and does not affect subsequent turns.
  * Configuration values now handle quoted and unquoted YAML scalars consistently, including explicit empty strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->