### PR TITLE
fix(omp): keep task context append-only for provider prefix caching (#595)

### DIFF
--- a/.omp/extensions/trellis/index.ts
+++ b/.omp/extensions/trellis/index.ts
@@ -353,13 +353,20 @@ interface ContextInjectionLimits {
    max_file_bytes: number;
    max_artifact_bytes: number;
    max_total_bytes: number;
+   /** Largest unified diff (bytes) appended for one file before falling back to the full block. */
+   diff_max_bytes: number;
+   /** Consecutive diffs allowed per file within one compaction epoch before a full block resets the baseline. */
+   diff_max_stack: number;
 }
 
 const DEFAULT_CONTEXT_INJECTION_LIMITS: ContextInjectionLimits = {
    max_file_bytes: 32768,
    max_artifact_bytes: 65536,
    max_total_bytes: 131072,
+   diff_max_bytes: 8192,
+   diff_max_stack: 3,
 };
+
 const MAX_JSONL_BYTES = 1024 * 1024;
 
 function stripInlineComment(value: string): string {
@@ -619,61 +626,71 @@ function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string
    }
 }
 
-function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
-   const parts: string[] = [];
+/** One ordered unit of task context, before the total-bytes budget is applied. */
+type TaskContextEntry =
+   | { kind: "artifact"; displayPath: string; materialized: MaterializedFile }
+   | { kind: "manifest-omitted"; section: string; displayPath: string; notice: string }
+   | { kind: "file"; section: string; displayPath: string; materialized: MaterializedFile };
+
+/**
+ * Materializes prd.md, info.md and every manifest-referenced file in the order
+ * they are injected. Per-file caps are applied here; the shared total budget is
+ * applied by the consumer so the same entries can feed both the system prompt
+ * block and the per-file update baselines.
+ */
+function materializeTaskContextFiles(projectRoot: string, taskDir: string, agentType?: AgentType): TaskContextEntry[] {
+   const entries: TaskContextEntry[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
    const limits = readContextInjectionLimits(projectRoot);
-   const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
-   const suffix = "\n</task-context>";
-   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
-   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) return "";
-   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
-
-   const appendCandidate = (primary: string | null, fallback: string | null = null): void => {
-      const separator = parts.length > 0 ? "\n\n" : "";
-      const output = budget.emitCandidate(
-         primary === null ? null : separator + primary,
-         fallback === null ? null : separator + fallback,
-      );
-      if (output !== null) parts.push(output);
-   };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
-   const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
    if (existsSync(prdPath)) {
-      const artifact = materialize(prdPath, relativePrdPath, "Requirements document", limits.max_artifact_bytes, "artifact");
-      appendCandidate(artifact.block, artifact.notice);
+      const displayPath = displayProjectPath(projectRoot, prdPath, taskDir);
+      entries.push({
+         kind: "artifact",
+         displayPath,
+         materialized: materialize(
+            prdPath,
+            displayPath,
+            "Requirements document",
+            limits.max_artifact_bytes,
+            "artifact",
+         ),
+      });
    }
    const infoPath = join(taskDir, "info.md");
-   const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
    if (existsSync(infoPath)) {
-      const artifact = materialize(infoPath, relativeInfoPath, "Task information", limits.max_artifact_bytes, "artifact");
-      appendCandidate(artifact.block, artifact.notice);
+      const displayPath = displayProjectPath(projectRoot, infoPath, taskDir);
+      entries.push({
+         kind: "artifact",
+         displayPath,
+         materialized: materialize(infoPath, displayPath, "Task information", limits.max_artifact_bytes, "artifact"),
+      });
    }
-
-   // Determine which jsonl files to read based on agent type
-   const jsonlNames = taskContextJsonlNames(agentType);
 
    // A file may be referenced by both manifests. Use the resolved real path so
    // relative aliases and symlinked paths cannot consume the context budget twice.
    const includedPaths = new Set<string>();
 
-   for (const jsonlName of jsonlNames) {
+   for (const jsonlName of taskContextJsonlNames(agentType)) {
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
 
       const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
       const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
       if (manifest.omitted) {
-         appendCandidate(`## ${jsonlName}\n\n${manifest.omitted}`);
+         entries.push({
+            kind: "manifest-omitted",
+            section: jsonlName,
+            displayPath: relativeJsonlPath,
+            notice: manifest.omitted,
+         });
          continue;
       }
 
-      const fileChunks: string[] = [];
-      let sectionHeaderEmitted = false;
       for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
@@ -685,33 +702,122 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            const materialized = materialize(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits.max_file_bytes, "file");
-            const sectionPrefix = sectionHeaderEmitted
-               ? "\n\n---\n\n"
-               : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
-            const output = budget.emitCandidate(
-               materialized.block === null ? null : `${sectionPrefix}${materialized.block}`,
-               `${sectionPrefix}${materialized.notice}`,
-            );
-            if (output !== null) {
-               fileChunks.push(output);
-               sectionHeaderEmitted = true;
-            }
+            entries.push({
+               kind: "file",
+               section: jsonlName,
+               displayPath: file,
+               materialized: materialize(
+                  targetPath,
+                  file,
+                  typeof row.reason === "string" ? row.reason : "-",
+                  limits.max_file_bytes,
+                  "file",
+               ),
+            });
          } catch {
             // seed rows and malformed lines are non-fatal
          }
       }
-
-      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
    }
+   return entries;
+}
 
-   if (parts.length === 0) return "";
+/** Text the model is meant to see for one entry when the total budget allows it. */
+function entryBlock(entry: TaskContextEntry): string {
+   if (entry.kind === "manifest-omitted") return entry.notice;
+   return entry.materialized.block ?? entry.materialized.notice;
+}
+
+interface RenderedTaskContext {
+   content: string;
+   /** Display paths whose materialized text was replaced by a notice or dropped by the total budget. */
+   omittedPaths: Set<string>;
+}
+
+/**
+ * Renders materialized entries into the `<task-context>` block under the
+ * shared total budget. `omittedPaths` lets the caller avoid diffing against
+ * text the model never received.
+ */
+function renderTaskContext(projectRoot: string, entries: TaskContextEntry[]): RenderedTaskContext {
+   const parts: string[] = [];
+   const omittedPaths = new Set<string>();
+   const limits = readContextInjectionLimits(projectRoot);
+   const prefix =
+      "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
+   const suffix = "\n</task-context>";
+   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) {
+      for (const entry of entries) omittedPaths.add(entry.displayPath);
+      return { content: "", omittedPaths };
+   }
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+
+   // Emits `primary` (or `fallback` once the budget is exhausted) and reports
+   // whether the text the baseline will remember (`shown`) is what went out.
+   const appendCandidate = (primary: string | null, fallback: string | null, shown: string): boolean => {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const output = budget.emitCandidate(
+         primary === null ? null : separator + primary,
+         fallback === null ? null : separator + fallback,
+      );
+      if (output !== null) parts.push(output);
+      return output === separator + shown;
+   };
+
+   let sectionName: string | null = null;
+   let fileChunks: string[] = [];
+   let sectionHeaderEmitted = false;
+   const flushSection = (): void => {
+      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
+      fileChunks = [];
+      sectionHeaderEmitted = false;
+      sectionName = null;
+   };
+
+   for (const entry of entries) {
+      if (entry.kind === "artifact") {
+         const shown = entryBlock(entry);
+         if (!appendCandidate(entry.materialized.block, entry.materialized.notice, shown)) {
+            omittedPaths.add(entry.displayPath);
+         }
+         continue;
+      }
+      if (entry.section !== sectionName) {
+         flushSection();
+         sectionName = entry.section;
+      }
+      if (entry.kind === "manifest-omitted") {
+         const text = `## ${entry.section}\n\n${entry.notice}`;
+         if (!appendCandidate(text, null, text)) omittedPaths.add(entry.displayPath);
+         sectionName = null;
+         continue;
+      }
+      const sectionPrefix = sectionHeaderEmitted
+         ? "\n\n---\n\n"
+         : `${parts.length > 0 ? "\n\n" : ""}## ${entry.section}\n\n`;
+      const primary = entry.materialized.block === null ? null : `${sectionPrefix}${entry.materialized.block}`;
+      const output = budget.emitCandidate(primary, `${sectionPrefix}${entry.materialized.notice}`);
+      if (output !== null) {
+         fileChunks.push(output);
+         sectionHeaderEmitted = true;
+      }
+      if (output !== `${sectionPrefix}${entryBlock(entry)}`) omittedPaths.add(entry.displayPath);
+   }
+   flushSection();
+
+   if (parts.length === 0) return { content: "", omittedPaths };
    const context = `${prefix}${parts.join("")}${suffix}`;
-   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes) return context;
+   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes)
+      return { content: context, omittedPaths };
    const suffixBytes = Buffer.byteLength(suffix, "utf-8");
    const bodyLimit = Math.max(0, limits.max_total_bytes - suffixBytes);
    const body = truncateUtf8(Buffer.from(`${prefix}${parts.join("")}`, "utf-8"), bodyLimit).toString("utf-8");
-   return `${body}${suffix}`;
+   return { content: `${body}${suffix}`, omittedPaths };
+}
+
+function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
+   return renderTaskContext(projectRoot, materializeTaskContextFiles(projectRoot, taskDir, agentType)).content;
 }
 
 // ---------------------------------------------------------------------------
@@ -884,44 +990,462 @@ function detectAgentType(): AgentType {
    return null;
 }
 
