### PR TITLE
fix(shared-hooks): port the guarded stdin read to the remaining three hooks (session-start.py hangs until EOF on hosts that keep stdin open)

### DIFF
--- a/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
@@ -265,6 +265,7 @@ def _load_hook_input() -> dict:
     result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
 
     def _read() -> None:
+        """Read all of stdin onto the queue; never raises."""
         try:
             result_queue.put(sys.stdin.read())
         except Exception as exc:
@@ -287,6 +288,7 @@ def _load_hook_input() -> dict:
 
 
 def main() -> int:
+    """Write a shell-session identity ticket for pending task.py commands."""
     if os.environ.get("TRELLIS_HOOKS") == "0" or os.environ.get("TRELLIS_DISABLE_HOOKS") == "1":
         return 0
 

--- a/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-shell-session-context.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import queue
 import shlex
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -249,16 +251,46 @@ def _write_ticket(
     )
 
 
+def _load_hook_input() -> dict:
+    """Read hook JSON without trusting host runners to close stdin.
+
+    Kiro IDE `runCommand` and similar hook runners can leave stdin open while
+    sending no payload. A plain `json.load(sys.stdin)` then blocks forever.
+    Normal hook runners write the complete JSON payload and close stdin, so the
+    short daemon read preserves that path while failing closed to `{}` for
+    non-piping hosts. The abandoned daemon thread is safe: interpreter
+    shutdown discards daemon threads outright (threading docs), so the
+    process exits without waiting for the pipe.
+    """
+    result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
+
+    def _read() -> None:
+        try:
+            result_queue.put(sys.stdin.read())
+        except Exception as exc:
+            result_queue.put(exc)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    try:
+        raw = result_queue.get(timeout=0.2)
+    except queue.Empty:
+        return {}
+
+    if isinstance(raw, Exception):
+        return {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def main() -> int:
     if os.environ.get("TRELLIS_HOOKS") == "0" or os.environ.get("TRELLIS_DISABLE_HOOKS") == "1":
         return 0
 
-    try:
-        hook_input = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, ValueError):
-        hook_input = {}
-    if not isinstance(hook_input, dict):
-        hook_input = {}
+    hook_input = _load_hook_input()
 
     command, response = _pending_shell_command(hook_input)
     subcommands = _extract_task_subcommands(command)

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -1105,6 +1105,7 @@ def _load_hook_input() -> dict:
     result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
 
     def _read() -> None:
+        """Read all of stdin onto the queue; never raises."""
         try:
             result_queue.put(sys.stdin.read())
         except Exception as exc:
@@ -1127,6 +1128,7 @@ def _load_hook_input() -> dict:
 
 
 def main():
+    """Rewrite the spawned sub-agent prompt with Trellis task context."""
     if os.environ.get("TRELLIS_HOOKS") == "0" or os.environ.get("TRELLIS_DISABLE_HOOKS") == "1":
         sys.exit(0)
 

--- a/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
+++ b/packages/cli/src/templates/shared-hooks/inject-subagent-context.py
@@ -28,7 +28,9 @@ warnings.filterwarnings("ignore")
 
 import json
 import os
+import queue
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -1089,14 +1091,46 @@ def _parse_hook_input(input_data: dict) -> tuple[str, str, dict]:
     return "", "", tool_input
 
 