-interface TaskContextCache {
-   projectRoot: string;
-   taskDir: string;
-   agentType: AgentType;
-   signature: string;
-   content: string;
+const SESSION_CONTEXT_TYPE = "trellis-session-context";
+const TASK_CONTEXT_TYPE = "trellis-task-context";
+const TASK_CONTEXT_UPDATE_TYPE = "trellis-task-context-update";
+const WORKFLOW_STATE_TYPE = "trellis-workflow-state";
+
+// ---------------------------------------------------------------------------
+// Line diff — self-contained Myers O(ND) with unified output. The provider
+// prefix cache only survives when history is append-only, so task file
+// changes are delivered as diffs against the last snapshot the model saw.
+// ---------------------------------------------------------------------------
+
+/** Lines per side beyond which a diff is not attempted; the full block is sent instead. */
+const DIFF_MAX_LINES = 4000;
+/** Edit-distance ceiling for the Myers search; larger rewrites fall back to the full block. */
+const DIFF_MAX_EDITS = 1000;
+const DIFF_CONTEXT_LINES = 3;
+
+interface DiffEdit {
+   kind: " " | "-" | "+";
+   line: string;
 }
 
+function splitLines(text: string): string[] {
+   if (text === "") return [];
+   const lines = text.split("\n");
+   if (lines[lines.length - 1] === "") lines.pop();
+   return lines;
+}
+
+function myersEdits(a: string[], b: string[], maxEdits: number): DiffEdit[] | null {
+   const n = a.length;
+   const m = b.length;
+   const max = Math.min(maxEdits, n + m);
+   const offset = max + 1;
+   const width = 2 * max + 3;
+   const trace: Int32Array[] = [];
+   const v = new Int32Array(width);
+   v[offset + 1] = 0;
+   let found = -1;
+   for (let d = 0; d <= max; d++) {
+      trace.push(Int32Array.from(v));
+      for (let k = -d; k <= d; k += 2) {
+         let x: number;
+         if (k === -d || (k !== d && v[offset + k - 1]! < v[offset + k + 1]!)) {
+            x = v[offset + k + 1]!;
+         } else {
+            x = v[offset + k - 1]! + 1;
+         }
+         let y = x - k;
+         while (x < n && y < m && a[x] === b[y]) {
+            x++;
+            y++;
+         }
+         v[offset + k] = x;
+         if (x >= n && y >= m) {
+            found = d;
+            break;
+         }
+      }
+      if (found >= 0) break;
+   }
+   if (found < 0) return null;
+
+   const edits: DiffEdit[] = [];
+   let x = n;
+   let y = m;
+   for (let d = found; d >= 0; d--) {
+      const vd = trace[d]!;
+      const k = x - y;
+      let prevK: number;
+      if (k === -d || (k !== d && vd[offset + k - 1]! < vd[offset + k + 1]!)) {
+         prevK = k + 1;
+      } else {
+         prevK = k - 1;
+      }
+      const prevX = vd[offset + prevK]!;
+      const prevY = prevX - prevK;
+      while (x > prevX && y > prevY) {
+         edits.push({ kind: " ", line: a[x - 1]! });
+         x--;
+         y--;
+      }
+      if (d > 0) {
+         if (x === prevX) edits.push({ kind: "+", line: b[prevY]! });
+         else edits.push({ kind: "-", line: a[prevX]! });
+      }
+      x = prevX;
+      y = prevY;
+   }
+   edits.reverse();
+   return edits;
+}
+
+/**
+ * Produces a unified diff between two snapshots of one file.
+ *
+ * @returns `''` when the texts are identical, `null` when a diff is not
+ *   attempted (too many lines or too many edits), otherwise unified hunks.
+ */
+export function unifiedDiff(previous: string, current: string, displayPath: string): string | null {
+   if (previous === current) return "";
+   const a = splitLines(previous);
+   const b = splitLines(current);
+   if (a.length > DIFF_MAX_LINES || b.length > DIFF_MAX_LINES) return null;
+
+   // Trim the shared prefix and suffix so typical localized edits keep the
+   // Myers search tiny regardless of file size.
+   let start = 0;
+   while (start < a.length && start < b.length && a[start] === b[start]) start++;
+   let endA = a.length;
+   let endB = b.length;
+   while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+      endA--;
+      endB--;
+   }
+   const middle = myersEdits(a.slice(start, endA), b.slice(start, endB), DIFF_MAX_EDITS);
+   if (middle === null) return null;
+   const edits: DiffEdit[] = [
+      ...a.slice(0, start).map((line): DiffEdit => ({ kind: " ", line })),
+      ...middle,
+      ...a.slice(endA).map((line): DiffEdit => ({ kind: " ", line })),
+   ];
+
+   // Group changes into hunks; merge when the gap fits inside twice the context.
+   const changeIndexes: number[] = [];
+   for (let index = 0; index < edits.length; index++) {
+      if (edits[index]!.kind !== " ") changeIndexes.push(index);
+   }
+   if (changeIndexes.length === 0) return "";
+   const ranges: Array<[number, number]> = [];
+   for (const index of changeIndexes) {
+      const from = Math.max(0, index - DIFF_CONTEXT_LINES);
+      const to = Math.min(edits.length - 1, index + DIFF_CONTEXT_LINES);
+      const last = ranges[ranges.length - 1];
+      if (last && from <= last[1] + 1) last[1] = Math.max(last[1], to);
+      else ranges.push([from, to]);
+   }
+
+   const out: string[] = [`--- ${displayPath} (previous snapshot)`, `+++ ${displayPath} (current)`];
+   let oldLine = 1;
+   let newLine = 1;
+   let cursor = 0;
+   for (const [from, to] of ranges) {
+      for (; cursor < from; cursor++) {
+         const edit = edits[cursor]!;
+         if (edit.kind !== "+") oldLine++;
+         if (edit.kind !== "-") newLine++;
+      }
+      let oldCount = 0;
+      let newCount = 0;
+      const body: string[] = [];
+      for (let index = from; index <= to; index++) {
+         const edit = edits[index]!;
+         if (edit.kind !== "+") oldCount++;
+         if (edit.kind !== "-") newCount++;
+         body.push(`${edit.kind}${edit.line}`);
+      }
+      // Match git: an empty side reports the line before the hunk.
+      const oldStart = oldCount === 0 ? oldLine - 1 : oldLine;
+      const newStart = newCount === 0 ? newLine - 1 : newLine;
+      out.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`, ...body);
+      oldLine += oldCount;
+      newLine += newCount;
+      cursor = to + 1;
+   }
+   return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Task context update planning (pure). The system prompt carries the first
+// snapshot for the life of the process; every later change is appended as a
+// persisted message so provider-bound history never rewrites earlier bytes.
+// ---------------------------------------------------------------------------
+
+/** Last text sent to the model for one task file, plus its diff stack within the current epoch. */
+export interface TaskFileBaseline {
+   block: string;
+   stackedDiffs: number;
+   stackedDiffBytes: number;
+   /**
+    * The model may no longer hold `block` verbatim (the update carrying it was
+    * omitted by the budget, or a compaction happened since), so the next change
+    * must be sent in full instead of as a diff against it.
+    */
+   stale: boolean;
+   /**
+    * The model never received `block` at all (omitted by the system prompt or
+    * update budget), so the file is re-sent in full on the next update pass
+    * even when it did not change on disk.
+    */
+   unseen: boolean;
+}
+
+/** Baseline for the bound task; `files` preserves injection order. */
+export interface TaskContextBaseline {
+   taskDir: string;
+   /** Project-relative label used in update headers. */
+   taskLabel: string;
+   signature: string;
+   files: Map<string, TaskFileBaseline>;
+}
+
+/** Current on-disk snapshot of the bound task. */
+export interface TaskContextSnapshot {
+   taskDir: string;
+   taskLabel: string;
+   signature: string;
+   files: Array<{ displayPath: string; block: string }>;
+}
+
+export interface TaskContextUpdatePlan {
+   /** Message body to append, or `''` when nothing changed. */
+   content: string;
+   baseline: TaskContextBaseline | null;
+}
+
+export interface TaskContextUpdateInput {
+   previous: TaskContextBaseline | null;
+   current: TaskContextSnapshot | null;
+   limits: Pick<ContextInjectionLimits, "max_total_bytes" | "diff_max_bytes" | "diff_max_stack">;
+   /** True once after a compaction: earlier snapshots may be summarized away, so diffs need a fresh base. */
+   epochReset: boolean;
+   /** True when the system prompt holds a task block; only affects the wording of the update header. */
+   promptHasTask: boolean;
+}
+
+const UPDATE_PREFIX = `<${TASK_CONTEXT_UPDATE_TYPE}>\n`;
+const UPDATE_SUFFIX = `\n</${TASK_CONTEXT_UPDATE_TYPE}>`;
+
+function snapshotFiles(entries: TaskContextEntry[]): TaskContextSnapshot["files"] {
+   const files: TaskContextSnapshot["files"] = [];
+   const seen = new Set<string>();
+   for (const entry of entries) {
+      if (seen.has(entry.displayPath)) continue;
+      seen.add(entry.displayPath);
+      files.push({ displayPath: entry.displayPath, block: entryBlock(entry) });
+   }
+   return files;
+}
+
+function baselineFrom(snapshot: TaskContextSnapshot, stalePaths: ReadonlySet<string> = new Set()): TaskContextBaseline {
+   const files = new Map<string, TaskFileBaseline>();
+   for (const file of snapshot.files) {
+      files.set(file.displayPath, {
+         block: file.block,
+         stackedDiffs: 0,
+         stackedDiffBytes: 0,
+         stale: stalePaths.has(file.displayPath),
+         unseen: stalePaths.has(file.displayPath),
+      });
+   }
+   return {
+      taskDir: snapshot.taskDir,
+      taskLabel: snapshot.taskLabel,
+      signature: snapshot.signature,
+      files,
+   };
+}
+
+/**
+ * Decides what to append for this turn and what the next baseline is.
+ *
+ * Section shapes degrade in order: unified diff, full block, omitted notice
+ * (when the shared total budget is exhausted). A full block is used whenever
+ * there is no baseline for the file, the baseline is stale (compaction since
+ * it was sent, or its update was omitted), the per-file diff stack is
+ * exhausted, the diffs stacked since the last full send would exceed one full
+ * block, or the diff itself is larger than `diff_max_bytes` or the block.
+ */
+export function planTaskContextUpdate(input: TaskContextUpdateInput): TaskContextUpdatePlan {
+   const { previous, current, limits, epochReset, promptHasTask } = input;
+   if (!current) {
+      if (!previous) return { content: "", baseline: null };
+      const label = previous.taskLabel;
+      return {
+         content: `${UPDATE_PREFIX}Task context for ${label} is no longer active. Ignore its files in the system prompt and earlier updates unless a task is bound again.${UPDATE_SUFFIX}`,
+         baseline: null,
+      };
+   }
+
+   const sameTask = previous !== null && previous.taskDir === current.taskDir;
+   const headerLines: string[] = [];
+   if (previous && !sameTask) {
+      headerLines.push(
+         `Task context for ${previous.taskLabel} is no longer active; the sections below describe the newly bound task.`,
+      );
+   }
+   if (!sameTask && !promptHasTask) {
+      headerLines.push(
+         "The system prompt holds no task context for this task; the sections below are the full baseline.",
+      );
+   } else if (!sameTask) {
+      headerLines.push("The sections below are the full baseline for the newly bound task.");
+   } else {
+      headerLines.push(
+         `Task context changed on disk. Each section below supersedes the same file in ${promptHasTask ? "the system prompt and in earlier updates" : "earlier updates"}.`,
+      );
+   }
+   headerLines.push("Files on disk remain authoritative; use read for anything not shown.");
+   const header = `${headerLines.join(" ")}\n\n`;
+
+   const nextFiles = new Map<string, TaskFileBaseline>();
+   interface Section {
+      primary: string;
+      fallback: string;
+      /** Baseline entry to downgrade to stale when `primary` does not go out; null for removal notices. */
+      file: { displayPath: string; block: string } | null;
+   }
+   const sections: Section[] = [];
+   // A different task has no usable baseline: every file starts without `old`.
+   const previousFiles = sameTask && previous ? previous.files : new Map<string, TaskFileBaseline>();
+
+   for (const file of current.files) {
+      const old = previousFiles.get(file.displayPath);
+      if (old && old.block === file.block && !old.unseen) {
+         // Unchanged. After a compaction the update that carried `old.block` may
+         // have been summarized away, so its next change must be sent in full.
+         nextFiles.set(file.displayPath, epochReset && !old.stale ? { ...old, stale: true } : old);
+         continue;
+      }
+      const blockBytes = Buffer.byteLength(file.block, "utf-8");
+      let diff: string | null = null;
+      if (old && !old.stale && !epochReset && old.stackedDiffs < limits.diff_max_stack) {
+         const candidate = unifiedDiff(old.block, file.block, file.displayPath);
+         const candidateBytes = candidate === null ? 0 : Buffer.byteLength(candidate, "utf-8");
+         // A diff is only worth it when it is cheaper than the block itself and
+         // the diffs stacked since the last full send still cost less than one
+         // full resend; otherwise the full block resets the stack.
+         if (
+            candidate !== null &&
+            candidate !== "" &&
+            candidateBytes <= limits.diff_max_bytes &&
+            candidateBytes < blockBytes &&
+            old.stackedDiffBytes + candidateBytes <= blockBytes
+         ) {
+            diff = candidate;
+         }
+      }
+      const fallback = `## ${file.displayPath} [omitted]\n\n[Trellis: omitted (update budget reached) — ${file.displayPath}; required_read: ${file.displayPath}]`;
+      if (diff !== null && old) {
+         sections.push({ primary: `## ${file.displayPath} (diff)\n\n${diff}`, fallback, file });
+         nextFiles.set(file.displayPath, {
+            block: file.block,
+            stackedDiffs: old.stackedDiffs + 1,
+            stackedDiffBytes: old.stackedDiffBytes + Buffer.byteLength(diff, "utf-8"),
+            stale: false,
+            unseen: false,
+         });
+      } else {
+         sections.push({ primary: `## ${file.displayPath} (full)\n\n${file.block}`, fallback, file });
+         nextFiles.set(file.displayPath, {
+            block: file.block,
+            stackedDiffs: 0,
+            stackedDiffBytes: 0,
+            stale: false,
+            unseen: false,
+         });
+      }
+   }
+   for (const displayPath of previousFiles.keys()) {
+      if (nextFiles.has(displayPath)) continue;
+      const text = `## ${displayPath} (removed)\n\nNo longer part of the task context.`;
+      sections.push({ primary: text, fallback: text, file: null });
+   }
+
+   const baseline: TaskContextBaseline = {
+      taskDir: current.taskDir,
+      taskLabel: current.taskLabel,
+      signature: current.signature,
+      files: nextFiles,
+   };
+   if (sections.length === 0) return { content: "", baseline };
+
+   const wrapperBytes = Buffer.byteLength(UPDATE_PREFIX + header + UPDATE_SUFFIX, "utf-8");
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+   const parts: string[] = [];
+   for (const section of sections) {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const primary = separator + section.primary;
+      const output = budget.emitCandidate(primary, separator + section.fallback);
+      if (output !== null) parts.push(output);
+      if (section.file && output !== primary) {
+         // The model only got a notice (or nothing): remember the current text so
+         // the change is not re-reported, but never diff against it.
+         nextFiles.set(section.file.displayPath, {
+            block: section.file.block,
+            stackedDiffs: 0,
+            stackedDiffBytes: 0,
+            stale: true,
+            unseen: true,
+         });
+      }
+   }
+   return {
+      content: `${UPDATE_PREFIX}${header}${parts.join("")}${UPDATE_SUFFIX}`,
+      baseline,
+   };
+}
 // ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
 
-export default function(pi: ExtensionAPI): void {
+export default function (pi: ExtensionAPI): void {
    let projectRoot: string | null = null;
    const turnCache = new TurnContextCache();
    const agentType = detectAgentType();
    const isSubAgent = agentType !== null;
-   let taskContextCache: TaskContextCache | null = null;
 
-   // Tracks compaction boundaries — context handler skips scanning when no
-   // compaction has occurred since last injection.
-   let lastCompactionTs = 0;
-   let lastInjectionTs = 0;
+   // Set when a compaction is announced and cleared once a workflow breadcrumb
+   // has been persisted or re-projected afterwards. A boolean instead of a
+   // timestamp pair: two events inside the same millisecond must not reopen
+   // the safety net.
+   let compactionPending = false;
 
-   const rememberContextKey = (ctx?: { sessionManager?: { getSessionId?: () => string | undefined; getSessionFile?: () => string | undefined } }): string | null => {
+   // Provider prefix caches invalidate from byte 0 whenever the system prompt
+   // changes, so the task block appended to the system prompt is memoized per
+   // context key + project root and stays byte-identical for the life of the
+   // process. Later on-disk changes travel through persisted update messages.
+   const memoizedTaskBlocks = new Map<string, string>();
+   const taskBaselines = new Map<string, TaskContextBaseline | null>();
+   // Set by session_before_compact and consumed by the next update planning:
+   // earlier snapshots may have been summarized away, so the first change after
+   // a compaction re-sends the full block instead of a diff.
+   let baselineEpochInvalidated = false;
+
+   const rememberContextKey = (ctx?: {
+      sessionManager?: {
+         getSessionId?: () => string | undefined;
+         getSessionFile?: () => string | undefined;
+      };
+   }): string | null => {
       const key = deriveContextKey(ctx);
       if (!key) return null;
       return key;
    };
 
-   const getTaskContext = (taskDir: string, root: string): string => {
+   const promptKey = (root: string, contextKey: string | null): string => `${contextKey ?? "default"}::${root}`;
+
+   const snapshotTask = (
+      taskDir: string,
+      root: string,
+   ): { snapshot: TaskContextSnapshot; entries: TaskContextEntry[] } => {
+      // Signature before content: a write landing between the two reads then
+      // leaves the stored signature older than the text, so the next turn
+      // re-plans (and stays silent if the content matches) instead of missing it.
       const signature = taskContextSignature(root, taskDir, agentType);
-      if (taskContextCache?.projectRoot === root && taskContextCache.taskDir === taskDir && taskContextCache.agentType === agentType && taskContextCache.signature === signature) {
-         return taskContextCache.content;
-      }
-      const content = buildTaskContext(root, taskDir, agentType);
-      taskContextCache = { projectRoot: root, taskDir, agentType, signature, content };
-      return content;
+      const entries = materializeTaskContextFiles(root, taskDir, agentType);
+      return {
+         entries,
+         snapshot: {
+            taskDir,
+            taskLabel: displayProjectPath(root, taskDir, taskDir),
+            signature,
+            files: snapshotFiles(entries),
+         },
+      };
    };
 
    pi.on("session_start", async (_event, ctx) => {
@@ -934,36 +1458,25 @@ export default function(pi: ExtensionAPI): void {
          // Sub-agent: inject precise task context once
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = getTaskContext(taskDir, projectRoot);
+            const taskContext = buildTaskContext(projectRoot, taskDir, agentType);
             if (taskContext) {
                await pi.sendMessage({
-                  customType: "trellis-task-context",
+                  customType: TASK_CONTEXT_TYPE,
                   content: taskContext,
                   display: false,
                });
             }
          }
       } else {
-         // Main session: inject session context (global map) + task context
+         // Main session: inject session context (global map). The task context
+         // is carried by the system prompt from the first turn onwards.
          const sessionContext = buildSessionContext(projectRoot, contextKey);
          if (sessionContext) {
             await pi.sendMessage({
-               customType: "trellis-session-context",
+               customType: SESSION_CONTEXT_TYPE,
                content: sessionContext,
                display: false,
             });
-         }
-
-         const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
-         if (taskDir) {
-            const taskContext = getTaskContext(taskDir, projectRoot);
-            if (taskContext) {
-               await pi.sendMessage({
-                  customType: "trellis-task-context",
-                  content: taskContext,
-                  display: false,
-               });
-            }
          }
 
          ctx.ui.notify("Trellis workflow system available", "info");
@@ -971,10 +1484,11 @@ export default function(pi: ExtensionAPI): void {
    });
 
    pi.on("session_before_compact", async () => {
-      lastCompactionTs = Date.now();
+      compactionPending = true;
+      baselineEpochInvalidated = true;
    });
 
-   pi.on("before_agent_start", async (_event, ctx) => {
+   pi.on("before_agent_start", async (event, ctx) => {
       if (!projectRoot) {
          projectRoot = findProjectRoot(ctx.cwd);
       }
@@ -983,86 +1497,133 @@ export default function(pi: ExtensionAPI): void {
 
       // Persistent injection: workflow state for this turn
       const cached = turnCache.get(projectRoot, contextKey);
-      lastInjectionTs = Date.now();
+      compactionPending = false;
 
-      // Skip turn: inject nothing (escape hatch)
-      if (!cached.workflowMsg) return;
+      const message = cached.workflowMsg
+         ? {
+              customType: WORKFLOW_STATE_TYPE,
+              content: cached.workflowMsg,
+              display: false,
+           }
+         : undefined;
 
+      if (isSubAgent) return message ? { message } : undefined;
+
+      // Task block: snapshot once per context key, then keep the system prompt
+      // byte-identical. `event.systemPrompt` already carries earlier handlers'
+      // segments; only append, never replace.
+      const key = promptKey(projectRoot, contextKey);
+      let block = memoizedTaskBlocks.get(key);
+      if (block === undefined) {
+         const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+         block = "";
+         let baseline: TaskContextBaseline | null = null;
+         if (taskDir) {
+            // One materialization feeds both the prompt block and the baseline so
+            // later diffs are computed against exactly the text the model saw.
+            const { snapshot, entries } = snapshotTask(taskDir, projectRoot);
+            const rendered = renderTaskContext(projectRoot, entries);
+            block = rendered.content;
+            if (block) baseline = baselineFrom(snapshot, rendered.omittedPaths);
+         }
+         memoizedTaskBlocks.set(key, block);
+         taskBaselines.set(key, baseline);
+      }
+      const basePrompt = (event as { systemPrompt?: unknown }).systemPrompt;
+      const systemPrompt = block && Array.isArray(basePrompt) ? [...basePrompt, block] : undefined;
+      if (!message && !systemPrompt) return;
+      return {
+         ...(message ? { message } : {}),
+         ...(systemPrompt ? { systemPrompt } : {}),
+      };
+   });
+
+   // Second handler: append-only task context refresh. Runs after the memoize
+   // handler above (same registration order), returns at most one persisted
+   // message per turn and never touches the system prompt.
+   pi.on("before_agent_start", async (_event, ctx) => {
+      if (!projectRoot || isSubAgent) return;
+      const contextKey = rememberContextKey(ctx);
+      const key = promptKey(projectRoot, contextKey);
+      if (!memoizedTaskBlocks.has(key)) return;
+      // Skip turn (escape hatch): inject nothing and leave the baseline alone so
+      // the change is still reported on the next normal turn.
+      if (!turnCache.get(projectRoot, contextKey).workflowMsg) return;
+
+      const previous = taskBaselines.get(key) ?? null;
+      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+      const epochReset = baselineEpochInvalidated;
+      if (
+         taskDir &&
+         previous &&
+         previous.taskDir === taskDir &&
+         !epochReset &&
+         previous.signature === taskContextSignature(projectRoot, taskDir, agentType)
+      ) {
+         return;
+      }
+      baselineEpochInvalidated = false;
+      const plan = planTaskContextUpdate({
+         previous,
+         current: taskDir ? snapshotTask(taskDir, projectRoot).snapshot : null,
+         limits: readContextInjectionLimits(projectRoot),
+         epochReset,
+         promptHasTask: (memoizedTaskBlocks.get(key) ?? "") !== "",
+      });
+      taskBaselines.set(key, plan.baseline);
+      if (!plan.content) return;
       return {
          message: {
-            customType: "trellis-workflow-state",
-            content: cached.workflowMsg,
+            customType: TASK_CONTEXT_UPDATE_TYPE,
+            content: plan.content,
             display: false,
          },
       };
    });
 
    // context fires before EVERY LLM API call (including tool-use continuations
-   // and post-compaction agent.continue() paths). Acts as a safety net when
-   // before_agent_start's persisted message was removed by compaction.
+   // and post-compaction agent.continue() paths). It only acts as a safety net
+   // for the workflow breadcrumb; task context is never rewritten here because
+   // any change to an earlier message breaks the provider prefix cache.
    pi.on("context", async (event, ctx) => {
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
 
       const messages = event.messages as { role?: string; customType?: string; content?: string }[];
-      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
-      const currentTaskContext = taskDir ? getTaskContext(taskDir, projectRoot) : "";
-      const taskContextIndexes = messages
-         .map((message, index) => message.customType === "trellis-task-context" ? index : -1)
-         .filter((index) => index >= 0);
-      const existingTaskContext = taskContextIndexes.length > 0
-         ? messages[taskContextIndexes[0]]?.content ?? ""
-         : "";
-      const taskContextChanged = existingTaskContext !== currentTaskContext || taskContextIndexes.length > 1;
-      let projectedMessages = messages;
-      if (taskContextChanged) {
-         const replacement = currentTaskContext
-            ? { role: "custom" as const, customType: "trellis-task-context", content: currentTaskContext, display: false, timestamp: Date.now() }
-            : null;
-         let replaced = false;
-         projectedMessages = messages.flatMap((message) => {
-            if (message.customType !== "trellis-task-context") return [message];
-            if (replaced || !replacement) return [];
-            replaced = true;
-            return [replacement];
-         });
-         if (replacement && !replaced) projectedMessages.push(replacement);
-      }
 
       // Resolve the turn state before the fast path: a skip turn must still
       // run breadcrumb cleanup even when nothing else changed.
       const cached = turnCache.get(projectRoot, contextKey);
       const skipping = !cached.workflowMsg;
 
-      // Fast path: no task change, no compaction, not skipping — all persisted context is current.
-      if (!taskContextChanged && !skipping && lastInjectionTs > lastCompactionTs) return;
+      if (!skipping && !compactionPending) return;
 
       if (skipping) {
          // Skip turn (escape hatch): drop any persisted breadcrumb from an
          // earlier turn so the skip actually takes effect.
-         const withoutBreadcrumb = projectedMessages.filter(
-            (message) => !(message.role === "custom" && message.customType === "trellis-workflow-state"),
+         const withoutBreadcrumb = messages.filter(
+            (message) => !(message.role === "custom" && message.customType === WORKFLOW_STATE_TYPE),
          );
-         if (withoutBreadcrumb.length === projectedMessages.length && !taskContextChanged) return;
-         lastInjectionTs = Date.now();
+         if (withoutBreadcrumb.length === messages.length) return;
+         compactionPending = false;
          return { messages: withoutBreadcrumb };
       }
 
       // Post-compaction: reverse-scan to confirm absence before injecting
-      for (let i = projectedMessages.length - 1; i >= 0; i--) {
-         if (projectedMessages[i].role === "custom" && projectedMessages[i].customType === "trellis-workflow-state") {
-            lastInjectionTs = Date.now();
-            return taskContextChanged ? { messages: projectedMessages } : undefined;
+      for (let i = messages.length - 1; i >= 0; i--) {
+         if (messages[i].role === "custom" && messages[i].customType === WORKFLOW_STATE_TYPE) {
+            compactionPending = false;
+            return;
          }
       }
 
-      lastInjectionTs = Date.now();
+      compactionPending = false;
       return {
          messages: [
-            ...projectedMessages,
+            ...messages,
             {
                role: "custom" as const,
-               customType: "trellis-workflow-state",
+               customType: WORKFLOW_STATE_TYPE,
                content: cached.workflowMsg,
                display: false,
                timestamp: Date.now(),

--- a/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
+++ b/packages/cli/src/templates/omp/extensions/trellis/index.ts.txt
@@ -353,13 +353,20 @@ interface ContextInjectionLimits {
    max_file_bytes: number;
    max_artifact_bytes: number;
    max_total_bytes: number;
+   /** Largest unified diff (bytes) appended for one file before falling back to the full block. */
+   diff_max_bytes: number;
+   /** Consecutive diffs allowed per file within one compaction epoch before a full block resets the baseline. */
+   diff_max_stack: number;
 }
 
 const DEFAULT_CONTEXT_INJECTION_LIMITS: ContextInjectionLimits = {
    max_file_bytes: 32768,
    max_artifact_bytes: 65536,
    max_total_bytes: 131072,
+   diff_max_bytes: 8192,
+   diff_max_stack: 3,
 };
+
 const MAX_JSONL_BYTES = 1024 * 1024;
 
 function stripInlineComment(value: string): string {
@@ -619,61 +626,71 @@ function readJsonlLines(jsonlPath: string, displayPath: string): { lines: string
    }
 }
 
-function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
-   const parts: string[] = [];
+/** One ordered unit of task context, before the total-bytes budget is applied. */
+type TaskContextEntry =
+   | { kind: "artifact"; displayPath: string; materialized: MaterializedFile }
+   | { kind: "manifest-omitted"; section: string; displayPath: string; notice: string }
+   | { kind: "file"; section: string; displayPath: string; materialized: MaterializedFile };
+
+/**
+ * Materializes prd.md, info.md and every manifest-referenced file in the order
+ * they are injected. Per-file caps are applied here; the shared total budget is
+ * applied by the consumer so the same entries can feed both the system prompt
+ * block and the per-file update baselines.
+ */
+function materializeTaskContextFiles(projectRoot: string, taskDir: string, agentType?: AgentType): TaskContextEntry[] {
+   const entries: TaskContextEntry[] = [];
    // Resolved once per call (not per referenced file) — avoids re-parsing
    // config.yaml for every jsonl row.
    const trustedRoots = resolveTrustedRoots(projectRoot);
    const limits = readContextInjectionLimits(projectRoot);
-   const prefix = "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
-   const suffix = "\n</task-context>";
-   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
-   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) return "";
-   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
-
-   const appendCandidate = (primary: string | null, fallback: string | null = null): void => {
-      const separator = parts.length > 0 ? "\n\n" : "";
-      const output = budget.emitCandidate(
-         primary === null ? null : separator + primary,
-         fallback === null ? null : separator + fallback,
-      );
-      if (output !== null) parts.push(output);
-   };
 
    // prd.md and info.md — always included
    const prdPath = join(taskDir, "prd.md");
-   const relativePrdPath = displayProjectPath(projectRoot, prdPath, taskDir);
    if (existsSync(prdPath)) {
-      const artifact = materialize(prdPath, relativePrdPath, "Requirements document", limits.max_artifact_bytes, "artifact");
-      appendCandidate(artifact.block, artifact.notice);
+      const displayPath = displayProjectPath(projectRoot, prdPath, taskDir);
+      entries.push({
+         kind: "artifact",
+         displayPath,
+         materialized: materialize(
+            prdPath,
+            displayPath,
+            "Requirements document",
+            limits.max_artifact_bytes,
+            "artifact",
+         ),
+      });
    }
    const infoPath = join(taskDir, "info.md");
-   const relativeInfoPath = displayProjectPath(projectRoot, infoPath, taskDir);
    if (existsSync(infoPath)) {
-      const artifact = materialize(infoPath, relativeInfoPath, "Task information", limits.max_artifact_bytes, "artifact");
-      appendCandidate(artifact.block, artifact.notice);
+      const displayPath = displayProjectPath(projectRoot, infoPath, taskDir);
+      entries.push({
+         kind: "artifact",
+         displayPath,
+         materialized: materialize(infoPath, displayPath, "Task information", limits.max_artifact_bytes, "artifact"),
+      });
    }
-
-   // Determine which jsonl files to read based on agent type
-   const jsonlNames = taskContextJsonlNames(agentType);
 
    // A file may be referenced by both manifests. Use the resolved real path so
    // relative aliases and symlinked paths cannot consume the context budget twice.
    const includedPaths = new Set<string>();
 
-   for (const jsonlName of jsonlNames) {
+   for (const jsonlName of taskContextJsonlNames(agentType)) {
       const jsonlPath = join(taskDir, jsonlName);
       if (!existsSync(jsonlPath)) continue;
 
       const relativeJsonlPath = displayProjectPath(projectRoot, jsonlPath, taskDir);
       const manifest = readJsonlLines(jsonlPath, relativeJsonlPath);
       if (manifest.omitted) {
-         appendCandidate(`## ${jsonlName}\n\n${manifest.omitted}`);
+         entries.push({
+            kind: "manifest-omitted",
+            section: jsonlName,
+            displayPath: relativeJsonlPath,
+            notice: manifest.omitted,
+         });
          continue;
       }
 
-      const fileChunks: string[] = [];
-      let sectionHeaderEmitted = false;
       for (const line of manifest.lines) {
          const trimmed = line.trim();
          if (!trimmed) continue;
@@ -685,33 +702,122 @@ function buildTaskContext(projectRoot: string, taskDir: string, agentType?: Agen
             if (!targetPath) continue;
             if (includedPaths.has(targetPath)) continue;
             includedPaths.add(targetPath);
-            const materialized = materialize(targetPath, file, typeof row.reason === "string" ? row.reason : "-", limits.max_file_bytes, "file");
-            const sectionPrefix = sectionHeaderEmitted
-               ? "\n\n---\n\n"
-               : `${parts.length > 0 ? "\n\n" : ""}## ${jsonlName}\n\n`;
-            const output = budget.emitCandidate(
-               materialized.block === null ? null : `${sectionPrefix}${materialized.block}`,
-               `${sectionPrefix}${materialized.notice}`,
-            );
-            if (output !== null) {
-               fileChunks.push(output);
-               sectionHeaderEmitted = true;
-            }
+            entries.push({
+               kind: "file",
+               section: jsonlName,
+               displayPath: file,
+               materialized: materialize(
+                  targetPath,
+                  file,
+                  typeof row.reason === "string" ? row.reason : "-",
+                  limits.max_file_bytes,
+                  "file",
+               ),
+            });
          } catch {
             // seed rows and malformed lines are non-fatal
          }
       }
-
-      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
    }
+   return entries;
+}
 
-   if (parts.length === 0) return "";
+/** Text the model is meant to see for one entry when the total budget allows it. */
+function entryBlock(entry: TaskContextEntry): string {
+   if (entry.kind === "manifest-omitted") return entry.notice;
+   return entry.materialized.block ?? entry.materialized.notice;
+}
+
+interface RenderedTaskContext {
+   content: string;
+   /** Display paths whose materialized text was replaced by a notice or dropped by the total budget. */
+   omittedPaths: Set<string>;
+}
+
+/**
+ * Renders materialized entries into the `<task-context>` block under the
+ * shared total budget. `omittedPaths` lets the caller avoid diffing against
+ * text the model never received.
+ */
+function renderTaskContext(projectRoot: string, entries: TaskContextEntry[]): RenderedTaskContext {
+   const parts: string[] = [];
+   const omittedPaths = new Set<string>();
+   const limits = readContextInjectionLimits(projectRoot);
+   const prefix =
+      "<task-context>\nContext is bounded by .trellis/config.yaml. Files marked [truncated] or [omitted] remain authoritative on disk; use their required_read path before relying on missing detail.\n\n";
+   const suffix = "\n</task-context>";
+   const wrapperBytes = Buffer.byteLength(prefix + suffix, "utf-8");
+   if (limits.max_total_bytes > 0 && limits.max_total_bytes < wrapperBytes) {
+      for (const entry of entries) omittedPaths.add(entry.displayPath);
+      return { content: "", omittedPaths };
+   }
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+
+   // Emits `primary` (or `fallback` once the budget is exhausted) and reports
+   // whether the text the baseline will remember (`shown`) is what went out.
+   const appendCandidate = (primary: string | null, fallback: string | null, shown: string): boolean => {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const output = budget.emitCandidate(
+         primary === null ? null : separator + primary,
+         fallback === null ? null : separator + fallback,
+      );
+      if (output !== null) parts.push(output);
+      return output === separator + shown;
+   };
+
+   let sectionName: string | null = null;
+   let fileChunks: string[] = [];
+   let sectionHeaderEmitted = false;
+   const flushSection = (): void => {
+      if (fileChunks.length > 0) parts.push(fileChunks.join(""));
+      fileChunks = [];
+      sectionHeaderEmitted = false;
+      sectionName = null;
+   };
+
+   for (const entry of entries) {
+      if (entry.kind === "artifact") {
+         const shown = entryBlock(entry);
+         if (!appendCandidate(entry.materialized.block, entry.materialized.notice, shown)) {
+            omittedPaths.add(entry.displayPath);
+         }
+         continue;
+      }
+      if (entry.section !== sectionName) {
+         flushSection();
+         sectionName = entry.section;
+      }
+      if (entry.kind === "manifest-omitted") {
+         const text = `## ${entry.section}\n\n${entry.notice}`;
+         if (!appendCandidate(text, null, text)) omittedPaths.add(entry.displayPath);
+         sectionName = null;
+         continue;
+      }
+      const sectionPrefix = sectionHeaderEmitted
+         ? "\n\n---\n\n"
+         : `${parts.length > 0 ? "\n\n" : ""}## ${entry.section}\n\n`;
+      const primary = entry.materialized.block === null ? null : `${sectionPrefix}${entry.materialized.block}`;
+      const output = budget.emitCandidate(primary, `${sectionPrefix}${entry.materialized.notice}`);
+      if (output !== null) {
+         fileChunks.push(output);
+         sectionHeaderEmitted = true;
+      }
+      if (output !== `${sectionPrefix}${entryBlock(entry)}`) omittedPaths.add(entry.displayPath);
+   }
+   flushSection();
+
+   if (parts.length === 0) return { content: "", omittedPaths };
    const context = `${prefix}${parts.join("")}${suffix}`;
-   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes) return context;
+   if (limits.max_total_bytes <= 0 || Buffer.byteLength(context, "utf-8") <= limits.max_total_bytes)
+      return { content: context, omittedPaths };
    const suffixBytes = Buffer.byteLength(suffix, "utf-8");
    const bodyLimit = Math.max(0, limits.max_total_bytes - suffixBytes);
    const body = truncateUtf8(Buffer.from(`${prefix}${parts.join("")}`, "utf-8"), bodyLimit).toString("utf-8");
-   return `${body}${suffix}`;
+   return { content: `${body}${suffix}`, omittedPaths };
+}
+
+function buildTaskContext(projectRoot: string, taskDir: string, agentType?: AgentType): string {
+   return renderTaskContext(projectRoot, materializeTaskContextFiles(projectRoot, taskDir, agentType)).content;
 }
 
 // ---------------------------------------------------------------------------
@@ -884,44 +990,462 @@ function detectAgentType(): AgentType {
    return null;
 }
 
-interface TaskContextCache {
-   projectRoot: string;
-   taskDir: string;
-   agentType: AgentType;
-   signature: string;
-   content: string;
+const SESSION_CONTEXT_TYPE = "trellis-session-context";
+const TASK_CONTEXT_TYPE = "trellis-task-context";
+const TASK_CONTEXT_UPDATE_TYPE = "trellis-task-context-update";
+const WORKFLOW_STATE_TYPE = "trellis-workflow-state";
+
+// ---------------------------------------------------------------------------
+// Line diff — self-contained Myers O(ND) with unified output. The provider
+// prefix cache only survives when history is append-only, so task file
+// changes are delivered as diffs against the last snapshot the model saw.
+// ---------------------------------------------------------------------------
+
+/** Lines per side beyond which a diff is not attempted; the full block is sent instead. */
+const DIFF_MAX_LINES = 4000;
+/** Edit-distance ceiling for the Myers search; larger rewrites fall back to the full block. */
+const DIFF_MAX_EDITS = 1000;
+const DIFF_CONTEXT_LINES = 3;
+
+interface DiffEdit {
+   kind: " " | "-" | "+";
+   line: string;
 }
 
+function splitLines(text: string): string[] {
+   if (text === "") return [];
+   const lines = text.split("\n");
+   if (lines[lines.length - 1] === "") lines.pop();
+   return lines;
+}
+
+function myersEdits(a: string[], b: string[], maxEdits: number): DiffEdit[] | null {
+   const n = a.length;
+   const m = b.length;
+   const max = Math.min(maxEdits, n + m);
+   const offset = max + 1;
+   const width = 2 * max + 3;
+   const trace: Int32Array[] = [];
+   const v = new Int32Array(width);
+   v[offset + 1] = 0;
+   let found = -1;
+   for (let d = 0; d <= max; d++) {
+      trace.push(Int32Array.from(v));
+      for (let k = -d; k <= d; k += 2) {
+         let x: number;
+         if (k === -d || (k !== d && v[offset + k - 1]! < v[offset + k + 1]!)) {
+            x = v[offset + k + 1]!;
+         } else {
+            x = v[offset + k - 1]! + 1;
+         }
+         let y = x - k;
+         while (x < n && y < m && a[x] === b[y]) {
+            x++;
+            y++;
+         }
+         v[offset + k] = x;
+         if (x >= n && y >= m) {
+            found = d;
+            break;
+         }
+      }
+      if (found >= 0) break;
+   }
+   if (found < 0) return null;
+
+   const edits: DiffEdit[] = [];
+   let x = n;
+   let y = m;
+   for (let d = found; d >= 0; d--) {
+      const vd = trace[d]!;
+      const k = x - y;
+      let prevK: number;
+      if (k === -d || (k !== d && vd[offset + k - 1]! < vd[offset + k + 1]!)) {
+         prevK = k + 1;
+      } else {
+         prevK = k - 1;
+      }
+      const prevX = vd[offset + prevK]!;
+      const prevY = prevX - prevK;
+      while (x > prevX && y > prevY) {
+         edits.push({ kind: " ", line: a[x - 1]! });
+         x--;
+         y--;
+      }
+      if (d > 0) {
+         if (x === prevX) edits.push({ kind: "+", line: b[prevY]! });
+         else edits.push({ kind: "-", line: a[prevX]! });
+      }
+      x = prevX;
+      y = prevY;
+   }
+   edits.reverse();
+   return edits;
+}
+
+/**
+ * Produces a unified diff between two snapshots of one file.
+ *
+ * @returns `''` when the texts are identical, `null` when a diff is not
+ *   attempted (too many lines or too many edits), otherwise unified hunks.
+ */
+export function unifiedDiff(previous: string, current: string, displayPath: string): string | null {
+   if (previous === current) return "";
+   const a = splitLines(previous);
+   const b = splitLines(current);
+   if (a.length > DIFF_MAX_LINES || b.length > DIFF_MAX_LINES) return null;
+
+   // Trim the shared prefix and suffix so typical localized edits keep the
+   // Myers search tiny regardless of file size.
+   let start = 0;
+   while (start < a.length && start < b.length && a[start] === b[start]) start++;
+   let endA = a.length;
+   let endB = b.length;
+   while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+      endA--;
+      endB--;
+   }
+   const middle = myersEdits(a.slice(start, endA), b.slice(start, endB), DIFF_MAX_EDITS);
+   if (middle === null) return null;
+   const edits: DiffEdit[] = [
+      ...a.slice(0, start).map((line): DiffEdit => ({ kind: " ", line })),
+      ...middle,
+      ...a.slice(endA).map((line): DiffEdit => ({ kind: " ", line })),
+   ];
+
+   // Group changes into hunks; merge when the gap fits inside twice the context.
+   const changeIndexes: number[] = [];
+   for (let index = 0; index < edits.length; index++) {
+      if (edits[index]!.kind !== " ") changeIndexes.push(index);
+   }
+   if (changeIndexes.length === 0) return "";
+   const ranges: Array<[number, number]> = [];
+   for (const index of changeIndexes) {
+      const from = Math.max(0, index - DIFF_CONTEXT_LINES);
+      const to = Math.min(edits.length - 1, index + DIFF_CONTEXT_LINES);
+      const last = ranges[ranges.length - 1];
+      if (last && from <= last[1] + 1) last[1] = Math.max(last[1], to);
+      else ranges.push([from, to]);
+   }
+
+   const out: string[] = [`--- ${displayPath} (previous snapshot)`, `+++ ${displayPath} (current)`];
+   let oldLine = 1;
+   let newLine = 1;
+   let cursor = 0;
+   for (const [from, to] of ranges) {
+      for (; cursor < from; cursor++) {
+         const edit = edits[cursor]!;
+         if (edit.kind !== "+") oldLine++;
+         if (edit.kind !== "-") newLine++;
+      }
+      let oldCount = 0;
+      let newCount = 0;
+      const body: string[] = [];
+      for (let index = from; index <= to; index++) {
+         const edit = edits[index]!;
+         if (edit.kind !== "+") oldCount++;
+         if (edit.kind !== "-") newCount++;
+         body.push(`${edit.kind}${edit.line}`);
+      }
+      // Match git: an empty side reports the line before the hunk.
+      const oldStart = oldCount === 0 ? oldLine - 1 : oldLine;
+      const newStart = newCount === 0 ? newLine - 1 : newLine;
+      out.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`, ...body);
+      oldLine += oldCount;
+      newLine += newCount;
+      cursor = to + 1;
+   }
+   return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Task context update planning (pure). The system prompt carries the first
+// snapshot for the life of the process; every later change is appended as a
+// persisted message so provider-bound history never rewrites earlier bytes.
+// ---------------------------------------------------------------------------
+
+/** Last text sent to the model for one task file, plus its diff stack within the current epoch. */
+export interface TaskFileBaseline {
+   block: string;
+   stackedDiffs: number;
+   stackedDiffBytes: number;
+   /**
+    * The model may no longer hold `block` verbatim (the update carrying it was
+    * omitted by the budget, or a compaction happened since), so the next change
+    * must be sent in full instead of as a diff against it.
+    */
+   stale: boolean;
+   /**
+    * The model never received `block` at all (omitted by the system prompt or
+    * update budget), so the file is re-sent in full on the next update pass
+    * even when it did not change on disk.
+    */
+   unseen: boolean;
+}
+
+/** Baseline for the bound task; `files` preserves injection order. */
+export interface TaskContextBaseline {
+   taskDir: string;
+   /** Project-relative label used in update headers. */
+   taskLabel: string;
+   signature: string;
+   files: Map<string, TaskFileBaseline>;
+}
+
+/** Current on-disk snapshot of the bound task. */
+export interface TaskContextSnapshot {
+   taskDir: string;
+   taskLabel: string;
+   signature: string;
+   files: Array<{ displayPath: string; block: string }>;
+}
+
+export interface TaskContextUpdatePlan {
+   /** Message body to append, or `''` when nothing changed. */
+   content: string;
+   baseline: TaskContextBaseline | null;
+}
+
+export interface TaskContextUpdateInput {
+   previous: TaskContextBaseline | null;
+   current: TaskContextSnapshot | null;
+   limits: Pick<ContextInjectionLimits, "max_total_bytes" | "diff_max_bytes" | "diff_max_stack">;
+   /** True once after a compaction: earlier snapshots may be summarized away, so diffs need a fresh base. */
+   epochReset: boolean;
+   /** True when the system prompt holds a task block; only affects the wording of the update header. */
+   promptHasTask: boolean;
+}
+
+const UPDATE_PREFIX = `<${TASK_CONTEXT_UPDATE_TYPE}>\n`;
+const UPDATE_SUFFIX = `\n</${TASK_CONTEXT_UPDATE_TYPE}>`;
+
+function snapshotFiles(entries: TaskContextEntry[]): TaskContextSnapshot["files"] {
+   const files: TaskContextSnapshot["files"] = [];
+   const seen = new Set<string>();
+   for (const entry of entries) {
+      if (seen.has(entry.displayPath)) continue;
+      seen.add(entry.displayPath);
+      files.push({ displayPath: entry.displayPath, block: entryBlock(entry) });
+   }
+   return files;
+}
+
+function baselineFrom(snapshot: TaskContextSnapshot, stalePaths: ReadonlySet<string> = new Set()): TaskContextBaseline {
+   const files = new Map<string, TaskFileBaseline>();
+   for (const file of snapshot.files) {
+      files.set(file.displayPath, {
+         block: file.block,
+         stackedDiffs: 0,
+         stackedDiffBytes: 0,
+         stale: stalePaths.has(file.displayPath),
+         unseen: stalePaths.has(file.displayPath),
+      });
+   }
+   return {
+      taskDir: snapshot.taskDir,
+      taskLabel: snapshot.taskLabel,
+      signature: snapshot.signature,
+      files,
+   };
+}
+
+/**
+ * Decides what to append for this turn and what the next baseline is.
+ *
+ * Section shapes degrade in order: unified diff, full block, omitted notice
+ * (when the shared total budget is exhausted). A full block is used whenever
+ * there is no baseline for the file, the baseline is stale (compaction since
+ * it was sent, or its update was omitted), the per-file diff stack is
+ * exhausted, the diffs stacked since the last full send would exceed one full
+ * block, or the diff itself is larger than `diff_max_bytes` or the block.
+ */
+export function planTaskContextUpdate(input: TaskContextUpdateInput): TaskContextUpdatePlan {
+   const { previous, current, limits, epochReset, promptHasTask } = input;
+   if (!current) {
+      if (!previous) return { content: "", baseline: null };
+      const label = previous.taskLabel;
+      return {
+         content: `${UPDATE_PREFIX}Task context for ${label} is no longer active. Ignore its files in the system prompt and earlier updates unless a task is bound again.${UPDATE_SUFFIX}`,
+         baseline: null,
+      };
+   }
+
+   const sameTask = previous !== null && previous.taskDir === current.taskDir;
+   const headerLines: string[] = [];
+   if (previous && !sameTask) {
+      headerLines.push(
+         `Task context for ${previous.taskLabel} is no longer active; the sections below describe the newly bound task.`,
+      );
+   }
+   if (!sameTask && !promptHasTask) {
+      headerLines.push(
+         "The system prompt holds no task context for this task; the sections below are the full baseline.",
+      );
+   } else if (!sameTask) {
+      headerLines.push("The sections below are the full baseline for the newly bound task.");
+   } else {
+      headerLines.push(
+         `Task context changed on disk. Each section below supersedes the same file in ${promptHasTask ? "the system prompt and in earlier updates" : "earlier updates"}.`,
+      );
+   }
+   headerLines.push("Files on disk remain authoritative; use read for anything not shown.");
+   const header = `${headerLines.join(" ")}\n\n`;
+
+   const nextFiles = new Map<string, TaskFileBaseline>();
+   interface Section {
+      primary: string;
+      fallback: string;
+      /** Baseline entry to downgrade to stale when `primary` does not go out; null for removal notices. */
+      file: { displayPath: string; block: string } | null;
+   }
+   const sections: Section[] = [];
+   // A different task has no usable baseline: every file starts without `old`.
+   const previousFiles = sameTask && previous ? previous.files : new Map<string, TaskFileBaseline>();
+
+   for (const file of current.files) {
+      const old = previousFiles.get(file.displayPath);
+      if (old && old.block === file.block && !old.unseen) {
+         // Unchanged. After a compaction the update that carried `old.block` may
+         // have been summarized away, so its next change must be sent in full.
+         nextFiles.set(file.displayPath, epochReset && !old.stale ? { ...old, stale: true } : old);
+         continue;
+      }
+      const blockBytes = Buffer.byteLength(file.block, "utf-8");
+      let diff: string | null = null;
+      if (old && !old.stale && !epochReset && old.stackedDiffs < limits.diff_max_stack) {
+         const candidate = unifiedDiff(old.block, file.block, file.displayPath);
+         const candidateBytes = candidate === null ? 0 : Buffer.byteLength(candidate, "utf-8");
+         // A diff is only worth it when it is cheaper than the block itself and
+         // the diffs stacked since the last full send still cost less than one
+         // full resend; otherwise the full block resets the stack.
+         if (
+            candidate !== null &&
+            candidate !== "" &&
+            candidateBytes <= limits.diff_max_bytes &&
+            candidateBytes < blockBytes &&
+            old.stackedDiffBytes + candidateBytes <= blockBytes
+         ) {
+            diff = candidate;
+         }
+      }
+      const fallback = `## ${file.displayPath} [omitted]\n\n[Trellis: omitted (update budget reached) — ${file.displayPath}; required_read: ${file.displayPath}]`;
+      if (diff !== null && old) {
+         sections.push({ primary: `## ${file.displayPath} (diff)\n\n${diff}`, fallback, file });
+         nextFiles.set(file.displayPath, {
+            block: file.block,
+            stackedDiffs: old.stackedDiffs + 1,
+            stackedDiffBytes: old.stackedDiffBytes + Buffer.byteLength(diff, "utf-8"),
+            stale: false,
+            unseen: false,
+         });
+      } else {
+         sections.push({ primary: `## ${file.displayPath} (full)\n\n${file.block}`, fallback, file });
+         nextFiles.set(file.displayPath, {
+            block: file.block,
+            stackedDiffs: 0,
+            stackedDiffBytes: 0,
+            stale: false,
+            unseen: false,
+         });
+      }
+   }
+   for (const displayPath of previousFiles.keys()) {
+      if (nextFiles.has(displayPath)) continue;
+      const text = `## ${displayPath} (removed)\n\nNo longer part of the task context.`;
+      sections.push({ primary: text, fallback: text, file: null });
+   }
+
+   const baseline: TaskContextBaseline = {
+      taskDir: current.taskDir,
+      taskLabel: current.taskLabel,
+      signature: current.signature,
+      files: nextFiles,
+   };
+   if (sections.length === 0) return { content: "", baseline };
+
+   const wrapperBytes = Buffer.byteLength(UPDATE_PREFIX + header + UPDATE_SUFFIX, "utf-8");
+   const budget = new ContextBudget(limits.max_total_bytes, wrapperBytes);
+   const parts: string[] = [];
+   for (const section of sections) {
+      const separator = parts.length > 0 ? "\n\n" : "";
+      const primary = separator + section.primary;
+      const output = budget.emitCandidate(primary, separator + section.fallback);
+      if (output !== null) parts.push(output);
+      if (section.file && output !== primary) {
+         // The model only got a notice (or nothing): remember the current text so
+         // the change is not re-reported, but never diff against it.
+         nextFiles.set(section.file.displayPath, {
+            block: section.file.block,
+            stackedDiffs: 0,
+            stackedDiffBytes: 0,
+            stale: true,
+            unseen: true,
+         });
+      }
+   }
+   return {
+      content: `${UPDATE_PREFIX}${header}${parts.join("")}${UPDATE_SUFFIX}`,
+      baseline,
+   };
+}
 // ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
 
-export default function(pi: ExtensionAPI): void {
+export default function (pi: ExtensionAPI): void {
    let projectRoot: string | null = null;
    const turnCache = new TurnContextCache();
    const agentType = detectAgentType();
    const isSubAgent = agentType !== null;
-   let taskContextCache: TaskContextCache | null = null;
 
-   // Tracks compaction boundaries — context handler skips scanning when no
-   // compaction has occurred since last injection.
-   let lastCompactionTs = 0;
-   let lastInjectionTs = 0;
+   // Set when a compaction is announced and cleared once a workflow breadcrumb
+   // has been persisted or re-projected afterwards. A boolean instead of a
+   // timestamp pair: two events inside the same millisecond must not reopen
+   // the safety net.
+   let compactionPending = false;
 
-   const rememberContextKey = (ctx?: { sessionManager?: { getSessionId?: () => string | undefined; getSessionFile?: () => string | undefined } }): string | null => {
+   // Provider prefix caches invalidate from byte 0 whenever the system prompt
+   // changes, so the task block appended to the system prompt is memoized per
+   // context key + project root and stays byte-identical for the life of the
+   // process. Later on-disk changes travel through persisted update messages.
+   const memoizedTaskBlocks = new Map<string, string>();
+   const taskBaselines = new Map<string, TaskContextBaseline | null>();
+   // Set by session_before_compact and consumed by the next update planning:
+   // earlier snapshots may have been summarized away, so the first change after
+   // a compaction re-sends the full block instead of a diff.
+   let baselineEpochInvalidated = false;
+
+   const rememberContextKey = (ctx?: {
+      sessionManager?: {
+         getSessionId?: () => string | undefined;
+         getSessionFile?: () => string | undefined;
+      };
+   }): string | null => {
       const key = deriveContextKey(ctx);
       if (!key) return null;
       return key;
    };
 
-   const getTaskContext = (taskDir: string, root: string): string => {
+   const promptKey = (root: string, contextKey: string | null): string => `${contextKey ?? "default"}::${root}`;
+
+   const snapshotTask = (
+      taskDir: string,
+      root: string,
+   ): { snapshot: TaskContextSnapshot; entries: TaskContextEntry[] } => {
+      // Signature before content: a write landing between the two reads then
+      // leaves the stored signature older than the text, so the next turn
+      // re-plans (and stays silent if the content matches) instead of missing it.
       const signature = taskContextSignature(root, taskDir, agentType);
-      if (taskContextCache?.projectRoot === root && taskContextCache.taskDir === taskDir && taskContextCache.agentType === agentType && taskContextCache.signature === signature) {
-         return taskContextCache.content;
-      }
-      const content = buildTaskContext(root, taskDir, agentType);
-      taskContextCache = { projectRoot: root, taskDir, agentType, signature, content };
-      return content;
+      const entries = materializeTaskContextFiles(root, taskDir, agentType);
+      return {
+         entries,
+         snapshot: {
+            taskDir,
+            taskLabel: displayProjectPath(root, taskDir, taskDir),
+            signature,
+            files: snapshotFiles(entries),
+         },
+      };
    };
 
    pi.on("session_start", async (_event, ctx) => {
@@ -934,36 +1458,25 @@ export default function(pi: ExtensionAPI): void {
          // Sub-agent: inject precise task context once
          const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
          if (taskDir) {
-            const taskContext = getTaskContext(taskDir, projectRoot);
+            const taskContext = buildTaskContext(projectRoot, taskDir, agentType);
             if (taskContext) {
                await pi.sendMessage({
-                  customType: "trellis-task-context",
+                  customType: TASK_CONTEXT_TYPE,
                   content: taskContext,
                   display: false,
                });
             }
          }
       } else {
-         // Main session: inject session context (global map) + task context
+         // Main session: inject session context (global map). The task context
+         // is carried by the system prompt from the first turn onwards.
          const sessionContext = buildSessionContext(projectRoot, contextKey);
          if (sessionContext) {
             await pi.sendMessage({
-               customType: "trellis-session-context",
+               customType: SESSION_CONTEXT_TYPE,
                content: sessionContext,
                display: false,
             });
-         }
-
-         const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
-         if (taskDir) {
-            const taskContext = getTaskContext(taskDir, projectRoot);
-            if (taskContext) {
-               await pi.sendMessage({
-                  customType: "trellis-task-context",
-                  content: taskContext,
-                  display: false,
-               });
-            }
          }
 
          ctx.ui.notify("Trellis workflow system available", "info");
@@ -971,10 +1484,11 @@ export default function(pi: ExtensionAPI): void {
    });
 
    pi.on("session_before_compact", async () => {
-      lastCompactionTs = Date.now();
+      compactionPending = true;
+      baselineEpochInvalidated = true;
    });
 
-   pi.on("before_agent_start", async (_event, ctx) => {
+   pi.on("before_agent_start", async (event, ctx) => {
       if (!projectRoot) {
          projectRoot = findProjectRoot(ctx.cwd);
       }
@@ -983,86 +1497,133 @@ export default function(pi: ExtensionAPI): void {
 
       // Persistent injection: workflow state for this turn
       const cached = turnCache.get(projectRoot, contextKey);
-      lastInjectionTs = Date.now();
+      compactionPending = false;
 
-      // Skip turn: inject nothing (escape hatch)
-      if (!cached.workflowMsg) return;
+      const message = cached.workflowMsg
+         ? {
+              customType: WORKFLOW_STATE_TYPE,
+              content: cached.workflowMsg,
+              display: false,
+           }
+         : undefined;
 
+      if (isSubAgent) return message ? { message } : undefined;
+
+      // Task block: snapshot once per context key, then keep the system prompt
+      // byte-identical. `event.systemPrompt` already carries earlier handlers'
+      // segments; only append, never replace.
+      const key = promptKey(projectRoot, contextKey);
+      let block = memoizedTaskBlocks.get(key);
+      if (block === undefined) {
+         const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+         block = "";
+         let baseline: TaskContextBaseline | null = null;
+         if (taskDir) {
+            // One materialization feeds both the prompt block and the baseline so
+            // later diffs are computed against exactly the text the model saw.
+            const { snapshot, entries } = snapshotTask(taskDir, projectRoot);
+            const rendered = renderTaskContext(projectRoot, entries);
+            block = rendered.content;
+            if (block) baseline = baselineFrom(snapshot, rendered.omittedPaths);
+         }
+         memoizedTaskBlocks.set(key, block);
+         taskBaselines.set(key, baseline);
+      }
+      const basePrompt = (event as { systemPrompt?: unknown }).systemPrompt;
+      const systemPrompt = block && Array.isArray(basePrompt) ? [...basePrompt, block] : undefined;
+      if (!message && !systemPrompt) return;
+      return {
+         ...(message ? { message } : {}),
+         ...(systemPrompt ? { systemPrompt } : {}),
+      };
+   });
+
+   // Second handler: append-only task context refresh. Runs after the memoize
+   // handler above (same registration order), returns at most one persisted
+   // message per turn and never touches the system prompt.
+   pi.on("before_agent_start", async (_event, ctx) => {
+      if (!projectRoot || isSubAgent) return;
+      const contextKey = rememberContextKey(ctx);
+      const key = promptKey(projectRoot, contextKey);
+      if (!memoizedTaskBlocks.has(key)) return;
+      // Skip turn (escape hatch): inject nothing and leave the baseline alone so
+      // the change is still reported on the next normal turn.
+      if (!turnCache.get(projectRoot, contextKey).workflowMsg) return;
+
+      const previous = taskBaselines.get(key) ?? null;
+      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
+      const epochReset = baselineEpochInvalidated;
+      if (
+         taskDir &&
+         previous &&
+         previous.taskDir === taskDir &&
+         !epochReset &&
+         previous.signature === taskContextSignature(projectRoot, taskDir, agentType)
+      ) {
+         return;
+      }
+      baselineEpochInvalidated = false;
+      const plan = planTaskContextUpdate({
+         previous,
+         current: taskDir ? snapshotTask(taskDir, projectRoot).snapshot : null,
+         limits: readContextInjectionLimits(projectRoot),
+         epochReset,
+         promptHasTask: (memoizedTaskBlocks.get(key) ?? "") !== "",
+      });
+      taskBaselines.set(key, plan.baseline);
+      if (!plan.content) return;
       return {
          message: {
-            customType: "trellis-workflow-state",
-            content: cached.workflowMsg,
+            customType: TASK_CONTEXT_UPDATE_TYPE,
+            content: plan.content,
             display: false,
          },
       };
    });
 
    // context fires before EVERY LLM API call (including tool-use continuations
-   // and post-compaction agent.continue() paths). Acts as a safety net when
-   // before_agent_start's persisted message was removed by compaction.
+   // and post-compaction agent.continue() paths). It only acts as a safety net
+   // for the workflow breadcrumb; task context is never rewritten here because
+   // any change to an earlier message breaks the provider prefix cache.
    pi.on("context", async (event, ctx) => {
       if (!projectRoot) return;
       const contextKey = rememberContextKey(ctx);
 
       const messages = event.messages as { role?: string; customType?: string; content?: string }[];
-      const { taskDir } = resolveActiveTaskStatus(projectRoot, contextKey);
-      const currentTaskContext = taskDir ? getTaskContext(taskDir, projectRoot) : "";
-      const taskContextIndexes = messages
-         .map((message, index) => message.customType === "trellis-task-context" ? index : -1)
-         .filter((index) => index >= 0);
-      const existingTaskContext = taskContextIndexes.length > 0
-         ? messages[taskContextIndexes[0]]?.content ?? ""
-         : "";
-      const taskContextChanged = existingTaskContext !== currentTaskContext || taskContextIndexes.length > 1;
-      let projectedMessages = messages;
-      if (taskContextChanged) {
-         const replacement = currentTaskContext
-            ? { role: "custom" as const, customType: "trellis-task-context", content: currentTaskContext, display: false, timestamp: Date.now() }
-            : null;
-         let replaced = false;
-         projectedMessages = messages.flatMap((message) => {
-            if (message.customType !== "trellis-task-context") return [message];
-            if (replaced || !replacement) return [];
-            replaced = true;
-            return [replacement];
-         });
-         if (replacement && !replaced) projectedMessages.push(replacement);
-      }
 
       // Resolve the turn state before the fast path: a skip turn must still
       // run breadcrumb cleanup even when nothing else changed.
       const cached = turnCache.get(projectRoot, contextKey);
       const skipping = !cached.workflowMsg;
 
-      // Fast path: no task change, no compaction, not skipping — all persisted context is current.
-      if (!taskContextChanged && !skipping && lastInjectionTs > lastCompactionTs) return;
+      if (!skipping && !compactionPending) return;
 
       if (skipping) {
          // Skip turn (escape hatch): drop any persisted breadcrumb from an
          // earlier turn so the skip actually takes effect.
-         const withoutBreadcrumb = projectedMessages.filter(
-            (message) => !(message.role === "custom" && message.customType === "trellis-workflow-state"),
+         const withoutBreadcrumb = messages.filter(
+            (message) => !(message.role === "custom" && message.customType === WORKFLOW_STATE_TYPE),
          );
-         if (withoutBreadcrumb.length === projectedMessages.length && !taskContextChanged) return;
-         lastInjectionTs = Date.now();
+         if (withoutBreadcrumb.length === messages.length) return;
+         compactionPending = false;
          return { messages: withoutBreadcrumb };
       }
 
       // Post-compaction: reverse-scan to confirm absence before injecting
-      for (let i = projectedMessages.length - 1; i >= 0; i--) {
-         if (projectedMessages[i].role === "custom" && projectedMessages[i].customType === "trellis-workflow-state") {
-            lastInjectionTs = Date.now();
-            return taskContextChanged ? { messages: projectedMessages } : undefined;
+      for (let i = messages.length - 1; i >= 0; i--) {
+         if (messages[i].role === "custom" && messages[i].customType === WORKFLOW_STATE_TYPE) {
+            compactionPending = false;
+            return;
          }
       }
 
-      lastInjectionTs = Date.now();
+      compactionPending = false;
       return {
          messages: [
-            ...projectedMessages,
+            ...messages,
             {
                role: "custom" as const,
-               customType: "trellis-workflow-state",
+               customType: WORKFLOW_STATE_TYPE,
                content: cached.workflowMsg,
                display: false,
                timestamp: Date.now(),

--- a/packages/cli/test/templates/omp.test.ts
+++ b/packages/cli/test/templates/omp.test.ts
@@ -45,49 +45,136 @@ function loadOmpExtension(): OmpExtension {
   });
   vm.runInContext(compiled, sandbox);
   const extension = moduleObject.exports.default;
-  if (!extension) throw new Error("OMP extension template has no default export");
+  if (!extension)
+    throw new Error("OMP extension template has no default export");
   return extension;
 }
 
 function captureOmpHandlers(): Map<string, OmpEventHandler> {
   const handlers = new Map<string, OmpEventHandler>();
   loadOmpExtension()({
-    on: (event, handler) => handlers.set(event, handler),
+    on: (event, handler) => addHandler(handlers, event, handler),
   });
   return handlers;
 }
 
-function makeOmpProject(): { root: string; taskDir: string; sessionId: string } {
-  const root = fs.mkdtempSync(path.join(process.env.TMPDIR ?? "/tmp", "trellis-omp-") );
+
+// Mirrors the OMP extension runner: every handler registered for an event runs
+// in order, and before_agent_start collects one persisted message per handler
+// while chaining the system prompt through them.
+function addHandler(
+  handlers: Map<string, OmpEventHandler>,
+  event: string,
+  handler: OmpEventHandler,
+): void {
+  const previous = handlers.get(event);
+  if (!previous) {
+    handlers.set(event, handler);
+    return;
+  }
+  handlers.set(event, async (payload, ctx) => {
+    const first = (await previous(payload, ctx)) as
+      | Record<string, unknown>
+      | undefined;
+    const second = (await handler(payload, ctx)) as
+      | Record<string, unknown>
+      | undefined;
+    if (!first) return second;
+    if (!second) return first;
+    const messages = [first.message, second.message].filter(Boolean);
+    return { ...first, ...second, message: messages[0], messages };
+  });
+}
+
+interface PersistedPayload {
+  customType?: string;
+  content?: string;
+  display?: boolean;
+}
+
+interface TurnResult {
+  systemPrompt?: string[];
+  messages: PersistedPayload[];
+}
+
+async function runTurn(
+  handlers: Map<string, OmpEventHandler>,
+  ctx: unknown,
+  text = "",
+): Promise<TurnResult> {
+  const input = handlers.get("input");
+  const beforeAgentStart = handlers.get("before_agent_start");
+  if (!input || !beforeAgentStart)
+    throw new Error("OMP extension did not register required handlers");
+  await input({ text }, ctx);
+  const result = (await beforeAgentStart({ systemPrompt: ["base"] }, ctx)) as
+    | { systemPrompt?: string[]; message?: PersistedPayload; messages?: PersistedPayload[] }
+    | undefined;
+  return {
+    systemPrompt: result?.systemPrompt,
+    messages: result?.messages ?? (result?.message ? [result.message] : []),
+  };
+}
+
+function updateOf(turn: TurnResult): PersistedPayload | undefined {
+  return turn.messages.find(
+    (message) => message.customType === "trellis-task-context-update",
+  );
+}
+
+function makeOmpProject(): {
+  root: string;
+  taskDir: string;
+  sessionId: string;
+} {
+  const root = fs.mkdtempSync(
+    path.join(process.env.TMPDIR ?? "/tmp", "trellis-omp-"),
+  );
   const taskDir = path.join(root, ".trellis", "tasks", "08-13-context-limits");
   const sessionId = "context_limits";
-  fs.mkdirSync(path.join(root, ".trellis", ".runtime", "sessions"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".trellis", ".runtime", "sessions"), {
+    recursive: true,
+  });
   fs.mkdirSync(taskDir, { recursive: true });
-  fs.writeFileSync(path.join(taskDir, "task.json"), JSON.stringify({ status: "in_progress", title: "Context limits" }));
   fs.writeFileSync(
-    path.join(root, ".trellis", ".runtime", "sessions", "omp_context_limits.json"),
+    path.join(taskDir, "task.json"),
+    JSON.stringify({ status: "in_progress", title: "Context limits" }),
+  );
+  fs.writeFileSync(
+    path.join(
+      root,
+      ".trellis",
+      ".runtime",
+      "sessions",
+      "omp_context_limits.json",
+    ),
     JSON.stringify({ current_task: ".trellis/tasks/08-13-context-limits" }),
   );
   return { root, taskDir, sessionId };
 }
 
-async function runSessionStart(root: string, sessionId: string): Promise<string> {
-  const messages: { customType?: string; content?: string }[] = [];
+// The main session carries the task context in the memoized system prompt
+// (first before_agent_start) rather than as a persisted session_start message,
+// so "the task context at session start" is the system prompt task block.
+async function runSessionStart(
+  root: string,
+  sessionId: string,
+): Promise<string> {
   const handlers = new Map<string, OmpEventHandler>();
   loadOmpExtension()({
-    on: (event, handler) => handlers.set(event, handler),
-    sendMessage: async (message: { customType?: string; content?: string }) => {
-      messages.push(message);
-    },
+    on: (event, handler) => addHandler(handlers, event, handler),
+    sendMessage: async () => undefined,
   } as never);
   const handler = handlers.get("session_start");
   if (!handler) throw new Error("OMP extension did not register session_start");
-  await handler({}, {
+  const ctx = {
     cwd: root,
     sessionManager: { getSessionId: () => sessionId },
     ui: { notify: () => undefined },
-  });
-  return messages.find((message) => message.customType === "trellis-task-context")?.content ?? "";
+  };
+  await handler({}, ctx);
+  const turn = await runTurn(handlers, ctx);
+  return turn.systemPrompt?.[1] ?? "";
 }
 
 describe("omp templates", () => {
@@ -118,6 +205,9 @@ describe("omp templates", () => {
     expect(extension).toContain("input");
     expect(extension).toContain("session_start");
     expect(extension).toContain("ExtensionAPI");
+    expect(extension).toContain("trellis-task-context-update");
+    expect(extension).toContain("planTaskContextUpdate");
+    expect(extension).not.toContain("projectTaskContext");
   });
 
   it("extension template avoids known runtime and context-safety regressions", () => {
@@ -127,7 +217,9 @@ describe("omp templates", () => {
     expect(extension).not.toContain("process.env.TRELLIS_CONTEXT_ID =");
     expect(extension).toContain('buildContextKey("omp", "session", sessionId)');
     expect(extension).toContain("realpathSync");
-    expect(extension).toContain("resolveProjectFile(projectRoot, file, trustedRoots)");
+    expect(extension).toContain(
+      "resolveProjectFile(projectRoot, file, trustedRoots)",
+    );
     expect(extension).toContain("readFilePrefix(targetPath");
     expect(extension).toContain("if (!key) return null;");
     expect(extension).toContain("return key;");
@@ -152,7 +244,12 @@ describe("omp templates", () => {
     };
 
     handler(
-      { type: "tool_call", toolName: "bash", toolCallId: "call-1", input: params },
+      {
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "call-1",
+        input: params,
+      },
       { sessionManager: { getSessionId: () => "session/a" } },
     );
 
@@ -171,7 +268,12 @@ describe("omp templates", () => {
     };
 
     handler(
-      { type: "tool_call", toolName: "bash", toolCallId: "call-2", input: params },
+      {
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "call-2",
+        input: params,
+      },
       { sessionManager: { getSessionId: () => "session/b" } },
     );
 
@@ -185,7 +287,12 @@ describe("omp templates", () => {
     const params: Record<string, unknown> = { path: "README.md" };
 
     handler(
-      { type: "tool_call", toolName: "read", toolCallId: "call-3", input: params },
+      {
+        type: "tool_call",
+        toolName: "read",
+        toolCallId: "call-3",
+        input: params,
+      },
       { sessionManager: { getSessionId: () => "session/c" } },
     );
 
@@ -259,26 +366,24 @@ describe("omp templates", () => {
 
       const handlers = new Map<string, OmpEventHandler>();
       loadOmpExtension()({
-        on: (event, handler) => handlers.set(event, handler),
+        on: (event, handler) => addHandler(handlers, event, handler),
         sendMessage: async (message) =>
           messages.push(message as { customType?: string; content?: string }),
       });
       const sessionStart = handlers.get("session_start");
       if (!sessionStart)
         throw new Error("OMP extension did not register session_start");
+      const ctx = {
+        cwd: projectRoot,
+        sessionManager: { getSessionId: () => "session/dedupe" },
+        ui: { notify: () => undefined },
+      };
 
-      await sessionStart(
-        {},
-        {
-          cwd: projectRoot,
-          sessionManager: { getSessionId: () => "session/dedupe" },
-          ui: { notify: () => undefined },
-        },
-      );
-
-      const taskContext = messages.find(
-        (message) => message.customType === "trellis-task-context",
-      );
+      await sessionStart({}, ctx);
+      expect(
+        messages.some((message) => message.customType === "trellis-task-context"),
+      ).toBe(false);
+      const taskContext = { content: (await runTurn(handlers, ctx)).systemPrompt?.[1] };
       expect(taskContext?.content).toContain("## implement.jsonl");
       expect(taskContext?.content).toContain("## check.jsonl");
       expect(taskContext?.content?.match(/shared context body/g)).toHaveLength(
@@ -290,10 +395,17 @@ describe("omp templates", () => {
     }
   });
 
-  it("refreshes task context when a referenced file changes mid-session", async () => {
-    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trellis-omp-refresh-"));
+  it("snapshots the task context into the system prompt and appends changes as diffs", async () => {
+    const projectRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "trellis-omp-refresh-"),
+    );
     const taskDir = path.join(projectRoot, ".trellis", "tasks", "demo-task");
-    const sessionsDir = path.join(projectRoot, ".trellis", ".runtime", "sessions");
+    const sessionsDir = path.join(
+      projectRoot,
+      ".trellis",
+      ".runtime",
+      "sessions",
+    );
     const referencedFile = path.join(projectRoot, "docs", "changing.md");
     const messages: { customType?: string; content?: string }[] = [];
 
@@ -301,8 +413,14 @@ describe("omp templates", () => {
       fs.mkdirSync(taskDir, { recursive: true });
       fs.mkdirSync(sessionsDir, { recursive: true });
       fs.mkdirSync(path.dirname(referencedFile), { recursive: true });
-      fs.writeFileSync(path.join(taskDir, "task.json"), JSON.stringify({ status: "in_progress" }));
-      fs.writeFileSync(referencedFile, "old context body");
+      fs.writeFileSync(
+        path.join(taskDir, "task.json"),
+        JSON.stringify({ status: "in_progress" }),
+      );
+      fs.writeFileSync(
+        referencedFile,
+        `${Array.from({ length: 20 }, (_, i) => `context line ${i + 1}`).join("\n")}\nold context body\n`,
+      );
       fs.writeFileSync(
         path.join(taskDir, "implement.jsonl"),
         `${JSON.stringify({ file: "docs/changing.md" })}\n${JSON.stringify({ file: "docs/created-later.md" })}\n`,
@@ -314,12 +432,14 @@ describe("omp templates", () => {
 
       const handlers = new Map<string, OmpEventHandler>();
       loadOmpExtension()({
-        on: (event, handler) => handlers.set(event, handler),
-        sendMessage: async (message) => messages.push(message as { customType?: string; content?: string }),
+        on: (event, handler) => addHandler(handlers, event, handler),
+        sendMessage: async (message) =>
+          messages.push(message as { customType?: string; content?: string }),
       });
       const sessionStart = handlers.get("session_start");
       const context = handlers.get("context");
-      if (!sessionStart || !context) throw new Error("OMP extension did not register required handlers");
+      if (!sessionStart || !context)
+        throw new Error("OMP extension did not register required handlers");
       const ctx = {
         cwd: projectRoot,
         sessionManager: { getSessionId: () => "session/refresh" },
@@ -327,60 +447,81 @@ describe("omp templates", () => {
       };
 
       await sessionStart({}, ctx);
-      const initial = messages.find((message) => message.customType === "trellis-task-context");
-      expect(initial?.content).toContain("old context body");
-      expect(initial?.content).not.toContain("created later body");
+      // The main session no longer persists the task context: it rides in the
+      // system prompt so compaction cannot drop it and history stays append-only.
+      expect(
+        messages.some((message) => message.customType === "trellis-task-context"),
+      ).toBe(false);
 
-      fs.writeFileSync(referencedFile, "new context body with changed size");
-      fs.writeFileSync(path.join(projectRoot, "docs", "created-later.md"), "created later body");
-      const result = await context(
+      const first = await runTurn(handlers, ctx);
+      expect(first.systemPrompt?.[0]).toBe("base");
+      expect(first.systemPrompt?.[1]).toContain("old context body");
+      expect(first.systemPrompt?.[1]).not.toContain("created later body");
+      expect(updateOf(first)).toBeUndefined();
+
+      fs.writeFileSync(
+        referencedFile,
+        `${Array.from({ length: 20 }, (_, i) => `context line ${i + 1}`).join("\n")}\nnew context body with changed size\n`,
+      );
+      fs.writeFileSync(
+        path.join(projectRoot, "docs", "created-later.md"),
+        "created later body",
+      );
+      const second = await runTurn(handlers, ctx);
+      expect(second.systemPrompt).toEqual(first.systemPrompt);
+      const update = updateOf(second);
+      expect(update?.display).toBe(false);
+      expect(update?.content).toContain("## docs/changing.md (diff)");
+      expect(update?.content).toContain("-old context body");
+      expect(update?.content).toContain("+new context body with changed size");
+      expect(update?.content).toContain("## docs/created-later.md (full)");
+      expect(update?.content).toContain("created later body");
+
+      // Provider requests inside the turn never rewrite earlier messages.
+      const untouched = await context(
         {
           messages: [
-            { role: "custom", customType: "trellis-task-context", content: initial?.content },
-            { role: "custom", customType: "trellis-workflow-state", content: "workflow" },
+            { role: "custom", customType: "trellis-session-context", content: "s" },
+            { role: "user", content: "prompt" },
+            ...second.messages.map((message) => ({ role: "custom", ...message })),
+            { role: "assistant", content: "reply" },
           ],
         },
         ctx,
-      ) as { messages?: { customType?: string; content?: string }[] } | undefined;
+      );
+      expect(untouched).toBeUndefined();
 
-      const refreshed = result?.messages?.filter(
-        (message) => message.customType === "trellis-task-context",
-      ) ?? [];
-      expect(refreshed).toHaveLength(1);
-      expect(refreshed[0]?.content).toContain("new context body with changed size");
-      expect(refreshed[0]?.content).toContain("created later body");
-      expect(refreshed[0]?.content).not.toContain("old context body");
-
-      const unchanged = await context({ messages: result?.messages }, ctx);
-      expect(unchanged).toBeUndefined();
+      const third = await runTurn(handlers, ctx);
+      expect(third.systemPrompt).toEqual(first.systemPrompt);
+      expect(updateOf(third)).toBeUndefined();
     } finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
     }
   });
 
-  it("re-evaluates later budgeted files when an earlier file shrinks mid-session", async () => {
+  it("appends a late-bound task once and never rewrites provider history (#595)", async () => {
     const project = makeOmpProject();
     const messages: { customType?: string; content?: string }[] = [];
 
     try {
-      fs.writeFileSync(
-        path.join(project.root, ".trellis", "config.yaml"),
-        "context_injection:\n  max_file_bytes: 0\n  max_artifact_bytes: 64\n  max_total_bytes: 900\n",
+      // The session starts without an active task; the task is bound
+      // afterwards via task.py.
+      const sessionFile = path.join(
+        project.root,
+        ".trellis",
+        ".runtime",
+        "sessions",
+        `omp_${project.sessionId}.json`,
       );
-      const earlierFile = path.join(project.root, "earlier.md");
-      fs.writeFileSync(earlierFile, "a".repeat(450));
-      fs.writeFileSync(path.join(project.root, "later.md"), "later content ".repeat(25));
+      fs.writeFileSync(sessionFile, JSON.stringify({ current_task: null }));
       fs.writeFileSync(
-        path.join(project.taskDir, "implement.jsonl"),
-        [
-          JSON.stringify({ file: "earlier.md", reason: "earlier budget consumer" }),
-          JSON.stringify({ file: "later.md", reason: "later candidate" }),
-        ].join("\n") + "\n",
+        path.join(project.taskDir, "prd.md"),
+        "# Context limits\n",
       );
 
       const handlers = new Map<string, OmpEventHandler>();
       loadOmpExtension()({
-        on: (event, handler) => handlers.set(event, handler),
+        on: (event, handler) => addHandler(handlers, event, handler),
         sendMessage: async (message) =>
           messages.push(message as { customType?: string; content?: string }),
       });
@@ -395,41 +536,212 @@ describe("omp templates", () => {
       };
 
       await sessionStart({}, ctx);
-      const initial = messages.find(
-        (message) => message.customType === "trellis-task-context",
+      expect(
+        messages.some((m) => m.customType === "trellis-task-context"),
+      ).toBe(false);
+      const first = await runTurn(handlers, ctx);
+      // No task at the first turn: the memoized system prompt stays without a
+      // task block for the life of the process.
+      expect(first.systemPrompt).toBeUndefined();
+      expect(updateOf(first)).toBeUndefined();
+
+      fs.writeFileSync(
+        sessionFile,
+        JSON.stringify({ current_task: ".trellis/tasks/08-13-context-limits" }),
       );
-      expect(initial?.content).toContain("earlier.md [inline]");
-      expect(initial?.content).toContain("later.md [omitted]");
+      const second = await runTurn(handlers, ctx);
+      expect(second.systemPrompt).toBeUndefined();
+      const update = updateOf(second);
+      expect(update?.content).toContain(
+        "The system prompt holds no task context for this task",
+      );
+      expect(update?.content).toContain("## .trellis/tasks/08-13-context-limits/prd.md (full)");
+      expect(update?.content).toContain("# Context limits");
+
+      const history: Record<string, unknown>[] = [
+        { role: "custom", customType: "trellis-session-context", content: "session" },
+        { role: "user", content: "seed" },
+        ...second.messages.map((message) => ({ role: "custom", ...message })),
+      ];
+      // Append-only prefix: the context handler leaves history untouched no
+      // matter how it grows, so every request shares the previous prefix.
+      expect(await context({ messages: [...history] }, ctx)).toBeUndefined();
+      history.push(
+        { role: "assistant", content: "reply" },
+        { role: "toolResult", content: "result" },
+      );
+      expect(await context({ messages: [...history] }, ctx)).toBeUndefined();
+
+      const third = await runTurn(handlers, ctx);
+      expect(updateOf(third)).toBeUndefined();
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("appends the breadcrumb once after a compaction and re-sends changed files in full", async () => {
+    const project = makeOmpProject();
+    const handlers = captureOmpHandlers();
+    const beforeCompact = handlers.get("session_before_compact");
+    const context = handlers.get("context");
+    if (!beforeCompact || !context)
+      throw new Error("OMP extension did not register required handlers");
+    const ctx = {
+      cwd: project.root,
+      sessionManager: { getSessionId: () => project.sessionId },
+      ui: { notify: () => undefined },
+    };
+
+    try {
+      fs.writeFileSync(
+        path.join(project.taskDir, "prd.md"),
+        `${Array.from({ length: 20 }, (_, i) => `requirement ${i + 1}`).join("\n")}\n`,
+      );
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "workflow.md"),
+        "[workflow-state:in_progress]\nContinue.\n[/workflow-state:in_progress]\n",
+      );
+      const first = await runTurn(handlers, ctx, "go");
+      expect(first.systemPrompt?.[1]).toContain("requirement 20");
+      await beforeCompact({}, ctx);
+
+      // Split-turn compaction summarized the turn prefix (including the
+      // persisted breadcrumb); the tool loop then continues without a new
+      // before_agent_start, so every call here is a post-compaction request.
+      const summary = {
+        role: "compactionSummary",
+        summary: "s",
+        tokensBefore: 200000,
+        timestamp: 2,
+      };
+      const history: Record<string, unknown>[] = [
+        summary,
+        { role: "assistant", content: "a0" },
+        { role: "toolResult", content: "t0" },
+      ];
+      const shape = (list: Record<string, unknown>[]): string[] =>
+        list.map((m) => String(m.customType ?? m.role));
+
+      const result = (await context({ messages: [...history] }, ctx)) as
+        | { messages: Record<string, unknown>[] }
+        | undefined;
+      expect(result?.messages && shape(result.messages)).toEqual([
+        "compactionSummary",
+        "assistant",
+        "toolResult",
+        "trellis-workflow-state",
+      ]);
+      for (let round = 1; round <= 3; round++) {
+        history.push(
+          { role: "assistant", content: `a${round}` },
+          { role: "toolResult", content: `t${round}` },
+        );
+        expect(await context({ messages: [...history] }, ctx)).toBeUndefined();
+      }
+
+      // Earlier snapshots may have been summarized away, so the first change
+      // after the compaction is sent in full instead of as a diff.
+      fs.writeFileSync(
+        path.join(project.taskDir, "prd.md"),
+        `${Array.from({ length: 20 }, (_, i) => `requirement ${i + 1}`).join("\n")}\nrequirement 21\n`,
+      );
+      const second = await runTurn(handlers, ctx, "go on");
+      expect(second.systemPrompt).toEqual(first.systemPrompt);
+      expect(updateOf(second)?.content).toContain(
+        "## .trellis/tasks/08-13-context-limits/prd.md (full)",
+      );
+
+      fs.writeFileSync(
+        path.join(project.taskDir, "prd.md"),
+        `${Array.from({ length: 20 }, (_, i) => `requirement ${i + 1}`).join("\n")}\nrequirement 21 revised\n`,
+      );
+      const third = await runTurn(handlers, ctx, "go on");
+      expect(updateOf(third)?.content).toContain(
+        "## .trellis/tasks/08-13-context-limits/prd.md (diff)",
+      );
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent when only the mtime changed and defers changes made on a skip turn", async () => {
+    const project = makeOmpProject();
+    const handlers = captureOmpHandlers();
+    const ctx = {
+      cwd: project.root,
+      sessionManager: { getSessionId: () => project.sessionId },
+      ui: { notify: () => undefined },
+    };
+
+    try {
+      const prd = path.join(project.taskDir, "prd.md");
+      const body = `${Array.from({ length: 20 }, (_, i) => `requirement ${i + 1}`).join("\n")}\n`;
+      fs.writeFileSync(prd, body);
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "prompt_injection:\n  skip_keyword: no-trellis\n",
+      );
+      await runTurn(handlers, ctx, "go");
+
+      const later = new Date(Date.now() + 5000);
+      fs.utimesSync(prd, later, later);
+      expect(updateOf(await runTurn(handlers, ctx, "touch only"))).toBeUndefined();
+
+      fs.writeFileSync(prd, `${body}requirement 21\n`);
+      const skipped = await runTurn(handlers, ctx, "no-trellis for this turn");
+      expect(skipped.messages).toHaveLength(0);
+
+      const next = await runTurn(handlers, ctx, "back to normal");
+      expect(updateOf(next)?.content).toContain("+requirement 21");
+    } finally {
+      fs.rmSync(project.root, { recursive: true, force: true });
+    }
+  });
+
+  it("re-sends later budgeted files once an earlier file shrinks", async () => {
+    const project = makeOmpProject();
+
+    try {
+      fs.writeFileSync(
+        path.join(project.root, ".trellis", "config.yaml"),
+        "context_injection:\n  max_file_bytes: 0\n  max_artifact_bytes: 64\n  max_total_bytes: 900\n",
+      );
+      const earlierFile = path.join(project.root, "earlier.md");
+      fs.writeFileSync(earlierFile, "a".repeat(450));
+      fs.writeFileSync(
+        path.join(project.root, "later.md"),
+        "later content ".repeat(25),
+      );
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        [
+          JSON.stringify({
+            file: "earlier.md",
+            reason: "earlier budget consumer",
+          }),
+          JSON.stringify({ file: "later.md", reason: "later candidate" }),
+        ].join("\n") + "\n",
+      );
+
+      const handlers = captureOmpHandlers();
+      const ctx = {
+        cwd: project.root,
+        sessionManager: { getSessionId: () => project.sessionId },
+        ui: { notify: () => undefined },
+      };
+
+      const first = await runTurn(handlers, ctx);
+      expect(first.systemPrompt?.[1]).toContain("earlier.md [inline]");
+      expect(first.systemPrompt?.[1]).toContain("later.md [omitted]");
 
       fs.writeFileSync(earlierFile, "short earlier content");
-      const result = (await context(
-        {
-          messages: [
-            {
-              role: "custom",
-              customType: "trellis-task-context",
-              content: initial?.content,
-            },
-            {
-              role: "custom",
-              customType: "trellis-workflow-state",
-              content: "workflow",
-            },
-          ],
-        },
-        ctx,
-      )) as
-        | { messages?: { customType?: string; content?: string }[] }
-        | undefined;
-
-      const refreshed = result?.messages?.filter(
-        (message) => message.customType === "trellis-task-context",
-      );
-      expect(refreshed).toHaveLength(1);
-      expect(refreshed?.[0]?.content).toContain("short earlier content");
-      expect(refreshed?.[0]?.content).toContain("later.md [inline]");
-      expect(refreshed?.[0]?.content).toContain("later content");
-      expect(refreshed?.[0]?.content).not.toContain("later.md [omitted]");
+      const second = await runTurn(handlers, ctx);
+      expect(second.systemPrompt).toEqual(first.systemPrompt);
+      const update = updateOf(second);
+      expect(update?.content).toContain("short earlier content");
+      expect(update?.content).toContain("## later.md (full)");
+      expect(update?.content).toContain("later.md [inline]");
+      expect(update?.content).toContain("later content");
     } finally {
       fs.rmSync(project.root, { recursive: true, force: true });
     }
@@ -490,8 +802,12 @@ describe("omp templates", () => {
         " ".repeat(1024 * 1024 + 1),
       );
       const context = await runSessionStart(project.root, project.sessionId);
-      expect(context).toContain(".trellis/tasks/08-13-context-limits/implement.jsonl [omitted]");
-      expect(context).toContain("required_read: .trellis/tasks/08-13-context-limits/implement.jsonl");
+      expect(context).toContain(
+        ".trellis/tasks/08-13-context-limits/implement.jsonl [omitted]",
+      );
+      expect(context).toContain(
+        "required_read: .trellis/tasks/08-13-context-limits/implement.jsonl",
+      );
       expect(context).toContain("manifest exceeds 1048576 byte parse limit");
     } finally {
       fs.rmSync(project.root, { recursive: true, force: true });
@@ -505,10 +821,14 @@ describe("omp templates", () => {
         path.join(project.root, ".trellis", "config.yaml"),
         "context_injection:\n  max_file_bytes: 3\n  max_artifact_bytes: 64\n  max_total_bytes: 2000\n",
       );
-      fs.writeFileSync(path.join(project.root, "invalid.md"), Buffer.from([0x61, 0x62, 0x63, 0x80, 0x64]));
+      fs.writeFileSync(
+        path.join(project.root, "invalid.md"),
+        Buffer.from([0x61, 0x62, 0x63, 0x80, 0x64]),
+      );
       fs.writeFileSync(
         path.join(project.taskDir, "implement.jsonl"),
-        JSON.stringify({ file: "invalid.md", reason: "invalid boundary" }) + "\n",
+        JSON.stringify({ file: "invalid.md", reason: "invalid boundary" }) +
+          "\n",
       );
 
       const context = await runSessionStart(project.root, project.sessionId);
@@ -534,7 +854,10 @@ describe("omp templates", () => {
         fs.writeFileSync(path.join(project.root, name), Buffer.from(bytes));
         fs.writeFileSync(
           path.join(project.taskDir, "implement.jsonl"),
-          JSON.stringify({ file: name, reason: "invalid second-byte boundary" }) + "\n",
+          JSON.stringify({
+            file: name,
+            reason: "invalid second-byte boundary",
+          }) + "\n",
         );
 
         const context = await runSessionStart(project.root, project.sessionId);
@@ -556,12 +879,15 @@ describe("omp templates", () => {
       fs.writeFileSync(path.join(project.root, "unicode.md"), "a€tail");
       fs.writeFileSync(
         path.join(project.taskDir, "implement.jsonl"),
-        JSON.stringify({ file: "unicode.md", reason: "unicode boundary" }) + "\n",
+        JSON.stringify({ file: "unicode.md", reason: "unicode boundary" }) +
+          "\n",
       );
 
       const context = await runSessionStart(project.root, project.sessionId);
       expect(context).toContain("unicode.md [truncated]");
-      expect(context).toContain("### unicode.md [truncated]\n\na\n[Trellis: truncated at 3 bytes");
+      expect(context).toContain(
+        "### unicode.md [truncated]\n\na\n[Trellis: truncated at 3 bytes",
+      );
       expect(context).not.toContain("€");
       expect(context).not.toContain("unicode.md [omitted]");
     } finally {
@@ -579,7 +905,10 @@ describe("omp templates", () => {
       fs.writeFileSync(path.join(project.root, "unicode-end.md"), "a€tail");
       fs.writeFileSync(
         path.join(project.taskDir, "implement.jsonl"),
-        JSON.stringify({ file: "unicode-end.md", reason: "unicode end boundary" }) + "\n",
+        JSON.stringify({
+          file: "unicode-end.md",
+          reason: "unicode end boundary",
+        }) + "\n",
       );
 
       const context = await runSessionStart(project.root, project.sessionId);
@@ -605,10 +934,15 @@ describe("omp templates", () => {
         fs.writeFileSync(path.join(project.root, file), "x".repeat(2000));
         rows.push(JSON.stringify({ file, reason: "budget regression" }));
       }
-      fs.writeFileSync(path.join(project.taskDir, "implement.jsonl"), `${rows.join("\n")}\n`);
+      fs.writeFileSync(
+        path.join(project.taskDir, "implement.jsonl"),
+        `${rows.join("\n")}\n`,
+      );
 
       const context = await runSessionStart(project.root, project.sessionId);
-      expect(Buffer.byteLength(context, "utf-8")).toBeLessThanOrEqual(maxTotalBytes);
+      expect(Buffer.byteLength(context, "utf-8")).toBeLessThanOrEqual(
+        maxTotalBytes,
+      );
       const omittedCount = context.match(/\[omitted\]/g)?.length ?? 0;
       expect(omittedCount).toBeGreaterThan(0);
       expect(omittedCount).toBeLessThan(20);


### PR DESCRIPTION
## Problem

The OMP extension refreshes the active task context on every `context` event (since #541) and rewrites the persisted `trellis-task-context` in place, or inserts one when none was persisted. `context` results are never persisted, so whenever the task files change the request replaces a message near the head of the history and the provider prompt cache loses everything after it.

Measured on 18.1.9 with the first revision of this PR (stable slot after the session context) in a real session:

| event | next request `cacheRead` | uncached input |
|---|---|---|
| `task.py create` (late bind) | 37,632 | ~30k |
| edit `prd.md` | 37,632 | ~153k |
| `task.py add-context` | 37,632 | ~171k |

Writes to `design.md` / `implement.md` (not part of the context signature) did **not** reset the cache, which pins the cause to the in-place refresh. A fixed slot only keeps the prefix stable until the task files change; during planning they change every turn. 0.6.15 never had the problem because it injected once at `session_start` and never rewrote history.

## Fix

Mirror the Pi extension (`taskCtxSnapshot` + persisted `trellis-runtime-context`), with a smaller payload:

- **System prompt baseline.** On the first `before_agent_start` for a context key + project root the task context is appended to `event.systemPrompt` and memoized for the life of the process. The system prompt stays byte-identical, survives compaction, and earlier handlers' segments are never replaced.
- **Append-only updates.** Once per user turn the task files are compared by content (mtime-only changes are ignored). Changes go out as one persisted `trellis-task-context-update` message with one section per file. Sections degrade in order: unified diff against the last text the model saw → full block → `[omitted]` notice. A full block is used when there is no baseline, after a compaction (`stale`), when the per-file diff stack or cumulative diff bytes exceed their caps, or when the diff would not be smaller than the block. Files the model never received (`unseen`, dropped by the budget) are re-sent in full on the next update pass.
- **`context` no longer touches task context.** It keeps only the skip-turn cleanup and the post-compaction breadcrumb safety net.
- A late-bound task is appended in full once; unbinding appends a short status message. Sub-agents keep their single `session_start` injection.
- `.trellis/config.yaml` gains `context_injection.diff_max_bytes` (default 8192) and `diff_max_stack` (default 3). The line diff is a self-contained Myers implementation.

Two `before_agent_start` handlers are registered (memoize/breadcrumb, then update) because `BeforeAgentStartEventResult.message` is a single message; the OMP runner collects one per handler and chains `systemPrompt` through them.

## Tests

`test/templates/omp.test.ts`: the harness now composes multiple handlers per event like the OMP runner. Replaced the stable-slot tests with: system prompt byte-identical across turns + diff update + `context` untouched; late-bound task appended once with append-only history; compaction breadcrumb once + full re-send after compaction; mtime-only silence + skip-turn deferral; budget-omitted file re-sent once room exists. `runSessionStart` reads the task block from the memoized system prompt.

Whole suite: 1896 passed; the 3 `platforms.integration` failures also fail on unmodified `main` in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trellis task context is now provided through the system prompt for more stable conversation context.
  - Task-context changes are delivered as append-only updates, using concise diffs when possible.
  - Added configurable limits for diff size, stacking, and total context size.
  - Workflow breadcrumbs continue to be restored when needed after compaction.

- **Bug Fixes**
  - Improved handling of late-bound tasks, file changes, compaction, and context budget changes.
  - Prevented duplicate or uncertain task-context injections and unnecessary persisted history messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->