+def _load_hook_input() -> dict:
+    """Read hook JSON without trusting host runners to close stdin.
+
+    Kiro IDE `runCommand` and similar hook runners can leave stdin open while
+    sending no payload. A plain `json.load(sys.stdin)` then blocks forever.
+    Normal hook runners write the complete JSON payload and close stdin, so the
+    short daemon read preserves that path while failing closed to `{}` for
+    non-piping hosts. The abandoned daemon thread is safe: interpreter
+    shutdown discards daemon threads outright (threading docs), so the
+    process exits without waiting for the pipe.
+    """
+    result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
+
+    def _read() -> None:
+        try:
+            result_queue.put(sys.stdin.read())
+        except Exception as exc:
+            result_queue.put(exc)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    try:
+        raw = result_queue.get(timeout=0.2)
+    except queue.Empty:
+        return {}
+
+    if isinstance(raw, Exception):
+        return {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def main():
     if os.environ.get("TRELLIS_HOOKS") == "0" or os.environ.get("TRELLIS_DISABLE_HOOKS") == "1":
         sys.exit(0)
 
-    try:
-        input_data = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        sys.exit(0)
+    input_data = _load_hook_input()
     if not isinstance(input_data, dict):
         sys.exit(0)
 

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -835,6 +835,7 @@ def _load_hook_input() -> dict:
     result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
 
     def _read() -> None:
+        """Read all of stdin onto the queue; never raises."""
         try:
             result_queue.put(sys.stdin.read())
         except Exception as exc:
@@ -857,6 +858,7 @@ def _load_hook_input() -> dict:
 
 
 def main():
+    """Assemble and print the SessionStart additionalContext payload."""
     if should_skip_injection():
         sys.exit(0)
 

--- a/packages/cli/src/templates/shared-hooks/session-start.py
+++ b/packages/cli/src/templates/shared-hooks/session-start.py
@@ -11,10 +11,12 @@ warnings.filterwarnings("ignore")
 
 import json
 import os
+import queue
 import re
 import shlex
 import subprocess
 import sys
+import threading
 from io import StringIO
 from pathlib import Path
 
@@ -819,16 +821,46 @@ def _build_workflow_overview(workflow_path: Path) -> str:
     return "\n".join(out_lines).rstrip()
 
 
+def _load_hook_input() -> dict:
+    """Read hook JSON without trusting host runners to close stdin.
+
+    Kiro IDE `runCommand` and similar hook runners can leave stdin open while
+    sending no payload. A plain `json.load(sys.stdin)` then blocks forever.
+    Normal hook runners write the complete JSON payload and close stdin, so the
+    short daemon read preserves that path while failing closed to `{}` for
+    non-piping hosts. The abandoned daemon thread is safe: interpreter
+    shutdown discards daemon threads outright (threading docs), so the
+    process exits without waiting for the pipe.
+    """
+    result_queue: "queue.Queue[str | Exception]" = queue.Queue(maxsize=1)
+
+    def _read() -> None:
+        try:
+            result_queue.put(sys.stdin.read())
+        except Exception as exc:
+            result_queue.put(exc)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    try:
+        raw = result_queue.get(timeout=0.2)
+    except queue.Empty:
+        return {}
+
+    if isinstance(raw, Exception):
+        return {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def main():
     if should_skip_injection():
         sys.exit(0)
 
-    try:
-        hook_input = json.loads(sys.stdin.read())
-        if not isinstance(hook_input, dict):
-            hook_input = {}
-    except (json.JSONDecodeError, ValueError):
-        hook_input = {}
+    hook_input = _load_hook_input()
 
     # Try platform-specific env vars, hook cwd, fallback to cwd
     project_dir_env_vars = [


### PR DESCRIPTION
Fixes #590 — follow-up to #356.

## What

`#356` added a guarded stdin read (`_load_hook_input()`: daemon thread + 0.2s timeout, fail closed to `{}`) to `inject-workflow-state.py`, because some hook runners (Kiro IDE `runCommand` and similar desktop IDE runners) write the hook payload but never close stdin — a plain `sys.stdin.read()` on the main thread then blocks until EOF.

That guard was never ported to the other three shared hooks, which still read stdin unguarded:

- `session-start.py` — runs on every **startup / clear / compact**, the most latency-sensitive path
- `inject-subagent-context.py`
- `inject-shell-session-context.py`

This PR ports `_load_hook_input()` **as-is** (function body identical to the one already shipping in `inject-workflow-state.py`) into those three files and swaps the unguarded reads for it. No new pattern is introduced.

## Measured impact

Polling the hook process directly while stdin is held open for 20s (Windows 10 x64, Python 3.13.13):

| Script | before | after |
|---|---|---|
| `session-start.py` | alive the full 20s — hangs until the host closes/kills | ~7s, its own normal work, exits on its own |
| `inject-subagent-context.py` | 20s | exits immediately |
| `inject-shell-session-context.py` | 20s | exits immediately |

With a host kill-timeout (e.g. 30s on SessionStart in some host wirings) the before-column is a fixed 30s stall on every session start/clear/compact; without one, an indefinite hang.

With stdin closed normally (the standard runner behavior), the patched scripts' stdout is **byte-identical** to the unpatched ones, verified by diffing both runs' output.

## Alternatives considered (and why not)

- **`select()`-based non-blocking stdin** — rejected: per the [Python `select` docs](https://docs.python.org/3/library/select.html), *"File objects on Windows are not acceptable, but sockets are"* (WinSock `select()` does not handle non-socket fds). Not portable for a cross-platform template.
- **`os._exit()` shim to bypass interpreter finalization** — not needed: interpreter shutdown discards daemon threads outright ([`threading` docs](https://docs.python.org/3/library/threading.html#threading.Thread.daemon): *"Daemon threads are abruptly stopped at shutdown"*), which is exactly why the #356 pattern already exits cleanly. An `os._exit` shim would also deviate from its documented normal use (*"The standard way to exit is sys.exit(n). _exit() should normally only be used in the child process after a fork()"*) and require manual stdio flushing to compensate. Left out per KISS; can be added later if a platform/Python version ever shows a daemon-related shutdown stall.

## Verification

- `python -m py_compile` passes for all three patched scripts.
- Hang-path: payload written, stdin held open 20s → all three processes now exit on their own (exit code 0, output produced where applicable).
- Regression: payload written, stdin closed → output byte-identical to the unpatched scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session, shell-session, and subagent hooks from hanging when no input is provided.
  * Added graceful handling for empty, invalid, unavailable, or unexpected hook input.
  * Improved compatibility with environments that leave standard input open without sending data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->